### PR TITLE
Fix implement_exonum_serializer! to match ExonumJson

### DIFF
--- a/exonum/src/encoding/serialize/mod.rs
+++ b/exonum/src/encoding/serialize/mod.rs
@@ -59,7 +59,7 @@ macro_rules! implement_exonum_serializer {
 
             fn serialize_field(&self) ->
                 Result<$crate::encoding::serialize::json::reexport::Value,
-                        Box<::std::error::Error>>
+                        Box<::std::error::Error + Send + Sync>>
             {
                 use $crate::encoding::serialize::json::reexport::to_value;
                 Ok(to_value(self)?)


### PR DESCRIPTION
Here's the corresponding declaration: https://github.com/exonum/exonum/blob/e66158647b3c21919c2c5bc99d4388f1b77f7db4/exonum/src/encoding/serialize/json.rs#L69.

It's interesting that I've faced the bug when trying to upgrade btc-anchoring to new exonum.

Debugging this error from macro from macro from a patched crate was fun, but time consuming :) 

```
error[E0053]: method `serialize_field` has an incompatible type for trait
  --> src/details/btc/transactions.rs:97:1
   |
97 | implement_tx_wrapper! {FundingTx}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | expected trait `iron::Error + std::marker::Send + std::marker::Sync`, found trait `iron::Error`
   | in this macro invocation
   |
   = note: expected type `fn(&details::btc::transactions::FundingTx) -> std::result::Result<serde_json::Value, std::boxed::Box<iron::Error + std::marker::Send + std::marker::Sync + 'static>>`
              found type `fn(&details::btc::transactions::FundingTx) -> std::result::Result<serde_json::Value, std::boxed::Box<iron::Error + 'static>>`
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```
 
I think I'll write-up a short monorepo proposal :) 