### PR TITLE
`_self` -> `self_`

### DIFF
--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -158,13 +158,13 @@ impl SystemApi {
 impl Api for SystemApi {
     fn wire(&self, router: &mut Router) {
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let peer_add = move |req: &mut Request| -> IronResult<Response> {
             let map = req.get_ref::<Params>().unwrap();
             match map.find(&["ip"]) {
                 Some(&ParamsValue::String(ref ip_str)) => {
-                    _self.peer_add(ip_str)?;
-                    _self.ok_response(&::serde_json::to_value("Ok").unwrap())
+                    self_.peer_add(ip_str)?;
+                    self_.ok_response(&::serde_json::to_value("Ok").unwrap())
                 }
                 _ => {
                     Err(ApiError::IncorrectRequest(
@@ -174,16 +174,16 @@ impl Api for SystemApi {
             }
         };
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let peers_info = move |_: &mut Request| -> IronResult<Response> {
-            let info = _self.get_peers_info();
-            _self.ok_response(&::serde_json::to_value(info).unwrap())
+            let info = self_.get_peers_info();
+            self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let network = move |_: &mut Request| -> IronResult<Response> {
-            let info = _self.get_network_info();
-            _self.ok_response(&::serde_json::to_value(info).unwrap())
+            let info = self_.get_network_info();
+            self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
         router.get("/v1/peers", peers_info, "peers_info");

--- a/exonum/src/api/public/blockhain_explorer.rs
+++ b/exonum/src/api/public/blockhain_explorer.rs
@@ -65,7 +65,7 @@ impl ExplorerApi {
 impl Api for ExplorerApi {
     fn wire(&self, router: &mut Router) {
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let blocks = move |req: &mut Request| -> IronResult<Response> {
             let map = req.get_ref::<Params>().unwrap();
             let count: u64 = match map.find(&["count"]) {
@@ -96,11 +96,11 @@ impl Api for ExplorerApi {
                 }
                 _ => false,
             };
-            let info = _self.get_blocks(count, latest, skip_empty_blocks)?;
-            _self.ok_response(&::serde_json::to_value(info).unwrap())
+            let info = self_.get_blocks(count, latest, skip_empty_blocks)?;
+            self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let block = move |req: &mut Request| -> IronResult<Response> {
             let params = req.extensions.get::<Router>().unwrap();
             match params.find("height") {
@@ -108,8 +108,8 @@ impl Api for ExplorerApi {
                     let height: u64 = height_str.parse().map_err(|e: ParseIntError| {
                         ApiError::IncorrectRequest(Box::new(e))
                     })?;
-                    let info = _self.get_block(Height(height))?;
-                    _self.ok_response(&::serde_json::to_value(info).unwrap())
+                    let info = self_.get_block(Height(height))?;
+                    self_.ok_response(&::serde_json::to_value(info).unwrap())
                 }
                 None => {
                     Err(ApiError::IncorrectRequest(

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -101,23 +101,23 @@ impl SystemApi {
 
 impl Api for SystemApi {
     fn wire(&self, router: &mut Router) {
-        let _self = self.clone();
+        let self_ = self.clone();
         let mempool_info = move |_: &mut Request| -> IronResult<Response> {
-            let info = _self.get_mempool_info();
-            _self.ok_response(&::serde_json::to_value(info).unwrap())
+            let info = self_.get_mempool_info();
+            self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let transaction = move |req: &mut Request| -> IronResult<Response> {
             let params = req.extensions.get::<Router>().unwrap();
             match params.find("hash") {
                 Some(hash_str) => {
-                    let info = _self.get_transaction(hash_str)?;
+                    let info = self_.get_transaction(hash_str)?;
                     let result = match info {
                         MemPoolResult::Unknown => Self::not_found_response,
                         _ => Self::ok_response,
                     };
-                    result(&_self, &::serde_json::to_value(info).unwrap())
+                    result(&self_, &::serde_json::to_value(info).unwrap())
                 }
                 None => {
                     Err(ApiError::IncorrectRequest(
@@ -127,10 +127,10 @@ impl Api for SystemApi {
             }
         };
 
-        let _self = self.clone();
+        let self_ = self.clone();
         let healthcheck = move |_: &mut Request| {
-            let info = _self.get_healthcheck_info();
-            _self.ok_response(&::serde_json::to_value(info).unwrap())
+            let info = self_.get_healthcheck_info();
+            self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
         router.get("/v1/mempool", mempool_info, "mempool");


### PR DESCRIPTION

### Description

See https://github.com/exonum/exonum/pull/405#discussion_r158683937

> @DarkEld3r:
> Maybe self_ instead of _self? Underscore prefix suppresses "unused variable" warning.

### What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Other (CI-improvements, docs fixes, version bumps, clippy, rustfmt)

### Checklist:
- [x] All commits are named based on our guideline (read CONTRIBUTING.md)

- [ ] Tests for the changes have been added

- [ ] Docs have been added / updated

- [ ] CHANGELOG.md have been updated


### How can we test these changes?

--