### PR TITLE
Database trait simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `message!` and `encoding_struct!` no longer require manual `SIZE` and offset specification.
 - `from_raw(raw: RawMessage)` method is not part of the `Message` trait, and not an inherent method. (#427)
 - Log dependency was updated to 0.4, which can cause issues with previous versions. (#433)
+- The `Database` trait is simplified: it is not longer required to implement state-sharing `clone` method.
+  Instead, the `merge` method now takes a shared reference to `self`.
 
 ### Removed
 - Removed default `state_hash` implementation in the `Service` trait. (#399)

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -66,7 +66,7 @@ pub mod config;
 /// Only blockchains with the identical set of services and genesis block can be combined
 /// into the single network.
 pub struct Blockchain {
-    db: Box<Database>,
+    db: Arc<Database>,
     service_map: Arc<VecMap<Box<Service>>>,
     service_keypair: (PublicKey, SecretKey),
     api_sender: ApiSender,
@@ -94,7 +94,7 @@ impl Blockchain {
         }
 
         Blockchain {
-            db: storage,
+            db: storage.into(),
             service_map: Arc::new(service_map),
             service_keypair: (service_public_key, service_secret_key),
             api_sender,
@@ -463,7 +463,7 @@ impl fmt::Debug for Blockchain {
 impl Clone for Blockchain {
     fn clone(&self) -> Blockchain {
         Blockchain {
-            db: self.db.clone(),
+            db: Arc::clone(&self.db),
             service_map: Arc::clone(&self.service_map),
             api_sender: self.api_sender.clone(),
             service_keypair: self.service_keypair.clone(),

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -248,6 +248,9 @@ pub trait Database: Send + Sync + 'static {
 
     /// Atomically applies a sequence of patch changes to the database.
     ///
+    /// Note that this method may be called concurrently from different threads, the
+    /// onus to guarantee atomicity is on the implementor of the trait.
+    ///
     /// # Errors
     /// If this method encounters any form of I/O or other error during merging, an error variant
     /// will be returned. In case of an error the method guarantees no changes were applied to
@@ -255,6 +258,9 @@ pub trait Database: Send + Sync + 'static {
     fn merge(&self, patch: Patch) -> Result<()>;
 
     /// Atomically applies a sequence of patch changes to the database with fsync.
+    ///
+    /// Note that this method may be called concurrently from different threads, the
+    /// onus to guarantee atomicity is on the implementor of the trait.
     ///
     /// # Errors
     /// If this method encounters any form of I/O or other error during merging, an error variant

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -205,9 +205,7 @@ enum NextIterValue {
 
 /// A trait that defines a low-level storage backend.
 ///
-/// The trait `Database` requires to implement traits `Send` and `Sync` and should not be borrowed
-/// data, so you can use method [`clone`] to get the references to the database for concurrent
-/// usage.
+/// A `Database` instance is shared across different threads, so it must be `Sync` and `Send`.
 ///
 /// There is no way to directly interact with data in the database.
 ///
@@ -218,7 +216,8 @@ enum NextIterValue {
 /// If you need to make any changes to the data, you need to create a [`Fork`] using method
 /// [`fork`][2]. As well as `Snapshot`, `Fork` provides read isolation and also allows you to create
 /// a sequence of changes to the database that are specified as a [`Patch`]. Later you can
-/// atomically merge a patch into the database using method [`merge`].
+/// atomically merge a patch into the database using method [`merge`]. Note that different threads
+/// may call `merge` concurrently.
 ///
 /// [`clone`]: #tymethod.fork
 /// [`Snapshot`]: trait.Snapshot.html
@@ -228,9 +227,6 @@ enum NextIterValue {
 /// [`Patch`]: struct.Patch.html
 /// [`merge`]: #tymethod.merge
 pub trait Database: Send + Sync + 'static {
-    /// Creates a new reference to the database as `Box<Database>`.
-    fn clone(&self) -> Box<Database>;
-
     /// Creates a new snapshot of the database from its current state.
     ///
     /// See [`Snapshot`] documentation for more.

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -256,7 +256,7 @@ pub trait Database: Send + Sync + 'static {
     /// If this method encounters any form of I/O or other error during merging, an error variant
     /// will be returned. In case of an error the method guarantees no changes were applied to
     /// the database.
-    fn merge(&mut self, patch: Patch) -> Result<()>;
+    fn merge(&self, patch: Patch) -> Result<()>;
 
     /// Atomically applies a sequence of patch changes to the database with fsync.
     ///
@@ -264,7 +264,7 @@ pub trait Database: Send + Sync + 'static {
     /// If this method encounters any form of I/O or other error during merging, an error variant
     /// will be returned. In case of an error the method guarantees no changes were applied to
     /// the database.
-    fn merge_sync(&mut self, patch: Patch) -> Result<()>;
+    fn merge_sync(&self, patch: Patch) -> Result<()>;
 }
 
 /// A trait that defines a snapshot of storage backend.

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -46,10 +46,6 @@ impl MemoryDB {
 }
 
 impl Database for MemoryDB {
-    fn clone(&self) -> Box<Database> {
-        Box::new(Clone::clone(self))
-    }
-
     fn snapshot(&self) -> Box<Snapshot> {
         Box::new(MemoryDB {
             map: Arc::new(RwLock::new(self.map.read().unwrap().clone())),

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -56,7 +56,7 @@ impl Database for MemoryDB {
         })
     }
 
-    fn merge(&mut self, patch: Patch) -> Result<()> {
+    fn merge(&self, patch: Patch) -> Result<()> {
         for (cf_name, changes) in patch {
             let mut guard = self.map.write().unwrap();
             if !guard.contains_key(&cf_name) {
@@ -77,7 +77,7 @@ impl Database for MemoryDB {
         Ok(())
     }
 
-    fn merge_sync(&mut self, patch: Patch) -> Result<()> {
+    fn merge_sync(&self, patch: Patch) -> Result<()> {
         self.merge(patch)
     }
 }

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -14,7 +14,7 @@
 
 //! An implementation of `MemoryDB` database.
 
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use std::clone::Clone;
 use std::collections::btree_map::BTreeMap;
 use std::collections::HashMap;
@@ -27,9 +27,9 @@ type DB = HashMap<String, BTreeMap<Vec<u8>, Vec<u8>>>;
 /// Database implementation that stores all the data in memory.
 ///
 /// It's mainly used for testing and not designed to be efficient.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Debug)]
 pub struct MemoryDB {
-    map: Arc<RwLock<DB>>,
+    map: RwLock<DB>,
 }
 
 /// An iterator over the entries of a `MemoryDB`.
@@ -41,14 +41,14 @@ struct MemoryDBIter {
 impl MemoryDB {
     /// Creates a new, empty database.
     pub fn new() -> MemoryDB {
-        MemoryDB { map: Arc::new(RwLock::new(HashMap::new())) }
+        MemoryDB { map: RwLock::new(HashMap::new()) }
     }
 }
 
 impl Database for MemoryDB {
     fn snapshot(&self) -> Box<Snapshot> {
         Box::new(MemoryDB {
-            map: Arc::new(RwLock::new(self.map.read().unwrap().clone())),
+            map: RwLock::new(self.map.read().unwrap().clone()),
         })
     }
 
@@ -151,12 +151,6 @@ fn test_memorydb_snapshot() {
     }
 
     assert!(!snapshot.contains(idx_name, vec![2, 3, 4].as_slice()));
-
-    {
-        let db_clone = Clone::clone(&db);
-        let snap_clone = db_clone.snapshot();
-        assert!(snap_clone.contains(idx_name, vec![2, 3, 4].as_slice()));
-    }
 
     let snapshot = db.snapshot();
     assert!(snapshot.contains(idx_name, vec![2, 3, 4].as_slice()));

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -53,8 +53,8 @@ impl Database for MemoryDB {
     }
 
     fn merge(&self, patch: Patch) -> Result<()> {
+        let mut guard = self.map.write().unwrap();
         for (cf_name, changes) in patch {
-            let mut guard = self.map.write().unwrap();
             if !guard.contains_key(&cf_name) {
                 guard.insert(cf_name.clone(), BTreeMap::new());
             }

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -97,10 +97,6 @@ impl RocksDB {
 }
 
 impl Database for RocksDB {
-    fn clone(&self) -> Box<Database> {
-        Box::new(Clone::clone(self))
-    }
-
     fn snapshot(&self) -> Box<Snapshot> {
         let _p = ProfilerSpan::new("RocksDB::snapshot");
         Box::new(RocksDBSnapshot {

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -73,7 +73,7 @@ impl RocksDB {
         Ok(RocksDB { db: Arc::new(db) })
     }
 
-    fn merge(&mut self, patch: Patch, w_opts: &RocksDBWriteOptions) -> Result<()> {
+    fn do_merge(&self, patch: Patch, w_opts: &RocksDBWriteOptions) -> Result<()> {
         let _p = ProfilerSpan::new("RocksDB::merge");
         let mut batch = WriteBatch::default();
         for (cf_name, changes) in patch {
@@ -109,15 +109,15 @@ impl Database for RocksDB {
         })
     }
 
-    fn merge(&mut self, patch: Patch) -> Result<()> {
+    fn merge(&self, patch: Patch) -> Result<()> {
         let w_opts = RocksDBWriteOptions::default();
-        self.merge(patch, &w_opts)
+        self.do_merge(patch, &w_opts)
     }
 
-    fn merge_sync(&mut self, patch: Patch) -> Result<()> {
+    fn merge_sync(&self, patch: Patch) -> Result<()> {
         let mut w_opts = RocksDBWriteOptions::default();
         w_opts.set_sync(true);
-        self.merge(patch, &w_opts)
+        self.do_merge(patch, &w_opts)
     }
 }
 

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -41,7 +41,6 @@ impl From<_Error> for Error {
 }
 
 /// Database implementation on the top of `RocksDB` backend.
-#[derive(Clone)]
 pub struct RocksDB {
     db: Arc<_RocksDB>,
 }

--- a/sandbox/examples/merkle_map.rs
+++ b/sandbox/examples/merkle_map.rs
@@ -84,7 +84,7 @@ fn main() {
         (k, v)
     };
 
-    let mut db = create_database(path);
+    let db = create_database(path);
 
     let patch;
     {


### PR DESCRIPTION
This is just a refactoring to make `Databases` trait easier to implement correctly, and to make a bug, which was almost introduced in #421, impossible. 

* Remove `clone` method from the `Database` trait.
* Store `Arc<Database>` instead of `Box<Database>` in `Blockchain` (this also should make cloning the blockchain faster, because it removes an allocation).
* Change `merge` signature from `&mut self` to `&self` which is semantically more clear.