### PR TITLE
Refactor `Transaction::info` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `patch` method to the `Fork` structure. (#393)
-- Replaced config param `timeout_events_capacity` with `internal_events_capacity`. (#388)
 
 ### Changed
 - Changed iterators over `Patch` and `Changes` data into custom types instead of standard collection iterators. (#393)
 - Fixed typo in `SparceListIndexKeys` and `SparceListIndexValues` (#398)
 - Fixed #15 consensus on the threshold of 1/3 sleeping validators. (#388)
+- Replaced config param `timeout_events_capacity` with `internal_events_capacity`. (#388)
+- The `Transaction` trait now inherit `ExonumJson`. (#402)
 
 ### Removed
 - Removed default `state_hash` implementation in the `Service` trait. (#399)
+- Removed `info` method from the `Transaction`. (#402)
 
 ## 0.4 - 2017-12-08
 

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -65,6 +65,8 @@ pub enum ApiError {
     Unauthorized,
     /// Address parse error.
     AddressParseError(::std::net::AddrParseError),
+    /// Serialize error,
+    Serialize(Box<::std::error::Error + Send + Sync>),
 }
 
 impl fmt::Display for ApiError {
@@ -87,6 +89,7 @@ impl ::std::error::Error for ApiError {
             ApiError::FileExists(_) => "File exists",
             ApiError::Unauthorized => "Unauthorized",
             ApiError::AddressParseError(_) => "AddressParseError",
+            ApiError::Serialize(_) => "Serialization error",
         }
     }
 }

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -71,7 +71,11 @@ impl SystemApi {
                         MemPoolResult::Committed,
                     ))
                 },
-                |o| Ok(MemPoolResult::MemPool(MemPoolTxInfo { content: o.info() })),
+                |o| {
+                    Ok(MemPoolResult::MemPool(MemPoolTxInfo {
+                        content: o.serialize_field().map_err(ApiError::Serialize)?,
+                    }))
+                },
             )
     }
 }

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -27,13 +27,14 @@ use crypto::{Hash, PublicKey, SecretKey};
 use storage::{Fork, Snapshot};
 use messages::{Message, RawTransaction};
 use encoding::Error as MessageError;
+use encoding::serialize::json::ExonumJson;
 use node::{ApiSender, Node, State, TransactionSend};
 use blockchain::{Blockchain, ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys};
 use helpers::{Height, Milliseconds, ValidatorId};
 
 /// A trait that describes transaction processing rules (a group of sequential operations
 /// with the Exonum storage) for the given `Message`.
-pub trait Transaction: Message + 'static {
+pub trait Transaction: Message + ExonumJson + 'static {
     /// Verifies the transaction, which includes the message signature verification and other
     /// specific internal constraints. verify is intended to check the internal consistency of
     /// a transaction; it has no access to the blockchain state.
@@ -52,48 +53,6 @@ pub trait Transaction: Message + 'static {
     /// - If the execute method of a transaction raises a `panic`, the changes made by the
     /// transactions are discarded, but the transaction itself is still considered committed.
     fn execute(&self, fork: &mut Fork);
-    /// Returns the useful information about the transaction in the JSON format. The returned value
-    /// is used to fill the [`TxInfo.content`] field in [the blockchain explorer][explorer].
-    ///
-    /// # Notes
-    ///
-    /// The default implementation returns `null`. For transactions defined with
-    /// the [`message!`] macro, you may redefine `info()` as
-    ///
-    /// ```
-    /// # #[macro_use] extern crate exonum;
-    /// extern crate serde_json;
-    /// # use exonum::blockchain::Transaction;
-    /// # use exonum::storage::Fork;
-    ///
-    /// message! {
-    ///     struct MyTransaction {
-    ///         // Transaction definition...
-    /// #       const TYPE = 1;
-    /// #       const ID = 1;
-    /// #       const SIZE = 8;
-    /// #       field foo: u64 [0 => 8]
-    ///     }
-    /// }
-    ///
-    /// impl Transaction for MyTransaction {
-    ///     // Other methods...
-    /// #   fn verify(&self) -> bool { true }
-    /// #   fn execute(&self, _: &mut Fork) { }
-    ///
-    ///     fn info(&self) -> serde_json::Value {
-    ///         serde_json::to_value(self).expect("Cannot serialize transaction to JSON")
-    ///     }
-    /// }
-    /// # fn main() { }
-    /// ```
-    ///
-    /// [`TxInfo.content`]: ../explorer/struct.TxInfo.html#structfield.content
-    /// [explorer]: ../explorer/index.html
-    /// [`message!`]: ../macro.message.html
-    fn info(&self) -> Value {
-        Value::Null
-    }
 }
 
 /// A trait that describes a business-logic of the concrete service.

--- a/exonum/src/encoding/serialize/json.rs
+++ b/exonum/src/encoding/serialize/json.rs
@@ -64,9 +64,11 @@ pub trait ExonumJson {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>>;
+    ) -> Result<(), Box<Error>>
+    where
+        Self: Sized;
     /// serialize field as `json::Value`
-    fn serialize_field(&self) -> Result<Value, Box<Error>>;
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>>;
 }
 
 /// `ExonumJsonDeserialize` is trait for objects that could be constructed from exonum json.
