### PR TITLE
Encoding: Properly handling float serialization of zero values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ script: |
       cd sandbox && cargo clippy --verbose -- -D warnings
   ;;
   "test-core" )
-      cargo test --manifest-path exonum/Cargo.toml --verbose --tests --lib
+      cargo test --manifest-path exonum/Cargo.toml --verbose --tests --lib --features "float_serialize"
   ;;
   "test-sandbox" )
       cargo test --manifest-path sandbox/Cargo.toml  --verbose

--- a/exonum/src/encoding/float.rs
+++ b/exonum/src/encoding/float.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::mem;
-use std::num::FpCategory;
 use std::error::Error;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -25,7 +24,8 @@ use encoding::{CheckedOffset, Field, Offset};
 use encoding::serialize::WriteBufferWrapper;
 use encoding::serialize::json::ExonumJson;
 
-/// Wrapper for the `f32` type that restricts non-finite (NaN and Infinity) values.
+/// Wrapper for the `f32` type that restricts non-finite
+/// (NaN, Infinity, negative zero and subnormal) values.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct F32 {
     value: f32,
@@ -36,7 +36,7 @@ impl F32 {
     ///
     /// # Panics
     ///
-    /// Panics if given value isn't normal (either `NaN`, `Infinity` or `SubNormal`).
+    /// Panics if given value isn't normal (either `NaN`, `Infinity`, negative zero or `SubNormal`).
     ///
     /// # Examples
     ///
@@ -51,7 +51,7 @@ impl F32 {
     }
 
     /// Creates a new `F32` instance with the given `value`. Returns `None` if the given value
-    /// isn't normal.
+    /// isn't normal (either `NaN`, `Infinity`, negative zero or `SubNormal`).
     ///
     /// # Examples
     ///
@@ -66,9 +66,10 @@ impl F32 {
     /// assert!(val.is_none());
     /// ```
     pub fn try_from(value: f32) -> Option<Self> {
-        match value.classify() {
-            FpCategory::Normal | FpCategory::Zero => Some(Self { value }),
-            _ => None,
+        if value.is_normal() || (value == 0.0 && value.signum() == 1.0) {
+            Some(Self { value })
+        } else {
+            None
         }
     }
 
@@ -87,7 +88,8 @@ impl F32 {
     }
 }
 
-/// Wrapper for the `f64` type that restricts non-numeric (NaN and Infinity) values.
+/// Wrapper for the `f64` type that restricts non-finite
+/// (NaN, Infinity, negative zero and subnormal) values.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct F64 {
     value: f64,
@@ -98,7 +100,7 @@ impl F64 {
     ///
     /// # Panics
     ///
-    /// Panics if given value isn't normal (either `NaN`, `Infinity` or `SubNormal`).
+    /// Panics if given value isn't normal (either `NaN`, `Infinity`, negative zero or `SubNormal`).
     ///
     /// # Examples
     ///
@@ -113,7 +115,7 @@ impl F64 {
     }
 
     /// Creates a new `F64` instance with the given `value`. Returns `None` if the given value
-    /// isn't normal.
+    /// isn't normal (either `NaN`, `Infinity`, negative zero or `SubNormal`).
     ///
     /// # Examples
     ///
@@ -128,9 +130,10 @@ impl F64 {
     /// assert!(val.is_none());
     /// ```
     pub fn try_from(value: f64) -> Option<Self> {
-        match value.classify() {
-            FpCategory::Normal | FpCategory::Zero => Some(Self { value }),
-            _ => None,
+        if value.is_normal() || (value == 0.0 && value.signum() == 1.0) {
+            Some(Self { value })
+        } else {
+            None
         }
     }
 
@@ -231,7 +234,7 @@ impl ExonumJson for F32 {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(Value::Number(
             Number::from_f64(f64::from(self.get())).ok_or(
                 "Can't cast float as json",
@@ -252,7 +255,7 @@ impl ExonumJson for F64 {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error>> {
+    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
         Ok(Value::Number(Number::from_f64(self.get()).ok_or(
             "Can't cast float as json",
         )?))
@@ -300,7 +303,7 @@ mod tests {
         let sub: f32 = 1.1754942e-38;
         assert_eq!(sub.classify(), FpCategory::Subnormal);
         let valid_data = vec![0f32, 3.14, -1.0, 1.0, f32::MAX, f32::MIN];
-        let invalid_data = vec![f32::INFINITY, f32::NEG_INFINITY, f32::NAN, sub];
+        let invalid_data = vec![-0.0f32, f32::INFINITY, f32::NEG_INFINITY, f32::NAN, sub];
         let mut buf = vec![0; 4];
         for value in valid_data {
             LittleEndian::write_f32(&mut buf, value);
@@ -317,7 +320,7 @@ mod tests {
         let sub: f64 = 1.1754942e-315;
         assert_eq!(sub.classify(), FpCategory::Subnormal);
         let valid_data = vec![0f64, 3.14, -1.0, 1.0, f64::MAX, f64::MIN];
-        let invalid_data = vec![f64::INFINITY, f64::NEG_INFINITY, f64::NAN, sub];
+        let invalid_data = vec![-0.0f64, f64::INFINITY, f64::NEG_INFINITY, f64::NAN, sub];
         let mut buf = vec![0; 8];
         for value in valid_data {
             LittleEndian::write_f64(&mut buf, value);


### PR DESCRIPTION
### Description
Both positive and negative values has the same `classify` representation (`FpCategory::Zero`), which can make possible problems while encoding/decoding floats.

This change fixes behavior by forbidding negative zeros in wrappers' constructors.

### What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Other (CI-improvements, docs fixes, version bumps, clippy, rustfmt)

### Checklist:
- [x] All commits are named based on our guideline (read CONTRIBUTING.md)

- [x] Tests for the changes have been added

- [x] Docs have been added / updated

- [x] CHANGELOG.md have been updated

cc @matklad @vldm @DarkEld3r 