### PR TITLE
WIP: Add allow_origin option

### DIFF
--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -19,6 +19,7 @@
 use router::Router;
 use mount::Mount;
 use iron::{Chain, Iron};
+use iron::headers::AccessControlAllowOrigin;
 use toml::Value;
 
 use std::io;
@@ -134,6 +135,8 @@ pub struct NodeApiConfig {
     pub public_api_address: Option<SocketAddr>,
     /// Listen address for private api endpoints.
     pub private_api_address: Option<SocketAddr>,
+    /// Set CORS part of response header
+    pub allow_origin: Option<String>,
 }
 
 impl Default for NodeApiConfig {
@@ -143,6 +146,18 @@ impl Default for NodeApiConfig {
             enable_blockchain_explorer: true,
             public_api_address: None,
             private_api_address: None,
+            allow_origin: None,
+        }
+    }
+}
+
+impl NodeApiConfig {
+    /// Creates header from origin value
+    pub fn allow_origin_to_header(&self) -> AccessControlAllowOrigin {
+        match self.allow_origin {
+            None => AccessControlAllowOrigin::Null,
+            Some(ref s) if s == "*"  => AccessControlAllowOrigin::Any,
+            Some(ref s) => AccessControlAllowOrigin::Value(s.to_owned()),
         }
     }
 }


### PR DESCRIPTION
Fixes #263 

I convert `Option<String>` (from `api.allow_origin` field of the config) to `AccessControlAllowOrigin` header:

- `None` to `Null`
- `Some("*")` to `Any`
- `Some(_)` to `Value(_)`

It also adds middleware to Iron (after the public api's chain) and set `AccessControl` header to every response. This middleware adds `Null` value to header if option not set. Do I keep this behavior or I should drop this header if `allow_origin` value had not set? Ideas?