### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ script: |
       cargo fmt -p sandbox -- --write-mode=diff
   ;;
   "clippy-core" )
-      cd exonum && cargo clippy --verbose --features long_benchmarks,rocksdb,flame_profile  -- -D warnings
+      cd exonum && cargo clippy --verbose --features long_benchmarks,rocksdb  -- -D warnings
   ;;
   "clippy-sandbox" )
       cd sandbox && cargo clippy --verbose -- -D warnings


### PR DESCRIPTION
Flamer expand code like 
```
fn void() {
logic();
}
```
into code like:

```
fn void() {
let profiler = Profiler...
let logic = {logic();}
logic
}
```

This makes clippy fail.

