### PR TITLE
Fix network reconnect test

### DIFF
--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -278,10 +278,8 @@ fn test_network_reconnect() {
     t1.send_to(second, msg.clone());
     assert_eq!(t2.wait_for_message(), msg);
 
-    t1.disconnect_with(second);
-    assert_eq!(t1.wait_for_disconnect(), second);
-
     drop(t2);
+    assert_eq!(t1.wait_for_disconnect(), second);
 
     // Handle second attempt.
     let mut t2 = TestEvents::with_addr(second).spawn();
@@ -292,8 +290,7 @@ fn test_network_reconnect() {
     t1.send_to(second, msg.clone());
     assert_eq!(t2.wait_for_message(), msg);
 
-    drop(t2);
-
+    t1.disconnect_with(second);
     assert_eq!(t1.wait_for_disconnect(), second);
 }
 


### PR DESCRIPTION
Fixed a problem in `test_network_reconnect` 
Our assumption was that `DisconnectWithPeer` event is processed synchronized.
But if reconnect time is small enough, it's possible that we already disconnect and reconnect to peer, and only after this starting to process `DisconnectWithPeer`.
This cause to disconnect just after reconnect. And double "`Connect` message" processing.

In real code, the time between disconnect and reconnect is significant, and this case could be ignored.
Another reason to ignore this, is that it is a valid case to process double "`Connect` message".


Closes: https://github.com/exonum/exonum/issues/354