### PR TITLE
FIX toml serialize bug

### DIFF
--- a/exonum/src/config/mod.rs
+++ b/exonum/src/config/mod.rs
@@ -29,7 +29,8 @@ impl ConfigFile {
         }
 
         let mut file = File::create(path)?;
-        file.write_all(&toml::ser::to_vec(&value)?)?;
+        let value_toml = toml::Value::try_from(value)?;
+        file.write_all(&format!("{}", value_toml).into_bytes())?;
 
         Ok(())
     }


### PR DESCRIPTION
Generating config for testate with new toml, causes error, this is because of "unsorted maps".
To workaround this we can convert Config into `toml::Value` and then print it.
As said in comments https://github.com/alexcrichton/toml-rs/issues/145 .
```
configuration generate 1 -o /tmp/exonum
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ValueAfterTable', /checkout/src/libcore/result.rs:859
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
             at /checkout/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at /checkout/src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at /checkout/src/libstd/sys_common/backtrace.rs:60
             at /checkout/src/libstd/panicking.rs:355
   3: std::panicking::default_hook
             at /checkout/src/libstd/panicking.rs:371
   4: std::panicking::rust_panic_with_hook
             at /checkout/src/libstd/panicking.rs:549
   5: std::panicking::begin_panic
             at /checkout/src/libstd/panicking.rs:511
   6: std::panicking::begin_panic_fmt
             at /checkout/src/libstd/panicking.rs:495
   7: rust_begin_unwind
             at /checkout/src/libstd/panicking.rs:471
   8: core::panicking::panic_fmt
             at /checkout/src/libcore/panicking.rs:69
   9: core::result::unwrap_failed
  10: exonum::helpers::clap::GenerateCommand::execute
  11: configuration::main
  12: __rust_maybe_catch_panic
             at /checkout/src/libpanic_unwind/lib.rs:98
  13: std::rt::lang_start
             at /checkout/src/libstd/panicking.rs:433
             at /checkout/src/libstd/panic.rs:361
             at /checkout/src/libstd/rt.rs:56
  14: __libc_start_main
  15: _start
```