### PR TITLE
Add profiler into build, make build verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,22 +98,22 @@ script: |
       cargo fmt -p sandbox -- --write-mode=diff
   ;;
   "clippy-core" )
-      cd exonum && cargo clippy --features long_benchmarks,rocksdb -- -D warnings
+      cd exonum && cargo clippy --verbose --features long_benchmarks,rocksdb,flame_profile  -- -D warnings
   ;;
   "clippy-sandbox" )
-      cd sandbox && cargo clippy -- -D warnings
+      cd sandbox && cargo clippy --verbose -- -D warnings
   ;;
   "test-core" )
-      cargo test --manifest-path exonum/Cargo.toml --features rocksdb --tests --lib
+      cargo test --manifest-path exonum/Cargo.toml --verbose --features rocksdb --tests --lib
   ;;
   "test-sandbox" )
-      cargo test -p sandbox
+      cargo test -p sandbox --verbose
   ;;
   "test-doc" )
-      cargo test -p exonum --doc -- --test-threads=2
+      cargo test -p exonum --verbose --doc  -- --test-threads=2
   ;;
   "benchmarks" )
-        RUST_LOG=off cargo bench --manifest-path exonum/Cargo.toml --features rocksdb,long_benchmarks --no-run
+        RUST_LOG=off cargo bench --verbose --manifest-path exonum/Cargo.toml --features rocksdb,long_benchmarks --no-run
   ;;
 
   esac


### PR DESCRIPTION
This changes adds profiler into travis "clippy" build, and makes build run with `--verbose`.
For now it should fail, until https://github.com/exonum/exonum/pull/338 will be merged.