### PR TITLE
Integrate dead links check into travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   global:
   - CLIPPY_VERS=0.0.156
   - RUSTFMT_VERS=0.9.0
+  - DEADLINKS_VERS=0.2.0
   - SODIUM_VERS=1.0.13
   - ROCKSDB_VERS=5.6.1
   - CARGO_INCREMENTAL=1
@@ -75,6 +76,7 @@ install:
 - |
   if [[ "$FEATURE" == "fmt" ]]; then
     cargo-audit -V || cargo install cargo-audit --force
+    cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
     rustfmt -V | grep $RUSTFMT_VERS || cargo install rustfmt --vers $RUSTFMT_VERS --force
     cargo update
     fi
@@ -89,6 +91,8 @@ script: |
   case "$FEATURE" in
 
   "fmt" )
+      cargo doc --no-deps -p exonum &&
+      cargo deadlinks --dir target/doc &&
       cargo audit &&
       cargo fmt -p exonum -- --write-mode=diff &&
       cargo fmt -p sandbox -- --write-mode=diff

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -22,7 +22,7 @@ use super::{BaseIndex, Snapshot, Fork, StorageValue};
 /// An index that may only contain one element.
 ///
 /// A value should implement [`StorageValue`] trait.
-/// [`StorageValue`]: ../trait.StorageValue.html
+/// [`StorageValue`]: trait.StorageValue.html
 #[derive(Debug)]
 pub struct Entry<T, V> {
     base: BaseIndex<T>,
@@ -35,8 +35,8 @@ impl<T, V> Entry<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
-    /// [`&Snapshot`]: ../trait.Snapshot.html
-    /// [`&mut Fork`]: ../struct.Fork.html
+    /// [`&Snapshot`]: trait.Snapshot.html
+    /// [`&mut Fork`]: struct.Fork.html
     ///
     /// # Examples
     ///

--- a/exonum/src/storage/mod.rs
+++ b/exonum/src/storage/mod.rs
@@ -83,7 +83,7 @@
 //! [`RocksDB`]: struct.RocksDB.html
 //! [`MemoryDB`]: struct.MemoryDB.html
 //! [`Snapshot`]: trait.Snapshot.html
-//! [`Fork`]: struct.fork.html
+//! [`Fork`]: struct.Fork.html
 //! [`Patch`]: type.Patch.html
 //! [1]: trait.Database.html#tymethod.snapshot
 //! [2]: trait.Database.html#method.fork

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -72,7 +72,7 @@ pub struct ProofMapIndexIter<'a, K, V> {
 ///
 /// [`keys`]: struct.ProofMapIndex.html#method.keys
 /// [`keys_from`]: struct.ProofMapIndex.html#method.keys_from
-/// [`ProofMapIndex`]: struct.MapIndex.html
+/// [`ProofMapIndex`]: struct.ProofMapIndex.html
 #[derive(Debug)]
 pub struct ProofMapIndexKeys<'a, K> {
     base_iter: BaseIndexIter<'a, DBKey, ()>,


### PR DESCRIPTION
Still we need https://github.com/deadlinks/cargo-deadlinks/issues/1 to be fixed for the correct usage.