### PR TITLE
Remove inner mutability in channels usage

### DIFF
--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -23,12 +23,15 @@ use std::time::SystemTime;
 use std::cmp::Ordering;
 
 use futures::{Future, Async, Poll, Stream};
-use futures::sync::mpsc;
+use futures::sink::Wait;
+use futures::sync::mpsc::{self, Sender};
 
 use node::{ExternalMessage, NodeTimeout};
 pub use self::network::{NetworkEvent, NetworkRequest, NetworkPart, NetworkConfiguration};
 pub use self::internal::InternalPart;
 use helpers::{Height, Round};
+
+pub type SyncSender<T> = Wait<Sender<T>>;
 
 /// This kind of events is used to schedule execution in next event-loop ticks
 /// Usable to make flat logic and remove recursions.

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -14,7 +14,6 @@
 
 use events::{Event, EventHandler, NetworkEvent, InternalEvent, InternalRequest};
 use super::{NodeHandler, ExternalMessage, NodeTimeout};
-use futures::{Sink, Future};
 use events::error::LogError;
 
 impl EventHandler for NodeHandler {
@@ -72,11 +71,6 @@ impl NodeHandler {
 
     /// Schedule execution for later time
     pub(crate) fn execute_later(&mut self, event: InternalRequest) {
-        self.channel
-            .internal_requests
-            .clone()
-            .send(event)
-            .wait()
-            .log_error();
+        self.channel.internal_requests.send(event).log_error();
     }
 }

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -24,6 +24,7 @@ use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
 
 use futures::{self, Async, Future, Stream};
+use futures::Sink;
 use futures::sync::mpsc;
 use exonum::node::{Configuration, ExternalMessage, ListenerConfig, NodeHandler, NodeSender,
                    ServiceConfig, State, SystemStateProvider, ApiSender};
@@ -621,9 +622,9 @@ pub fn sandbox_with_services(services: Vec<Box<Service>>) -> Sandbox {
     let network_channel = mpsc::channel(100);
     let internal_channel = mpsc::channel(100);
     let node_sender = NodeSender {
-        network_requests: network_channel.0.clone(),
-        internal_requests: internal_channel.0.clone(),
-        api_requests: api_channel.0.clone(),
+        network_requests: network_channel.0.clone().wait(),
+        internal_requests: internal_channel.0.clone().wait(),
+        api_requests: api_channel.0.clone().wait(),
     };
 
     let mut handler = NodeHandler::new(


### PR DESCRIPTION
### Description

exonum use `futures::sync::mpsc::channel` for sending events from main event-loop thread into workers threads.
`Sender` for this channel is async by default, which means that sending data produce new `Future`. Keeping this `Sender`s in synchronised code forces developer to `clone` `Sender`'s `Sink` and finalize sending with `.wait`. 
Usually code looks like:
```
sender.clone().send(request).wait().log_err() // .clone() and .wait() there redurant.
```
In code like this it's easy to forgot `wait` after send.
Additionally this leads to inner mutability, which is an implicit, that makes api worsen.

In this pull request: `Sender` replaced by `SyncSender` which designed especially for this kind of synchronisation, but this change introduce some code duplication, to fulfit borrow checker rules.

### What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [X] Other (**Refactor**)

### Checklist:
- [ ] All commits are named based on our guideline (read CONTRIBUTING.md)

- [ ] Tests for the changes have been added

- [ ] Docs have been added / updated

- [ ] CHANGELOG.md have been updated

