### PR TITLE
Remove unused imports and trailing spaces

### DIFF
--- a/3rdparty/profiler/src/lib.rs
+++ b/3rdparty/profiler/src/lib.rs
@@ -7,9 +7,9 @@ extern crate lazy_static;
 
 mod html;
 
-use std::cell::{RefCell};
+use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::marker::PhantomData;
@@ -24,7 +24,7 @@ lazy_static!{
     static ref SETTED_NAME: Mutex<Option<String>> = Mutex::new(None);
     static ref INTERRUPTED_TICKS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
 
-} 
+}
 
 pub struct ThreadFrame {
     epoch: Instant,
@@ -83,7 +83,7 @@ impl ThreadFrame {
         let span = Span::sub_span(&self.events[self.events.len()-1].span, name);
         self.events.push(Event::new(name, timestamp, span));
     }
-    
+
     fn end_span(&mut self) {
         let new_time = INTERRUPTED_TICKS.load(Ordering::SeqCst);
         if self.dumped_time < new_time {
@@ -135,12 +135,12 @@ impl Span {
 
 #[cfg(not(feature="nomock"))]
 pub fn start(name: &'static str) {
-    
+
 }
 
 #[cfg(not(feature="nomock"))]
 pub fn end() {
-    
+
 }
 
 
@@ -213,7 +213,7 @@ impl<'scope> ProfilerSpan<'scope> {
         start(self.name);
     }
 
-    pub fn sub_span<'smaller>(&'smaller mut self, name: &'static str) -> ProfilerSpan<'smaller> 
+    pub fn sub_span<'smaller>(&'smaller mut self, name: &'static str) -> ProfilerSpan<'smaller>
     where 'scope: 'smaller {
         ProfilerSpan::new(name)
     }
@@ -225,6 +225,7 @@ pub fn init_handler(file: String) {
 
 #[cfg(feature="nomock")]
 pub fn init_handler(file: String) {
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     *SETTED_NAME.lock().unwrap() = Some(file);
 


### PR DESCRIPTION
This PR removes warnings of `profiler` when `exonum` is built from scratch (no cache):
```none
   Compiling hyper v0.10.12
   Compiling profiler v0.1.0 (file:///home/denis/exonum/exonum/3rdparty/profiler)
warning: unused imports: `SystemTime`, `UNIX_EPOCH`
  --> 3rdparty/profiler/src/lib.rs:12:26
   |
12 | use std::time::{Instant, SystemTime, UNIX_EPOCH};
   |                          ^^^^^^^^^^  ^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default

   Compiling mio v0.5.1
   Compiling phf_codegen v0.7.21
```
Do we really need this imports?