### PR TITLE
Remove default 'state_hash' implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Changed iterators over `Patch` and `Changes` data into custom types instead of standard collection iterators. (#393)
-- Fixed typo in `SparceListIndexKeys` and `SparceListIndexValues` (#398)
+- Fixed typo in `SparceListIndexKeys` and `SparceListIndexValues`. (#398)
+
+### Removed
+- Removed default `state_hash` implementation in the `Service` trait. (#399)
 
 ## 0.4 - 2017-12-08
 

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -103,6 +103,34 @@ pub trait Service: Send + Sync + 'static {
     fn service_id(&self) -> u16;
 
     /// Unique human readable service name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exonum::blockchain::Service;
+    /// use exonum::crypto::Hash;
+    /// # use exonum::blockchain::Transaction;
+    /// # use exonum::messages::RawTransaction;
+    /// # use exonum::encoding::Error as MessageError;
+    /// # use exonum::storage::Snapshot;
+    ///
+    /// struct MyService {}
+    ///
+    /// impl Service for MyService {
+    /// #   fn service_id(&self) -> u16 {
+    /// #       8000
+    /// #   }
+    ///     fn service_name(&self) -> &'static str {
+    ///         "my_special_unique_service"
+    ///     }
+    /// #   fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    /// #       Vec::new()
+    /// #   }
+    /// #   fn tx_from_raw(&self, _: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    /// #       unimplemented!()
+    /// #   }
+    /// }
+    /// ```
     fn service_name(&self) -> &'static str;
 
     /// Returns a list of root hashes of tables that determine the current state
@@ -115,6 +143,34 @@ pub trait Service: Send + Sync + 'static {
     ///
     /// [1]: struct.Schema.html#method.state_hash_aggregator
     /// [2]: struct.Blockchain.html#method.service_table_unique_key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exonum::blockchain::Service;
+    /// use exonum::crypto::Hash;
+    /// use exonum::storage::Snapshot;
+    /// # use exonum::blockchain::Transaction;
+    /// # use exonum::messages::RawTransaction;
+    /// # use exonum::encoding::Error as MessageError;
+    ///
+    /// struct MyService {}
+    ///
+    /// impl Service for MyService {
+    /// #   fn service_id(&self) -> u16 {
+    /// #       8000
+    /// #   }
+    /// #   fn service_name(&self) -> &'static str {
+    /// #       "my_special_unique_service"
+    /// #   }
+    ///     fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    ///         Vec::new()
+    ///     }
+    /// #   fn tx_from_raw(&self, _: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    /// #       unimplemented!()
+    /// #   }
+    /// }
+    /// ```
     fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash>;
 
     /// Tries to create `Transaction` object from the given raw message.

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -109,13 +109,13 @@ pub trait Service: Send + Sync + 'static {
     /// of the service database. These hashes are collected from all services in a common
     ///  `MerklePatriciaTable` that named [`state_hash_aggregator`][1].
     ///
+    /// Empty `Vec` can be returned if service don't want to change blockchain state.
+    ///
     /// See also [`service_table_unique_key`][2].
     ///
     /// [1]: struct.Schema.html#method.state_hash_aggregator
     /// [2]: struct.Blockchain.html#method.service_table_unique_key
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
-        Vec::new()
-    }
+    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash>;
 
     /// Tries to create `Transaction` object from the given raw message.
     fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -28,8 +28,9 @@ use exonum::blockchain::{Service, ServiceContext, Transaction};
 use exonum::encoding::Error as EncodingError;
 use exonum::messages::RawTransaction;
 use exonum::node::Node;
-use exonum::storage::MemoryDB;
+use exonum::storage::{MemoryDB, Snapshot};
 use exonum::helpers;
+use exonum::crypto::Hash;
 
 struct CommitWatcherService(pub Mutex<Option<oneshot::Sender<()>>>);
 
@@ -40,6 +41,10 @@ impl Service for CommitWatcherService {
 
     fn service_name(&self) -> &'static str {
         "commit_watcher"
+    }
+
+    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        Vec::new()
     }
 
     fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -664,7 +664,7 @@ mod tests {
     use exonum::messages::RawTransaction;
     use exonum::encoding;
     use exonum::crypto::{gen_keypair_from_seed, Seed};
-    use exonum::storage::Fork;
+    use exonum::storage::{Fork, Snapshot};
 
     use sandbox_tests_helper::{add_one_height, SandboxState, VALIDATOR_1, VALIDATOR_2,
                                VALIDATOR_3, HEIGHT_ONE, ROUND_ONE, ROUND_TWO};
@@ -707,6 +707,10 @@ mod tests {
 
         fn service_id(&self) -> u16 {
             SERVICE_ID
+        }
+
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            Vec::new()
         }
 
         fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {


### PR DESCRIPTION
Motivation: default implementation can confuse users. Implementing `Service` trait it is easily to forget about `state_hash` method because it is already implemented. Without the default implementation user will get a compilation error and and this will force him look at the documentation.

Disadvantages: minimal service code becomes a little more "bloated".