### PR TITLE
Reorder imports (treat all 'extern create' as thirdparty)

### DIFF
--- a/exonum/benches/block.rs
+++ b/exonum/benches/block.rs
@@ -23,6 +23,8 @@ extern crate test;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempdir::TempDir;
     use futures::sync::mpsc;
     use test::Bencher;
@@ -33,8 +35,6 @@ mod tests {
     use exonum::messages::Message;
     use exonum::helpers::{Height, ValidatorId};
     use exonum::node::ApiSender;
-
-    use std::collections::BTreeMap;
 
     fn create_blockchain(db: Box<Database>) -> Blockchain {
         let dummy_channel = mpsc::channel(1);

--- a/exonum/benches/block.rs
+++ b/exonum/benches/block.rs
@@ -25,17 +25,16 @@ extern crate test;
 mod tests {
     use tempdir::TempDir;
     use futures::sync::mpsc;
-
     use test::Bencher;
-    use std::collections::BTreeMap;
-
-    use exonum::storage::{Database, Fork, Patch, ProofMapIndex, StorageValue};
-    use exonum::storage::{RocksDB, RocksDBOptions};
+    use exonum::storage::{Database, Fork, Patch, ProofMapIndex, StorageValue, RocksDB,
+                          RocksDBOptions};
     use exonum::blockchain::{Blockchain, Transaction};
     use exonum::crypto::{gen_keypair, Hash, PublicKey, SecretKey};
     use exonum::messages::Message;
     use exonum::helpers::{Height, ValidatorId};
     use exonum::node::ApiSender;
+
+    use std::collections::BTreeMap;
 
     fn create_blockchain(db: Box<Database>) -> Blockchain {
         let dummy_channel = mpsc::channel(1);

--- a/exonum/benches/network.rs
+++ b/exonum/benches/network.rs
@@ -6,13 +6,13 @@ extern crate test;
 #[cfg(all(test, feature = "long_benchmarks"))]
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+    use std::thread;
+
     use test::Bencher;
     use exonum::node::EventsPoolCapacity;
     use exonum::events::network::NetworkConfiguration;
     use exonum::events::tests::{connect_message, raw_message, TestEvents};
-
-    use std::net::SocketAddr;
-    use std::thread;
 
     struct BenchConfig {
         times: usize,

--- a/exonum/benches/network.rs
+++ b/exonum/benches/network.rs
@@ -7,13 +7,12 @@ extern crate test;
 #[cfg(test)]
 mod tests {
     use test::Bencher;
-
-    use std::net::SocketAddr;
-    use std::thread;
-
     use exonum::node::EventsPoolCapacity;
     use exonum::events::network::NetworkConfiguration;
     use exonum::events::tests::{connect_message, raw_message, TestEvents};
+
+    use std::net::SocketAddr;
+    use std::thread;
 
     struct BenchConfig {
         times: usize,

--- a/exonum/benches/storage.rs
+++ b/exonum/benches/storage.rs
@@ -21,6 +21,8 @@ extern crate exonum;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod tests {
+    use std::collections::HashSet;
+
     use test::Bencher;
     use rand::{Rng, thread_rng, XorShiftRng, SeedableRng};
     use tempdir::TempDir;
@@ -28,8 +30,6 @@ mod tests {
     use exonum::storage::{RocksDB, RocksDBOptions};
     use exonum::storage::{ProofMapIndex, ProofListIndex};
     use exonum::storage::proof_map_index::PROOF_MAP_KEY_SIZE as KEY_SIZE;
-
-    use std::collections::HashSet;
 
     const NAME: &str = "name";
 

--- a/exonum/benches/storage.rs
+++ b/exonum/benches/storage.rs
@@ -21,7 +21,6 @@ extern crate exonum;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod tests {
-    use std::collections::HashSet;
     use test::Bencher;
     use rand::{Rng, thread_rng, XorShiftRng, SeedableRng};
     use tempdir::TempDir;
@@ -29,6 +28,8 @@ mod tests {
     use exonum::storage::{RocksDB, RocksDBOptions};
     use exonum::storage::{ProofMapIndex, ProofListIndex};
     use exonum::storage::proof_map_index::PROOF_MAP_KEY_SIZE as KEY_SIZE;
+
+    use std::collections::HashSet;
 
     const NAME: &str = "name";
 

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -14,6 +14,12 @@
 
 //! `RESTful` API and corresponding utilities.
 
+use std::ops::Deref;
+use std::marker::PhantomData;
+use std::io;
+use std::collections::BTreeMap;
+use std::fmt;
+
 use iron::IronError;
 use iron::prelude::*;
 use iron::status;
@@ -24,12 +30,6 @@ use router::Router;
 use serde_json;
 use serde::{Serialize, Serializer};
 use serde::de::{self, Visitor, Deserialize, Deserializer};
-
-use std::ops::Deref;
-use std::marker::PhantomData;
-use std::io;
-use std::collections::BTreeMap;
-use std::fmt;
 
 use crypto::{PublicKey, SecretKey, Hash};
 use encoding::serialize::{FromHex, FromHexError, ToHex, encode_hex};

--- a/exonum/src/api/private/mod.rs
+++ b/exonum/src/api/private/mod.rs
@@ -15,4 +15,5 @@
 //! Private part of the Exonum rest api.
 
 pub use self::system::{SystemApi, NodeInfo};
+
 mod system;

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use router::Router;
+use iron::prelude::*;
+use params::{Params, Value as ParamsValue};
+
 use std::net::SocketAddr;
 use std::collections::HashMap;
 
 use crypto::PublicKey;
-use router::Router;
-use iron::prelude::*;
-
-use params::{Params, Value as ParamsValue};
 use node::ApiSender;
 use blockchain::{Service, Blockchain, SharedNodeState};
 use api::{Api, ApiError};

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
+use std::collections::HashMap;
+
 use router::Router;
 use iron::prelude::*;
 use params::{Params, Value as ParamsValue};
-
-use std::net::SocketAddr;
-use std::collections::HashMap;
 
 use crypto::PublicKey;
 use node::ApiSender;

--- a/exonum/src/api/public/blockhain_explorer.rs
+++ b/exonum/src/api/public/blockhain_explorer.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::num::ParseIntError;
+use std::str::ParseBoolError;
+
 use params::{Params, Value};
 use router::Router;
 use iron::prelude::*;
-
-use std::num::ParseIntError;
-use std::str::ParseBoolError;
 
 use blockchain::{Blockchain, Block};
 use explorer::{BlockInfo, BlockchainExplorer};

--- a/exonum/src/api/public/blockhain_explorer.rs
+++ b/exonum/src/api/public/blockhain_explorer.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::ParseIntError;
-use std::str::ParseBoolError;
-
 use params::{Params, Value};
 use router::Router;
 use iron::prelude::*;
+
+use std::num::ParseIntError;
+use std::str::ParseBoolError;
 
 use blockchain::{Blockchain, Block};
 use explorer::{BlockInfo, BlockchainExplorer};

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -14,10 +14,10 @@
 
 //! Exonum global variables which stored in blockchain as utf8 encoded json.
 
+use std::collections::{BTreeMap, HashSet};
+
 use serde::de::Error;
 use serde_json::{self, Error as JsonError};
-
-use std::collections::{BTreeMap, HashSet};
 
 use storage::StorageValue;
 use crypto::{hash, PublicKey, Hash};

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -28,15 +28,15 @@
 //!
 //! [1]: https://github.com/exonum/exonum-doc/blob/master/src/get-started/create-service.md
 
-use vec_map::VecMap;
-use byteorder::{ByteOrder, LittleEndian};
-use mount::Mount;
-
 use std::sync::Arc;
 use std::collections::BTreeMap;
 use std::mem;
 use std::fmt;
 use std::panic;
+
+use vec_map::VecMap;
+use byteorder::{ByteOrder, LittleEndian};
+use mount::Mount;
 
 use crypto::{self, Hash, PublicKey, SecretKey};
 use messages::{CONSENSUS as CORE_SERVICE, Precommit, RawMessage};

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -15,13 +15,13 @@
 //! This module defines the Exonum services interfaces. Like smart contracts in some other
 //! blockchain platforms, Exonum services encapsulate business logic of the blockchain application.
 
-use serde_json::Value;
-use iron::Handler;
-
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+
+use serde_json::Value;
+use iron::Handler;
 
 use crypto::{Hash, PublicKey, SecretKey};
 use storage::{Fork, Snapshot};

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(dead_code)]
+
 use std::collections::BTreeMap;
 
 use rand::{thread_rng, Rng};

--- a/exonum/src/crypto.rs
+++ b/exonum/src/crypto.rs
@@ -17,6 +17,10 @@
 //! [Sodium library](https://github.com/jedisct1/libsodium) is used under the hood through
 //! [sodiumoxide rust bindings](https://github.com/dnaq/sodiumoxide).
 
+use std::default::Default;
+use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
+use std::fmt;
+
 use sodiumoxide::crypto::sign::ed25519::{gen_keypair as gen_keypair_sodium, keypair_from_seed,
                                          sign_detached, verify_detached,
                                          PublicKey as PublicKeySodium,
@@ -26,10 +30,6 @@ use sodiumoxide::crypto::hash::sha256::{hash as hash_sodium, Digest, State as Ha
 use sodiumoxide;
 use serde::{Serialize, Serializer};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
-
-use std::default::Default;
-use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
-use std::fmt;
 
 use encoding::serialize::FromHex;
 

--- a/exonum/src/crypto.rs
+++ b/exonum/src/crypto.rs
@@ -31,13 +31,13 @@ use std::default::Default;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 use std::fmt;
 
+use encoding::serialize::FromHex;
+
 pub use sodiumoxide::crypto::sign::ed25519::{PUBLICKEYBYTES as PUBLIC_KEY_LENGTH,
                                              SECRETKEYBYTES as SECRET_KEY_LENGTH,
                                              SEEDBYTES as SEED_LENGTH,
                                              SIGNATUREBYTES as SIGNATURE_LENGTH};
 pub use sodiumoxide::crypto::hash::sha256::DIGESTBYTES as HASH_SIZE;
-
-use encoding::serialize::FromHex;
 
 /// The size to crop the string in debug messages.
 const BYTES_IN_DEBUG: usize = 4;

--- a/exonum/src/encoding/fields.rs
+++ b/exonum/src/encoding/fields.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use std::mem;
 use std::net::{SocketAddr, SocketAddrV4, Ipv4Addr};
 use std::time::{SystemTime, Duration, UNIX_EPOCH};
+
+use byteorder::{ByteOrder, LittleEndian};
 
 use crypto::{Hash, PublicKey, Signature};
 use helpers::{Height, Round, ValidatorId};

--- a/exonum/src/encoding/mod.rs
+++ b/exonum/src/encoding/mod.rs
@@ -119,7 +119,6 @@ mod segments;
 #[macro_use]
 mod spec;
 
-
 #[cfg(test)]
 mod tests;
 

--- a/exonum/src/encoding/segments.rs
+++ b/exonum/src/encoding/segments.rs
@@ -17,7 +17,6 @@ use bit_vec::BitVec;
 
 use messages::{RawMessage, HEADER_LENGTH, MessageBuffer};
 use crypto::Hash;
-
 use super::{Result, Error, Field, Offset, CheckedOffset};
 
 /// Trait for fields, that has unknown `compile-time` size.

--- a/exonum/src/encoding/serialize/json.rs
+++ b/exonum/src/encoding/serialize/json.rs
@@ -21,13 +21,13 @@
 // TODO remove WriteBufferWraper hack (after refactor storage),
 // should be moved into storage (ECR-156).
 
-use serde_json::value::Value;
-use bit_vec::BitVec;
-use hex::FromHex;
-
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::net::SocketAddr;
 use std::error::Error;
+
+use serde_json::value::Value;
+use bit_vec::BitVec;
+use hex::FromHex;
 
 use crypto::{Hash, PublicKey, Signature};
 use helpers::{Height, Round, ValidatorId};

--- a/exonum/src/encoding/serialize/mod.rs
+++ b/exonum/src/encoding/serialize/mod.rs
@@ -17,6 +17,7 @@
 //! This module is a pack of superstructures over serde `Serializer's`\\`Deserializer's`
 
 pub use hex::{FromHexError, ToHex, FromHex, encode as encode_hex, decode as decode_hex};
+
 use encoding::Field;
 use messages::MessageWriter;
 use super::Offset;

--- a/exonum/src/encoding/serialize/mod.rs
+++ b/exonum/src/encoding/serialize/mod.rs
@@ -16,11 +16,11 @@
 //! Currently support only json.
 //! This module is a pack of superstructures over serde `Serializer's`\\`Deserializer's`
 
-pub use hex::{FromHexError, ToHex, FromHex, encode as encode_hex, decode as decode_hex};
-
 use encoding::Field;
 use messages::MessageWriter;
 use super::Offset;
+
+pub use hex::{FromHexError, ToHex, FromHex, encode as encode_hex, decode as decode_hex};
 
 /// implement exonum serialization\deserialization based on serde `Serialize`\ `Deserialize`
 ///

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -22,7 +22,6 @@ use blockchain::{self, BlockProof, Block};
 use messages::{RawMessage, Message, Connect, Propose, Prevote, Precommit, Status, BlockResponse,
                BlockRequest};
 use helpers::{Height, Round, ValidatorId};
-
 use super::{Field, Offset};
 
 static VALIDATOR: ValidatorId = ValidatorId(65_123);

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bit_vec::BitVec;
-
 use std::net::SocketAddr;
 use std::time::SystemTime;
+
+use bit_vec::BitVec;
 
 use crypto::{hash, gen_keypair};
 use blockchain::{self, BlockProof, Block};

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
 use bytes::BytesMut;
 use byteorder::{LittleEndian, ByteOrder};
 use tokio_io::codec::{Decoder, Encoder};
-
-use std::io;
 
 use messages::{HEADER_LENGTH, MessageBuffer, RawMessage};
 use super::error::other_error;

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -19,11 +19,11 @@ pub mod error;
 pub mod network;
 pub mod timeouts;
 
-use futures::{Future, Async, Poll, Stream};
-use futures::sync::mpsc;
-
 use std::time::SystemTime;
 use std::cmp::Ordering;
+
+use futures::{Future, Async, Poll, Stream};
+use futures::sync::mpsc;
 
 use node::{ExternalMessage, NodeTimeout};
 pub use self::network::{NetworkEvent, NetworkRequest, NetworkPart, NetworkConfiguration};

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -26,10 +26,8 @@ use std::time::SystemTime;
 use std::cmp::Ordering;
 
 use node::{ExternalMessage, NodeTimeout};
-
 pub use self::network::{NetworkEvent, NetworkRequest, NetworkPart, NetworkConfiguration};
 pub use self::timeouts::TimeoutsPart;
-
 
 #[derive(Debug)]
 pub enum Event {

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -15,7 +15,6 @@
 use futures::{future, unsync, Future, IntoFuture, Sink, Stream, Poll};
 use futures::future::Either;
 use futures::sync::mpsc;
-
 use tokio_core::net::{TcpListener, TcpStream};
 use tokio_core::reactor::Handle;
 use tokio_io::AsyncRead;
@@ -31,7 +30,6 @@ use std::cell::RefCell;
 
 use messages::{Any, Connect, RawMessage, Message};
 use helpers::Milliseconds;
-
 use super::tobox;
 use super::error::{into_other, log_error, other_error, result_ok};
 use super::codec::MessagesCodec;

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::cell::RefCell;
+
 use futures::{future, unsync, Future, IntoFuture, Sink, Stream, Poll};
 use futures::future::Either;
 use futures::sync::mpsc;
@@ -20,13 +27,6 @@ use tokio_core::reactor::Handle;
 use tokio_io::AsyncRead;
 use tokio_retry::Retry;
 use tokio_retry::strategy::{jitter, FixedInterval};
-
-use std::io;
-use std::net::SocketAddr;
-use std::time::Duration;
-use std::collections::HashMap;
-use std::rc::Rc;
-use std::cell::RefCell;
 
 use messages::{Any, Connect, RawMessage, Message};
 use helpers::Milliseconds;

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use futures::{Future, Sink, Stream};
 use futures::stream::Wait;
 use futures::sync::mpsc;

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
+use std::thread;
+use std::time::{self, Duration};
+
 use futures::{Future, Sink, Stream};
 use futures::stream::Wait;
 use futures::sync::mpsc;
 use tokio_core::reactor::Core;
 use tokio_timer::{TimeoutStream, Timer};
-
-use std::net::SocketAddr;
-use std::thread;
-use std::time::{self, Duration};
 
 use crypto::{gen_keypair, PublicKey, Signature};
 use messages::{Connect, Message, MessageWriter, RawMessage};

--- a/exonum/src/events/timeouts.rs
+++ b/exonum/src/events/timeouts.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+use std::time::{Duration, SystemTime};
+
 use futures::{Future, Sink, Stream};
 use futures::sync::mpsc;
 use tokio_core::reactor::Handle;
 use tokio_core::reactor::Timeout;
-
-use std::io;
-use std::time::{Duration, SystemTime};
 
 use node::NodeTimeout;
 use super::error::{into_other, other_error};

--- a/exonum/src/events/timeouts.rs
+++ b/exonum/src/events/timeouts.rs
@@ -12,19 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use futures::{Future, Sink, Stream};
 use futures::sync::mpsc;
-
 use tokio_core::reactor::Handle;
 use tokio_core::reactor::Timeout;
 
 use std::io;
 use std::time::{Duration, SystemTime};
 
-
 use node::NodeTimeout;
-
 use super::error::{into_other, other_error};
 use super::{TimeoutRequest, tobox};
 

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -15,9 +15,9 @@
 //! Blockchain explorer module provides api for getting information about blocks and transactions
 //! from the blockchain.
 
-use serde_json::Value;
-
 use std::cmp;
+
+use serde_json::Value;
 
 use storage::ListProof;
 use crypto::Hash;

--- a/exonum/src/helpers/config.rs
+++ b/exonum/src/helpers/config.rs
@@ -14,13 +14,13 @@
 
 //! Loading and saving TOML-encoded configurations.
 
-use serde::{Serialize, Deserialize};
-use toml;
-
 use std::path::Path;
 use std::io::{self, Read, Write};
 use std::fs::{self, File};
 use std::error::Error;
+
+use serde::{Serialize, Deserialize};
+use toml;
 
 /// Implements loading and saving TOML-encoded configurations.
 #[derive(Debug)]

--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap;
-
 use std::ffi::OsString;
+
+use clap;
 
 use super::{Context, ArgumentType};
 use super::internal::{Feedback, CollectedCommand};

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -15,25 +15,23 @@
 #![allow(missing_debug_implementations)]
 
 //! This module implement all core commands.
-use toml::Value;
 
 use std::fs;
 use std::path::Path;
 use std::net::SocketAddr;
 use std::collections::BTreeMap;
 
+use toml::Value;
+
 use blockchain::GenesisConfig;
+use blockchain::config::ValidatorKeys;
 use helpers::generate_testnet_config;
 use helpers::config::ConfigFile;
 use node::{NodeConfig, NodeApiConfig};
 use storage::Database;
 use crypto;
-
-use blockchain::config::ValidatorKeys;
-
 use super::internal::{Command, Feedback};
 use super::{Argument, Context, CommandName};
-
 use super::shared::{AbstractConfig, NodePublicConfig, SharedConfig, NodePrivateConfig,
                     CommonConfigTemplate};
 use super::DEFAULT_EXONUM_LISTEN_PORT;

--- a/exonum/src/helpers/fabric/internal.rs
+++ b/exonum/src/helpers/fabric/internal.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{Context, CommandName, Argument, CommandExtension};
-
 use std::fmt;
 use std::error::Error;
+
+use super::{Context, CommandName, Argument, CommandExtension};
 
 /// Used to take some additional information from executed command
 #[derive(Debug, PartialEq, Clone)]

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -14,13 +14,13 @@
 
 //! Command line commands utilities.
 
-use clap;
-use toml::Value;
-use serde::{Serialize, Deserialize};
-
 use std::str::FromStr;
 use std::error::Error;
 use std::collections::BTreeMap;
+
+use clap;
+use toml::Value;
+use serde::{Serialize, Deserialize};
 
 use blockchain::Service;
 use self::internal::NotFoundInMap;

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -14,10 +14,10 @@
 
 //! This module is used to collect structures that is shared into `CommandExtension` from `Command`.
 
-use toml::Value;
-
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
+
+use toml::Value;
 
 use crypto::{PublicKey, SecretKey};
 use blockchain::config::ConsensusConfig;

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -15,6 +15,7 @@
 //! This module is used to collect structures that is shared into `CommandExtension` from `Command`.
 
 use toml::Value;
+
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -14,12 +14,12 @@
 
 //! Different assorted utilities.
 
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use log::{LogRecord, LogLevel, SetLoggerError};
 use env_logger::LogBuilder;
 use colored::*;
-
-use std::env;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use blockchain::{GenesisConfig, ValidatorKeys};
 use node::NodeConfig;

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -14,9 +14,9 @@
 
 //! Common widely used typedefs.
 
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-
 use std::fmt;
+
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
 /// Number of milliseconds.
 pub type Milliseconds = u64;

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -14,9 +14,9 @@
 
 //! Consensus and other messages and related utilities.
 
-use bit_vec::BitVec;
-
 use std::fmt;
+
+use bit_vec::BitVec;
 
 use crypto::PublicKey;
 use encoding::Error;

--- a/exonum/src/messages/raw.rs
+++ b/exonum/src/messages/raw.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use std::{convert, mem, sync};
 use std::fmt::Debug;
 use std::ops::Deref;
+
+use byteorder::{ByteOrder, LittleEndian};
 
 use crypto::{hash, sign, verify, Hash, PublicKey, SecretKey, Signature, SIGNATURE_LENGTH};
 use encoding::{CheckedOffset, Field, Offset, Result as StreamStructResult};

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rand;
-
-use rand::Rng;
+use rand::{self, Rng};
 
 use std::net::SocketAddr;
 use std::error::Error;

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{self, Rng};
-
 use std::net::SocketAddr;
 use std::error::Error;
+
+use rand::{self, Rng};
 
 use messages::{Any, RawMessage, Connect, Status, Message, PeersRequest};
 use helpers::Height;

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use std::collections::HashSet;
 
 use crypto::{Hash, PublicKey};

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -16,14 +16,6 @@
 //!
 //! For details about consensus message handling see messages module documentation.
 
-use toml::Value;
-use router::Router;
-use mount::Mount;
-use iron::{Chain, Iron};
-use futures::{Future, Sink};
-use futures::sync::mpsc;
-use tokio_core::reactor::Core;
-
 use std::io;
 use std::sync::Arc;
 use std::thread;
@@ -31,6 +23,14 @@ use std::net::SocketAddr;
 use std::time::{Duration, SystemTime};
 use std::collections::BTreeMap;
 use std::fmt;
+
+use toml::Value;
+use router::Router;
+use mount::Mount;
+use iron::{Chain, Iron};
+use futures::{Future, Sink};
+use futures::sync::mpsc;
+use tokio_core::reactor::Core;
 
 use crypto::{self, Hash, PublicKey, SecretKey};
 use blockchain::{Blockchain, GenesisConfig, Schema, SharedNodeState, Transaction, Service};

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -14,14 +14,14 @@
 
 //! State of the `NodeHandler`.
 
-use serde_json::Value;
-use bit_vec::BitVec;
-
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::collections::hash_map::Entry;
 use std::sync::{Arc, RwLock};
 use std::net::SocketAddr;
 use std::time::{SystemTime, Duration};
+
+use serde_json::Value;
+use bit_vec::BitVec;
 
 use messages::{Message, Propose, Prevote, Precommit, ConsensusMessage, Connect};
 use crypto::{PublicKey, SecretKey, Hash};

--- a/exonum/src/node/whitelist.rs
+++ b/exonum/src/node/whitelist.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: don't reload whitelisted_peers if path the same (ECR-172)
 use std::collections::BTreeSet;
 
 use crypto::PublicKey;
+
+// TODO: don't reload whitelisted_peers if path the same (ECR-172)
 
 /// `Whitelist` is special set to keep peers that can connect to us.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of base index with most common features.
+
 use std::borrow::Cow;
 use std::marker::PhantomData;
 

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -20,7 +20,6 @@ use std::cmp::Ordering::*;
 use std::iter::Peekable;
 
 use super::Result;
-
 use self::NextIterValue::*;
 
 /// Map containing changes with corresponding key.

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 //! An implementation of index that may only contain one element.
+
 use std::marker::PhantomData;
 
 use crypto::Hash;
-
 use super::{BaseIndex, Snapshot, Fork, StorageValue};
 
 /// An index that may only contain one element.

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of `Error` type.
+
 use std::fmt;
 use std::error;
 

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of set for items that implement `StorageKey` trait.
+
 use std::marker::PhantomData;
 
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageKey};

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 //! A definition of `StorageKey` trait and implementations for common types.
+
 use byteorder::{ByteOrder, BigEndian};
 use crypto::{Hash, PublicKey, HASH_SIZE, PUBLIC_KEY_LENGTH};
-
 
 /// A trait that defines serialization of corresponding types as storage keys.
 ///

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of array list of items.
+
 use std::cell::Cell;
 use std::marker::PhantomData;
 

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of key-value map.
+
 use std::marker::PhantomData;
 
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageKey, StorageValue};

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of `MemoryDB` database.
+
 use std::sync::{Arc, RwLock};
 use std::clone::Clone;
 use std::collections::btree_map::BTreeMap;

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 //! An implementation of a Merklized version of an array list (Merkle tree).
+
 use std::cell::Cell;
 use std::marker::PhantomData;
 
 use crypto::{Hash, hash, HashStream};
-
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
-
 use self::key::ProofListKey;
 
 pub use self::proof::{ListProof, ListProofError};

--- a/exonum/src/storage/proof_list_index/proof.rs
+++ b/exonum/src/storage/proof_list_index/proof.rs
@@ -18,11 +18,9 @@ use serde::de::Error;
 use serde_json::{Error as SerdeJsonError, Value, from_value};
 
 use crypto::{Hash, hash};
-
 use super::pair_hash;
 use super::super::StorageValue;
 use super::key::ProofListKey;
-
 use self::ListProof::*;
 
 /// An enum that represents a proof of existence for a proof list elements.

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -16,10 +16,9 @@ use rand::{thread_rng, Rng};
 
 use crypto::{Hash, hash};
 use storage::{Database, StorageValue};
-use super::{ProofListIndex, ListProof, pair_hash};
 use encoding::serialize::json::reexport::{to_string, from_str};
 use encoding::serialize::reexport::Serialize;
-
+use super::{ProofListIndex, ListProof, pair_hash};
 use self::ListProof::*;
 
 const IDX_NAME: &'static str = "idx_name";

--- a/exonum/src/storage/proof_map_index/key.rs
+++ b/exonum/src/storage/proof_map_index/key.rs
@@ -15,7 +15,6 @@
 use std::cmp::min;
 
 use crypto::{Hash, PublicKey, HASH_SIZE};
-
 use super::super::StorageKey;
 
 pub const BRANCH_KEY_PREFIX: u8 = 00;

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 //! An implementation of a Merklized version of a map (Merkle Patricia tree).
+
 use std::marker::PhantomData;
 
 use crypto::{Hash, HashStream};
-
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
-
 use self::key::{DBKey, ChildKind, LEAF_KEY_PREFIX};
 use self::node::{Node, BranchNode};
 

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
 
-use crypto::{Hash, HashStream};
+use std::fmt;
 
+use crypto::{Hash, HashStream};
 use super::super::{StorageValue, Error};
 use super::key::{ProofMapKey, DBKey, ChildKind, KEY_SIZE};
 

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
-
-use std::fmt;
 
 use crypto::{Hash, HashStream};
 use super::super::{StorageValue, Error};

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rand;
-
 use std::collections::HashSet;
-use rand::{thread_rng, Rng};
+
+use rand::{self, thread_rng, Rng};
 use crypto::{hash, Hash, HashStream};
 use storage::db::Database;
 use encoding::serialize::json::reexport::to_string;
 use encoding::serialize::reexport::{Serialize, Serializer};
-
 use super::{DBKey, ProofMapIndex};
 use super::proof::MapProof;
 use super::key::{KEY_SIZE, LEAF_KEY_PREFIX};

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -14,19 +14,19 @@
 
 //! An implementation of `RocksDB` database.
 
-use exonum_profiler::ProfilerSpan;
-use rocksdb::DB as _RocksDB;
-use rocksdb::{WriteBatch, DBIterator};
-use rocksdb::Snapshot as _Snapshot;
-use rocksdb::Error as _Error;
-use rocksdb::utils::get_cf_names;
-
 use std::mem;
 use std::sync::Arc;
 use std::path::Path;
 use std::fmt;
 use std::error;
 use std::iter::Peekable;
+
+use exonum_profiler::ProfilerSpan;
+use rocksdb::DB as _RocksDB;
+use rocksdb::{WriteBatch, DBIterator};
+use rocksdb::Snapshot as _Snapshot;
+use rocksdb::Error as _Error;
+use rocksdb::utils::get_cf_names;
 
 use super::{Database, Iterator, Iter, Snapshot, Error, Patch, Result};
 use super::db::Change;

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! An implementation of `RocksDB` database.
+
 use exonum_profiler::ProfilerSpan;
 use rocksdb::DB as _RocksDB;
 use rocksdb::{WriteBatch, DBIterator};
@@ -27,11 +28,11 @@ use std::fmt;
 use std::error;
 use std::iter::Peekable;
 
-pub use rocksdb::{Options as RocksDBOptions, WriteOptions as RocksDBWriteOptions};
-pub use rocksdb::BlockBasedOptions as RocksBlockOptions;
-
 use super::{Database, Iterator, Iter, Snapshot, Error, Patch, Result};
 use super::db::Change;
+
+pub use rocksdb::{Options as RocksDBOptions, WriteOptions as RocksDBWriteOptions};
+pub use rocksdb::BlockBasedOptions as RocksBlockOptions;
 
 impl From<_Error> for Error {
     fn from(err: _Error) -> Self {

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -17,11 +17,11 @@
 // TODO: Remove when https://github.com/rust-lang-nursery/rust-clippy/issues/2190 is fixed.
 #![cfg_attr(feature="cargo-clippy", allow(doc_markdown))]
 
-use byteorder::{BigEndian, ByteOrder};
-
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
+
+use byteorder::{BigEndian, ByteOrder};
 
 use crypto::{hash, Hash};
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 //! An implementation of set for items that implement `StorageValue` trait.
+
 use std::marker::PhantomData;
 
 use crypto::Hash;
-
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
 
 /// A set of items that implement `StorageValue` trait.

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! A definition of `StorageValue` trait and implementations for common types.
+
 use byteorder::{ByteOrder, LittleEndian};
 
 use std::mem;

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -14,10 +14,10 @@
 
 //! A definition of `StorageValue` trait and implementations for common types.
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use std::mem;
 use std::borrow::Cow;
+
+use byteorder::{ByteOrder, LittleEndian};
 
 use crypto::{Hash, hash, PublicKey};
 use messages::{RawMessage, MessageBuffer, Message};

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -24,7 +24,6 @@ use std::sync::Mutex;
 use futures::Future;
 use futures::sync::oneshot;
 use tokio_timer::Timer;
-
 use exonum::blockchain::{Service, ServiceContext, Transaction};
 use exonum::encoding::Error as EncodingError;
 use exonum::messages::RawTransaction;

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // Workaround: Clippy does not correctly handle borrowing checking rules for returned types.
 #![cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-
-use futures::{self, Async, Future, Stream};
-use futures::sync::mpsc;
 
 use std::ops::{AddAssign, Deref};
 use std::sync::{Arc, Mutex};
@@ -27,6 +23,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
 
+use futures::{self, Async, Future, Stream};
+use futures::sync::mpsc;
 use exonum::node::{Configuration, ExternalMessage, ListenerConfig, NodeHandler, NodeSender,
                    ServiceConfig, State, SystemStateProvider, ApiSender};
 use exonum::blockchain::{Block, BlockProof, Blockchain, ConsensusConfig, GenesisConfig, Schema,

--- a/sandbox/src/sandbox_tests_helper.rs
+++ b/sandbox/src/sandbox_tests_helper.rs
@@ -14,12 +14,11 @@
 
 /// purpose of this module is to keep functions with reusable code used for sandbox tests
 
-use bit_vec::BitVec;
-
 use std::time::Duration;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
+use bit_vec::BitVec;
 use exonum::messages::{RawTransaction, Message, Propose, Prevote, Precommit, ProposeRequest,
                        PrevotesRequest};
 use exonum::blockchain::{Block, SCHEMA_MAJOR_VERSION};

--- a/sandbox/tests/consensus.rs
+++ b/sandbox/tests/consensus.rs
@@ -20,12 +20,11 @@ extern crate log;
 extern crate env_logger;
 extern crate bit_vec;
 
-use rand::{thread_rng, Rng};
-use bit_vec::BitVec;
-
 use std::time::Duration;
 use std::collections::BTreeMap;
 
+use rand::{thread_rng, Rng};
+use bit_vec::BitVec;
 use exonum::messages::{RawMessage, Message, Propose, Prevote, Precommit, ProposeRequest,
                        TransactionsRequest, PrevotesRequest, CONSENSUS};
 use exonum::crypto::{Hash, Seed, gen_keypair, gen_keypair_from_seed};


### PR DESCRIPTION
Motivation: we had a (not described formally) convention to separate usings into three groups: first thirdparty, then `std` and finally the internal ones. I propose to treat all `external crate` usings as thirdparty just because it is a formal criteria.

The order is discussable too.