### PR TITLE
Docs: Add pkg-config to Linux packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ brew install libsodium leveldb openssl
 ## Linux
 For deb based systems like Debian or Ubuntu you need the following packages:
 ```shell
-apt install build-essential libsodium-dev libleveldb-dev libssl-dev
+apt install build-essential libsodium-dev libleveldb-dev libssl-dev pkg-config
 ```
 Other linux users may find the packages with similar names in their package managers.
 


### PR DESCRIPTION
libsodium-sys is not building without pkg-config. 👷 
And last one is not installed everywhere by default. 📦 
🙂 