### PR TITLE
Fix Network discover failure

### DIFF
--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -123,7 +123,7 @@ impl Network {
             &listener,
             SERVER_ID,
             EventSet::readable(),
-            PollOpt::edge(),
+            PollOpt::level(),
         )?;
         self.listener = Some(listener);
         Ok(())


### PR DESCRIPTION
Closes https://github.com/exonum/exonum/issues/73

With `PollOpt::edge()` mio could ignore connection events, if they appear in one short period.

https://carllerche.github.io/mio/mio/struct.Poll.html#edge-triggered-and-level-triggered