### PR TITLE
Introduce strongly-typed Context keys

### DIFF
--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -17,12 +17,13 @@ use std::panic::{self, PanicInfo};
 use std::ffi::OsString;
 
 use blockchain::Service;
-use node::{NodeConfig, Node};
+use node::Node;
 
 use super::internal::{CollectedCommand, Feedback};
 use super::clap_backend::ClapBackend;
 use super::ServiceFactory;
 use super::details::{Run, Finalize, GenerateNodeConfig, GenerateCommonConfig, GenerateTestnet};
+use super::keys;
 
 /// `NodeBuilder` is a high level object,
 /// usable for fast prototyping and creating app from services list.
@@ -73,8 +74,9 @@ impl NodeBuilder {
         match ClapBackend::execute(self.commands.as_slice()) {
             Feedback::RunNode(ref ctx) => {
                 let db = Run::db_helper(ctx);
-                let config: NodeConfig =
-                    ctx.get("node_config").expect("could not find node_config");
+                let config = ctx.get(keys::NODE_CONFIG).expect(
+                    "could not find node_config",
+                );
                 let services: Vec<Box<Service>> = self.service_factories
                     .into_iter()
                     .map(|mut factory| factory.make_service(ctx))

--- a/exonum/src/helpers/fabric/context_key.rs
+++ b/exonum/src/helpers/fabric/context_key.rs
@@ -1,0 +1,71 @@
+use std::marker::PhantomData;
+use std::fmt;
+
+/// `ContextKey` provides strongly typed access to data inside `Context`.
+/// See `exonum::fabric::keys` for keys used by the exonum itself.
+pub struct ContextKey<T> {
+    // These fields are public so that `context_key`
+    // macro works outside of this crate. It should be
+    // replaced with `const fn`, once it is stable.
+    #[doc(hidden)]
+    pub __name: &'static str,
+    #[doc(hidden)]
+    pub __phantom: PhantomData<T>,
+}
+
+// We need explicit `impl Copy` because derive won't work if `T: !Copy`.
+impl<T> Copy for ContextKey<T> {}
+
+// Bug in clippy, fixed on master branch.
+#[cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
+impl<T> Clone for ContextKey<T> {
+    fn clone(&self) -> Self {
+        ContextKey {
+            __name: self.__name,
+            __phantom: self.__phantom,
+        }
+    }
+}
+
+impl<T> fmt::Debug for ContextKey<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "ContextKey({:?})", self.__name)
+    }
+}
+
+impl<T> ContextKey<T> {
+    /// Name of this key.
+    pub fn name(&self) -> &str {
+        self.__name
+    }
+}
+
+/// Constructs a `ContextKey` from a given name.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use]
+/// extern crate exonum;
+/// use exonum::helpers::fabric::ContextKey;
+///
+/// const NAME: ContextKey<String> = context_key!("name");
+/// # fn main() {}
+/// ```
+#[macro_export]
+macro_rules! context_key {
+    ($name:expr) => {{
+        $crate::helpers::fabric::ContextKey {
+            __name: $name,
+            __phantom: ::std::marker::PhantomData
+        }
+    }}
+}
+
+#[test]
+fn key_is_copy() {
+    const K: ContextKey<Vec<String>> = context_key!("k");
+    let x = K;
+    let y = x;
+    assert_eq!(x.name(), y.name());
+}

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -28,12 +28,15 @@ use self::internal::NotFoundInMap;
 pub use self::builder::NodeBuilder;
 pub use self::details::{Run, Finalize, GenerateNodeConfig, GenerateCommonConfig, GenerateTestnet};
 pub use self::shared::{AbstractConfig, NodePublicConfig, CommonConfigTemplate, NodePrivateConfig};
+pub use self::context_key::ContextKey;
 
 mod shared;
 mod builder;
 mod details;
 mod internal;
 mod clap_backend;
+#[macro_use]
+mod context_key;
 
 /// Default port value.
 pub const DEFAULT_EXONUM_LISTEN_PORT: u16 = 6333;
@@ -110,8 +113,67 @@ impl Argument {
     }
 }
 
