### PR TITLE
Update cargo-deadlinks version (0.3.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
   global:
   - CLIPPY_VERS=0.0.169
   - RUSTFMT_VERS=0.9.0
-  - DEADLINKS_VERS=0.2.1
+  - DEADLINKS_VERS=0.3.0
   - SODIUM_VERS=1.0.13
   - CARGO_INCREMENTAL=1
   - RUSTFLAGS="-C link-dead-code"


### PR DESCRIPTION
`0.3.0` version supports `-V` (`--version`) flag, so  it will not be installed every time.