### PR TITLE
Add descriptions to check_bounds macro

### DIFF
--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -234,35 +234,35 @@ macro_rules! check_bounds {
      $field_name:ident : $field_type:ty [$field_from:expr => $field_to:expr],
      $($next_name:ident : $next_type:ty [$next_from:expr => $next_to:expr],)+
      ) => {
-        debug_assert_eq!($prev_to, $field_from);
-        debug_assert_eq!($field_to - $field_from, <$field_type as Field>::field_size());
+        debug_assert_eq!($prev_to, $field_from, "fields should be adjacent");
+        debug_assert_eq!($field_to - $field_from, <$field_type as Field>::field_size(), "wrong size of field");
         check_bounds!(@deep $size, $field_to, $($next_name : $next_type [$next_from => $next_to],)+);
     };
     (@deep $size:expr, $prev_to:expr,
      $last_name:ident : $last_type:ty [$last_from:expr => $last_to:expr],
      ) => {
-        debug_assert_eq!($prev_to, $last_from);
-        debug_assert_eq!($last_to, $size);
-        debug_assert_eq!($last_to - $last_from, <$last_type as Field>::field_size());
+        debug_assert_eq!($prev_to, $last_from, "fields should be adjacent");
+        debug_assert_eq!($last_to, $size, "last field should matches the size of struct");
+        debug_assert_eq!($last_to - $last_from, <$last_type as Field>::field_size(), "wrong size of field");
     };
     ($size:expr,
      $first_name:ident : $first_type:ty [$first_from:expr => $first_to:expr],
      ) => {{
         use $crate::encoding::Field;
-        debug_assert_eq!($first_from, 0);
-        debug_assert_eq!($first_to, $size);
-        debug_assert_eq!($first_to - $first_from, <$first_type as Field>::field_size());
+        debug_assert_eq!($first_from, 0, "first field should start from 0");
+        debug_assert_eq!($first_to, $size, "last field should matches the size of struct");
+        debug_assert_eq!($first_to - $first_from, <$first_type as Field>::field_size(), "wrong size of field");
     }};
     ($size:expr,
      $first_name:ident : $first_type:ty [$first_from:expr => $first_to:expr],
      $($next_name:ident : $next_type:ty [$next_from:expr => $next_to:expr],)+
      ) => {{
         use $crate::encoding::Field;
-        debug_assert_eq!($first_from, 0);
-        debug_assert_eq!($first_to - $first_from, <$first_type as Field>::field_size());
+        debug_assert_eq!($first_from, 0, "first field should start from 0");
+        debug_assert_eq!($first_to - $first_from, <$first_type as Field>::field_size(), "wrong size of field");
         check_bounds!(@deep $size, $first_to, $($next_name : $next_type [$next_from => $next_to],)+);
     }};
     ($size:expr,) => {{
-        debug_assert_eq!($size, 0);
+        debug_assert_eq!($size, 0, "size of empty struct should be 0");
     }};
 }

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -438,7 +438,7 @@ fn test_correct_encoding_struct() {
 }
 
 #[test]
-#[should_panic(expected = "(left: `2`, right: `3`)")]
+#[should_panic(expected = "fields should be adjacent")]
 fn test_encoding_struct_with_hole() {
     encoding_struct! {
         struct MiddleHole {
@@ -453,7 +453,7 @@ fn test_encoding_struct_with_hole() {
 }
 
 #[test]
-#[should_panic(expected = "(left: `2`, right: `1`)")]
+#[should_panic(expected = "fields should be adjacent")]
 fn test_encoding_struct_with_overlay() {
     encoding_struct! {
         struct FieldOverlay {
@@ -468,7 +468,7 @@ fn test_encoding_struct_with_overlay() {
 }
 
 #[test]
-#[should_panic(expected = "(left: `1`, right: `2`)")]
+#[should_panic(expected = "wrong size of field")]
 fn test_encoding_struct_wrong_size() {
     encoding_struct! {
         struct WrongSize {


### PR DESCRIPTION
Fixes #205 

This update is important to build both: with stable and nightly Rust,
because message format of `debug_assert_eq!` macro has changed.

Do I need to add nightly checking for Travis?
I haven't added this, because it will significantly increase testing time.