@@ -97,7 +99,7 @@ macro_rules! impl_deserialize_int {
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error>> {
+            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
                 Ok(Value::Number((*self).into()))
             }
         }
@@ -120,7 +122,7 @@ macro_rules! impl_deserialize_bigint {
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error>> {
+            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
                 Ok(Value::String(self.to_string()))
             }
         }
@@ -140,7 +142,7 @@ macro_rules! impl_deserialize_float {
                          .is_some()
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error>> {
+            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
                 Value::Number(self.into())
             }
         }
@@ -165,7 +167,7 @@ macro_rules! impl_deserialize_hex_segment {
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error>> {
+            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
                 let hex_str = $crate::encoding::serialize::encode_hex(&self[..]);
                 Ok(Value::String(hex_str))
             }
@@ -194,7 +196,7 @@ impl ExonumJson for bool {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(Value::Bool(*self))
     }
 }
@@ -211,7 +213,7 @@ impl<'a> ExonumJson for &'a str {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(Value::String(self.to_string()))
     }
 }
@@ -230,7 +232,7 @@ impl ExonumJson for SystemTime {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let duration = self.duration_since(UNIX_EPOCH)?;
         let duration = DurationHelper {
             secs: duration.as_secs().to_string(),
@@ -252,7 +254,7 @@ impl ExonumJson for SocketAddr {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(::serde_json::to_value(&self)?)
     }
 }
@@ -275,7 +277,7 @@ impl<'a> ExonumJson for &'a [Hash] {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let mut vec = Vec::new();
         for hash in self.iter() {
             vec.push(hash.serialize_field()?)
@@ -296,7 +298,7 @@ impl<'a> ExonumJson for &'a [u8] {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(Value::String(::encoding::serialize::encode_hex(self)))
     }
 }
@@ -320,7 +322,7 @@ impl ExonumJson for Vec<RawMessage> {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let vec = self.iter()
             .map(|slice| {
                 Value::String(::encoding::serialize::encode_hex(slice))
@@ -370,7 +372,7 @@ where
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let mut vec = Vec::new();
         for item in self {
             vec.push(item.serialize_field()?);
@@ -402,7 +404,7 @@ impl ExonumJson for BitVec {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let mut out = String::new();
         for i in self.iter() {
             if i {
@@ -428,7 +430,7 @@ impl ExonumJson for Height {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let val: u64 = self.to_owned().into();
         Ok(Value::String(val.to_string()))
     }
@@ -446,7 +448,7 @@ impl ExonumJson for Round {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let val: u32 = self.to_owned().into();
         Ok(Value::Number(val.into()))
     }
@@ -464,7 +466,7 @@ impl ExonumJson for ValidatorId {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         let val: u16 = self.to_owned().into();
         Ok(Value::Number(val.into()))
     }

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -201,7 +201,7 @@ macro_rules! encoding_struct {
             #[allow(unused_mut)]
             fn serialize_field(&self)
                 -> Result<$crate::encoding::serialize::json::reexport::Value,
-                          Box<::std::error::Error>>
+                          Box<::std::error::Error + Send + Sync>>
             {
                 use $crate::encoding::serialize::json::reexport::Value;
                 let mut map = $crate::encoding::serialize::json::reexport::Map::new();

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -73,7 +73,9 @@ impl<'a> BlockchainExplorer<'a> {
                 let box_transaction = self.blockchain.tx_from_raw(raw_tx.clone()).ok_or_else(|| {
                     ApiError::Service(format!("Service not found for tx: {:?}", raw_tx).into())
                 })?;
-                let content = box_transaction.info();
+                let content = box_transaction.serialize_field().map_err(
+                    ApiError::Serialize,
+                )?;
 
                 let location = schema.tx_location_by_tx_hash().get(tx_hash).expect(
                     &format!(

--- a/exonum/src/messages/spec.rs
+++ b/exonum/src/messages/spec.rs
@@ -311,7 +311,7 @@ macro_rules! message {
             #[allow(unused_mut)]
             fn serialize_field(&self)
                 -> Result<$crate::encoding::serialize::json::reexport::Value,
-                            Box<::std::error::Error>>
+                            Box<::std::error::Error + Send + Sync>>
             {
                 use $crate::encoding::serialize::json::reexport::Value;
                 use $crate::encoding::serialize::json::reexport::Map;


### PR DESCRIPTION
### Description

Removes `Transaction::info`.
Makes `Transaction` inherit `ExonumJson`. 

### What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Other (CI-improvements, docs fixes, version bumps, clippy, rustfmt)

### Checklist:
- [X] All commits are named based on our guideline (read CONTRIBUTING.md)

- [ ] Tests for the changes have been added

- [ ] Docs have been added / updated

- [x] CHANGELOG.md have been updated


### How can we test these changes?
We can test api. For example: result of `curl http://127.0.0.1:8000/api/system/v1/transactions/44c6c2c58eaab71f8d627d75ca72f244289bc84586a7fb42186a676b2ec4626b`
looks unchanged.