+/// Keys describing various pieces of data one can get from `Context`.
+pub mod keys {
+    use std::collections::BTreeMap;
+
+    use toml;
+
+    use node::NodeConfig;
+    use super::shared::{AbstractConfig, CommonConfigTemplate, NodePublicConfig};
+    use super::ContextKey;
+
+    /// Configuration for this node.
+    /// Set by `finalize` and `run` commands.
+    pub const NODE_CONFIG: ContextKey<NodeConfig> = context_key!("node_config");
+
+    /// Configurations for all nodes.
+    /// Set by `generate-testnet` command.
+    pub const CONFIGS: ContextKey<Vec<NodeConfig>> = context_key!("configs");
+
+    /// Services configuration.
+    /// Set by `generate-testnet` command.
+    pub const SERVICES_CONFIG: ContextKey<AbstractConfig> = context_key!("services_config");
+
+    /// Common configuration.
+    /// Set by `generate-config` and `finalize` commands.
+    pub const COMMON_CONFIG: ContextKey<CommonConfigTemplate> = context_key!("common_config");
+
+    /// Services public configuration.
+    /// Set by `generate-config` command.
+    pub const SERVICES_PUBLIC_CONFIGS: ContextKey<BTreeMap<String, toml::Value>> =
+        context_key!("services_public_configs");
+
+    /// Services secret configuration.
+    /// Set by `generate-config` command.
+    pub const SERVICES_SECRET_CONFIGS: ContextKey<BTreeMap<String, toml::Value>> =
+        context_key!("services_secret_configs");
+
+    /// Public configurations for all nodes.
+    /// Set by `finalize` command.
+    pub const PUBLIC_CONFIG_LIST: ContextKey<Vec<NodePublicConfig>> =
+        context_key!("public_config_list");
+
+    /// Auditor mode.
+    /// Set by `finalize` command.
+    pub const AUDITOR_MODE: ContextKey<bool> = context_key!("auditor_mode");
+}
+
+
 /// `Context` is a type, used to keep some values from `Command` into
 /// `CommandExtension` and vice verse.
+/// To access values stored inside Context, use `ContextKey`.
+///
+/// # Examples
+///
+/// ```
+/// use exonum::node::NodeConfig;
+/// use exonum::helpers::fabric::{keys, Context};
+///
+/// fn get_node_config(context: &Context) -> NodeConfig {
+///     context.get(keys::NODE_CONFIG).unwrap()
+/// }
+/// ```
 #[derive(PartialEq, Debug, Clone, Default)]
 pub struct Context {
     args: BTreeMap<String, String>,
@@ -183,12 +245,8 @@ impl Context {
     }
 
     /// Gets the variable from the context.
-    pub fn get<'de, T: Deserialize<'de>>(&self, key: &str) -> Result<T, Box<Error>> {
-        if let Some(v) = self.variables.get(key) {
-            Ok(v.clone().try_into()?)
-        } else {
-            Err(Box::new(NotFoundInMap))
-        }
+    pub fn get<'de, T: Deserialize<'de>>(&self, key: ContextKey<T>) -> Result<T, Box<Error>> {
+        self.get_raw(key.name())
     }
 
     /// Sets the variable in the context and returns the previous value.
@@ -196,7 +254,19 @@ impl Context {
     /// # Panic
     ///
     /// Panics if value could not be serialized as TOML.
-    pub fn set<T: Serialize>(&mut self, key: &'static str, value: T) -> Option<Value> {
+    pub fn set<T: Serialize>(&mut self, key: ContextKey<T>, value: T) -> Option<Value> {
+        self.set_raw(key.name(), value)
+    }
+
+    fn get_raw<'de, T: Deserialize<'de>>(&self, key: &str) -> Result<T, Box<Error>> {
+        if let Some(v) = self.variables.get(key) {
+            Ok(v.clone().try_into()?)
+        } else {
+            Err(Box::new(NotFoundInMap))
+        }
+    }
+
+    fn set_raw<T: Serialize>(&mut self, key: &str, value: T) -> Option<Value> {
         let value: Value = Value::try_from(value).expect("could not convert value into toml");
         self.variables.insert(key.to_owned(), value)
     }


### PR DESCRIPTION
So this was born out of https://github.com/exonum/exonum/pull/416#issuecomment-356197978.

The plan to add `Context::service_config` is not perfect, because context can very well lack `service_config` at all. I think what we really want here is something like this:

```Rust
pub trait ServiceFactory: 'static {
    #[allow(unused_variables)]
    fn command(&mut self, command: CommandName) -> Option<Box<CommandExtension>>;
    fn make_service(&mut self, run_context: &Context) -> Box<Service>;
}

pub trait ServiceFactoryWithConfig: ServiceFactory {
    type Config;
    fn make_service(&mut self, run_context: &Context, config: Self::Config) -> Box<Service>;
}
```

This is probably doable, and even in a nice way, despite the problem of object-safe associated types (which I believe is surmountable in a nice way by [this trick](https://github.com/exonum/exonum/pull/385#issuecomment-356329350)).

However, this PR in particular proposes a smaller and more localized fix: we actually can statically type all available `Context` keys. That is, we, instead of stringly-typed API, can provide users with a set of named constants, which allow to extract config values *of particular type*. 

This PR implements it only for `NodeConfig` and `AbstractConfig`, if this is something what we want, I'll convert all other string keys to this pattern.