### PR TITLE
ClapBackend: Show a help message when there're no args

### DIFF
--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -34,6 +34,7 @@ impl ClapBackend {
             .map(|command| ClapBackend::command_into_subcommand(command))
             .collect();
         let matches = clap::App::new("Exonum application based on fabric configuration.")
+            .setting(clap::AppSettings::ArgRequiredElseHelp)
             .version(crate_version!())
             .author(crate_authors!("\n"))
             .about(
@@ -63,6 +64,7 @@ impl ClapBackend {
             .collect();
 
         let matches = clap::App::new("Exonum application based on fabric configuration.")
+            .setting(clap::AppSettings::ArgRequiredElseHelp)
             .version(crate_version!())
             .author(crate_authors!("\n"))
             .about("Exonum application based on fabric configuration.")


### PR DESCRIPTION
https://docs.rs/clap/2.28.0/clap/enum.AppSettings.html#variant.ArgRequiredElseHelp seems to do the trick.

Closes https://github.com/exonum/exonum/issues/389