### PR TITLE
Change "rocksdb" commandline parameter to a more generic "database"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `mount_*_api` methods in `Blockchain` instance now do not require `ApiContext`. (#366)
 - Removed redundant `current_height` method in `Schema` and rename `last_height` to `height`. (#379)
 - `last_block` now returns `Block` instead of `Option<Block>`. (#379)
-- Replaced `rocksdb` commandline parameter to more generic `database`. (#376)
+- Replaced `rocksdb` commandline parameter to more generic `db-path`. (#376)
 
 ### Fixed
 - Fixed `crate_authors!` macro usage, this macro can't return static string in new clap version. (#370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `Node` constructor now requires `db` and `services` variables instead of `blockchain` instance. (#366)
 - The `Blockchain` constructor now requires services keypair and an `ApiSender` instance. (#366)
 - `mount_*_api` methods in `Blockchain` instance now do not require `ApiContext`. (#366)
+- Replaced `rocksdb` commandline parameter to more generic `database`. (#376)
 
 ### Fixed
 - Fixed `crate_authors!` macro usage, this macro can't return static string in new clap version. (#370)

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -53,9 +53,10 @@ impl Run {
     pub fn db_helper(ctx: &Context) -> Box<Database> {
         use storage::{RocksDB, RocksDBOptions};
 
-        let path = ctx.arg::<String>(DATABASE_PATH).expect(
-            format!("{} not found.", DATABASE_PATH),
-        );
+        let path = ctx.arg::<String>(DATABASE_PATH).expect(&format!(
+            "{} not found.",
+            DATABASE_PATH
+        ));
         let mut options = RocksDBOptions::default();
         options.create_if_missing(true);
         Box::new(RocksDB::open(Path::new(&path), &options).unwrap())
@@ -93,7 +94,7 @@ impl Command for Run {
                 true,
                 "Use database with the given path.",
                 "d",
-                "database_path",
+                "db-path",
                 false
             ),
             Argument::new_named(

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -93,7 +93,7 @@ impl Command for Run {
                 true,
                 "Use database with the given path.",
                 "d",
-                "database",
+                "database_path",
                 false
             ),
             Argument::new_named(

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -38,6 +38,8 @@ use super::shared::{AbstractConfig, NodePublicConfig, SharedConfig, NodePrivateC
                     CommonConfigTemplate};
 use super::DEFAULT_EXONUM_LISTEN_PORT;
 
+const DATABASE_PATH: &str = "DATABASE_PATH";
+
 /// Run command.
 pub struct Run;
 
@@ -51,8 +53,8 @@ impl Run {
     pub fn db_helper(ctx: &Context) -> Box<Database> {
         use storage::{RocksDB, RocksDBOptions};
 
-        let path = ctx.arg::<String>("ROCKSDB_PATH").expect(
-            "ROCKSDB_PATH not found.",
+        let path = ctx.arg::<String>(DATABASE_PATH).expect(
+            format!("{} not found.", DATABASE_PATH),
         );
         let mut options = RocksDBOptions::default();
         options.create_if_missing(true);
@@ -87,11 +89,11 @@ impl Command for Run {
                 false
             ),
             Argument::new_named(
-                "ROCKSDB_PATH",
+                DATABASE_PATH,
                 true,
-                "Use rocksdb database with the given path.",
+                "Use database with the given path.",
                 "d",
-                "rocksdb",
+                "database",
                 false
             ),
             Argument::new_named(


### PR DESCRIPTION
I'm not sure how many details of underlying database the user should now, but I like a more generic interface, because it will give us more possibilities to change the implementation without additional "breaking changes".

Opinions?