### PR TITLE
Make DBKey public

### DIFF
--- a/exonum/src/storage/proof_map_index/key.rs
+++ b/exonum/src/storage/proof_map_index/key.rs
@@ -91,25 +91,28 @@ impl DBKey {
         }
     }
 
+    #[doc(hidden)]
     pub fn from(&self) -> u16 {
         self.from
     }
 
     // TODO: terrible hack, try to remove this
+    #[doc(hidden)]
     pub fn set_from(&mut self, from: u16) {
         self.from = from
     }
 
+    #[doc(hidden)]
     pub fn to(&self) -> u16 {
         self.to
     }
 
-    /// Length of the `DBKey`
+    /// Returns length of the `DBKey`.
     pub fn len(&self) -> u16 {
         self.to - self.from
     }
 
-    /// Returns true if `DBKey` has zero length
+    /// Returns true if `DBKey` has zero length.
     pub fn is_empty(&self) -> bool {
         self.to == self.from
     }
@@ -192,6 +195,7 @@ impl DBKey {
     }
 
     // TODO: terrible hack, try to remove this
+    /// Writes `DBKey` into the vector and returns it (see `write` method of the `StorageKey`).
     pub fn to_vec(&self) -> Vec<u8> {
         let mut buffer = vec![0u8; DB_KEY_SIZE as usize];
         self.write(&mut buffer);

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -22,7 +22,7 @@ use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
 use self::key::{DBKey, ChildKind, LEAF_KEY_PREFIX};
 use self::node::{Node, BranchNode};
 
-pub use self::key::{ProofMapKey, KEY_SIZE as PROOF_MAP_KEY_SIZE};
+pub use self::key::{ProofMapKey, KEY_SIZE as PROOF_MAP_KEY_SIZE, DBKey as ProofMapDBKey};
 pub use self::proof::{MapProof, ProofNode, BranchProofNode};
 
 #[cfg(test)]


### PR DESCRIPTION
Currently `DBKey` is already exposed through `MapProof` enum:
```rust
pub enum MapProof<V> {
    /// A boundary case with a single element tree and a matching key.
    LeafRootInclusive(DBKey, V),
    /// A boundary case with a single element tree and a non-matching key
    LeafRootExclusive(DBKey, Hash),
    /// A boundary case with empty tree.
    Empty,
    /// A root branch of the tree.
    Branch(BranchProofNode<V>),
}
```
