### PR TITLE
Run dev mode

### DIFF
--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -23,7 +23,8 @@ use node::Node;
 use super::internal::{CollectedCommand, Feedback};
 use super::clap_backend::ClapBackend;
 use super::ServiceFactory;
-use super::details::{Run, Finalize, GenerateNodeConfig, GenerateCommonConfig, GenerateTestnet};
+use super::details::{Run, RunDev, Finalize, GenerateNodeConfig, GenerateCommonConfig,
+                     GenerateTestnet};
 use super::keys;
 use super::CommandName;
 
@@ -117,6 +118,7 @@ impl NodeBuilder {
             CollectedCommand::new(Box::new(GenerateTestnet)),
         );
         commands.insert(Run::name(), CollectedCommand::new(Box::new(Run)));
+        commands.insert(RunDev::name(), CollectedCommand::new(Box::new(RunDev)));
         commands.insert(
             GenerateNodeConfig::name(),
             CollectedCommand::new(Box::new(GenerateNodeConfig)),

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 use std::panic::{self, PanicInfo};
 use std::ffi::OsString;
+use std::collections::HashMap;
 
 use blockchain::Service;
 use node::Node;
@@ -24,12 +25,13 @@ use super::clap_backend::ClapBackend;
 use super::ServiceFactory;
 use super::details::{Run, Finalize, GenerateNodeConfig, GenerateCommonConfig, GenerateTestnet};
 use super::keys;
+use super::CommandName;
 
 /// `NodeBuilder` is a high level object,
 /// usable for fast prototyping and creating app from services list.
 #[derive(Default)]
 pub struct NodeBuilder {
-    commands: Vec<CollectedCommand>,
+    commands: HashMap<CommandName, CollectedCommand>,
     service_factories: Vec<Box<ServiceFactory>>,
 }
 
@@ -37,13 +39,7 @@ impl NodeBuilder {
     /// Creates a new empty `NodeBuilder`.
     pub fn new() -> Self {
         NodeBuilder {
-            commands: vec![
-                CollectedCommand::new(Box::new(GenerateTestnet)),
-                CollectedCommand::new(Box::new(Run)),
-                CollectedCommand::new(Box::new(GenerateNodeConfig)),
-                CollectedCommand::new(Box::new(GenerateCommonConfig)),
-                CollectedCommand::new(Box::new(Finalize)),
-            ],
+            commands: Self::commands(),
             service_factories: Vec::new(),
         }
     }
@@ -52,8 +48,7 @@ impl NodeBuilder {
     pub fn with_service(mut self, mut factory: Box<ServiceFactory>) -> NodeBuilder {
         //TODO: take endpoints, etc... (ECR-164)
 
-        for command in &mut self.commands {
-            let name = command.name();
+        for (name, command) in &mut self.commands {
             command.extend(factory.command(name))
         }
         self.service_factories.push(factory);
@@ -66,12 +61,13 @@ impl NodeBuilder {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        ClapBackend::execute_cmd_string(self.commands.as_slice(), cmd_line) != Feedback::None
+        let feedback = ClapBackend::execute_cmd_string(&self.commands, cmd_line);
+        feedback != Feedback::None
     }
 
     /// Parse cmd args, return `Node`, if run command found
     pub fn parse_cmd(self) -> Option<Node> {
-        match ClapBackend::execute(self.commands.as_slice()) {
+        match ClapBackend::execute(&self.commands) {
             Feedback::RunNode(ref ctx) => {
                 let db = Run::db_helper(ctx);
                 let config = ctx.get(keys::NODE_CONFIG).expect(
@@ -112,7 +108,25 @@ impl NodeBuilder {
         if let Some(node) = feedback {
             node.run().expect("Node return error")
         }
+    }
 
+    fn commands() -> HashMap<CommandName, CollectedCommand> {
+        let mut commands = HashMap::new();
+        commands.insert(
+            GenerateTestnet::name(),
+            CollectedCommand::new(Box::new(GenerateTestnet)),
+        );
+        commands.insert(Run::name(), CollectedCommand::new(Box::new(Run)));
+        commands.insert(
+            GenerateNodeConfig::name(),
+            CollectedCommand::new(Box::new(GenerateNodeConfig)),
+        );
+        commands.insert(
+            GenerateCommonConfig::name(),
+            CollectedCommand::new(Box::new(GenerateCommonConfig)),
+        );
+        commands.insert(Finalize::name(), CollectedCommand::new(Box::new(Finalize)));
+        commands
     }
 }
 
@@ -121,7 +135,7 @@ impl fmt::Debug for NodeBuilder {
         write!(
             f,
             "NodeBuilder {{ commands: {:?}, services_count: {} }}",
-            self.commands,
+            self.commands.values(),
             self.service_factories.len()
         )
     }

--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -80,14 +80,18 @@ impl ClapBackend {
     }
 
     fn command_into_subcommand(command: &CollectedCommand) -> clap::App {
+        let mut index = 1;
         let command_args: Vec<_> = command
             .args()
             .iter()
-            .zip(1..)
-            .map(|(arg, index)| {
+            .map(|arg| {
                 let clap_arg = clap::Arg::with_name(arg.name);
                 let clap_arg = match arg.argument_type {
-                    ArgumentType::Positional => clap_arg.index(index),
+                    ArgumentType::Positional => {
+                        let arg = clap_arg.index(index);
+                        index += 1;
+                        arg
+                    }
                     ArgumentType::Named(detail) => {
                         let mut clap_arg = clap_arg.long(detail.long_name);
                         if let Some(short) = detail.short_name {

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -19,7 +19,7 @@
 use std::fs;
 use std::path::Path;
 use std::net::SocketAddr;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use toml::Value;
 
@@ -27,13 +27,13 @@ use blockchain::GenesisConfig;
 use blockchain::config::ValidatorKeys;
 use helpers::generate_testnet_config;
 use helpers::config::ConfigFile;
-use node::{NodeConfig, NodeApiConfig};
+use node::{NodeApiConfig, NodeConfig};
 use storage::Database;
 use crypto;
-use super::internal::{Command, Feedback};
-use super::{Argument, Context, CommandName};
-use super::shared::{AbstractConfig, NodePublicConfig, SharedConfig, NodePrivateConfig,
-                    CommonConfigTemplate};
+use super::internal::{CollectedCommand, Command, Feedback};
+use super::{Argument, CommandName, Context};
+use super::shared::{AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig,
+                    SharedConfig};
 use super::DEFAULT_EXONUM_LISTEN_PORT;
 use super::keys;
 
@@ -123,7 +123,12 @@ impl Command for Run {
         "Run application"
     }
 
-    fn execute(&self, mut context: Context, exts: &Fn(Context) -> Context) -> Feedback {
+    fn execute(
+        &self,
+        _commands: &HashMap<CommandName, CollectedCommand>,
+        mut context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback {
         let config = Self::node_config(&context);
         let public_addr = Self::public_api_address(&context);
         let private_addr = Self::private_api_address(&context);
@@ -171,7 +176,12 @@ impl Command for GenerateCommonConfig {
         "Generate basic config template."
     }
 
-    fn execute(&self, mut context: Context, exts: &Fn(Context) -> Context) -> Feedback {
+    fn execute(
+        &self,
+        _commands: &HashMap<CommandName, CollectedCommand>,
+        mut context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback {
         let template_path = context.arg::<String>("COMMON_CONFIG").expect(
             "COMMON_CONFIG not found",
         );
@@ -241,7 +251,12 @@ impl Command for GenerateNodeConfig {
         "Generate node secret and public configs."
     }
 
-    fn execute(&self, mut context: Context, exts: &Fn(Context) -> Context) -> Feedback {
+    fn execute(
+        &self,
+        _commands: &HashMap<CommandName, CollectedCommand>,
+        mut context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback {
         let common_config_path = context.arg::<String>("COMMON_CONFIG").expect(
             "expected common config path",
         );
@@ -348,7 +363,6 @@ impl Finalize {
             {
                 panic!("Found duplicate consenus keys in PUBLIC_CONFIGS");
             }
-
         }
         (
             common,
@@ -398,7 +412,12 @@ impl Command for Finalize {
         "Collect public and secret configs into node config."
     }
 
-    fn execute(&self, mut context: Context, exts: &Fn(Context) -> Context) -> Feedback {
+    fn execute(
+        &self,
+        _commands: &HashMap<CommandName, CollectedCommand>,
+        mut context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback {
         let public_configs_path = context.arg_multiple::<String>("PUBLIC_CONFIGS").expect(
             "keychain path not found",
         );
@@ -510,8 +529,12 @@ impl Command for GenerateTestnet {
         "Generates genesis configuration for testnet"
     }
 
-    fn execute(&self, mut context: Context, exts: &Fn(Context) -> Context) -> Feedback {
-
+    fn execute(
+        &self,
+        _commands: &HashMap<CommandName, CollectedCommand>,
+        mut context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback {
         let dir = context.arg::<String>("OUTPUT_DIR").expect("output dir");
         let count: u8 = context.arg("COUNT").expect("count as int");
         let start_port = context.arg::<u16>("START_PORT").unwrap_or(

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -163,16 +163,16 @@ impl RunDev {
     }
 
     fn artifacts_directory(ctx: &Context) -> PathBuf {
-        let directory = ctx.arg::<String>("ARTIFACTS_DIR").unwrap_or_else(|_| {
-            String::from(".exonum")
-        });
+        let directory = ctx.arg::<String>("ARTIFACTS_DIR").unwrap_or_else(
+            |_| ".exonum".into(),
+        );
         PathBuf::from(&directory)
     }
 
     fn artifacts_path(inner_path: &str, ctx: &Context) -> String {
         let mut path = Self::artifacts_directory(ctx);
         path.push(inner_path);
-        String::from(path.to_str().expect("Expected correct path"))
+        path.to_str().expect("Expected correct path").into()
     }
 
     fn generate_config(commands: &HashMap<CommandName, CollectedCommand>, ctx: &Context) -> String {
@@ -193,7 +193,7 @@ impl RunDev {
         node_config_ctx.set_arg("COMMON_CONFIG", common_config_path.clone());
         node_config_ctx.set_arg("PUB_CONFIG", pub_config_path.clone());
         node_config_ctx.set_arg("SEC_CONFIG", sec_config_path.clone());
-        node_config_ctx.set_arg("PEER_ADDR", String::from(peer_addr));
+        node_config_ctx.set_arg("PEER_ADDR", peer_addr.into());
         let node_config_command = commands.get(GenerateNodeConfig::name()).expect(
             "Expected GenerateNodeConfig in the commands list.",
         );
@@ -260,7 +260,6 @@ impl Command for RunDev {
         context.set_arg("NODE_CONFIG_PATH", node_config_path);
 
         let new_context = exts(context);
-        // TODO: clean up artifacts directory.
         commands
             .get(Run::name())
             .expect("Expected Run in the commands list.")

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -210,6 +210,18 @@ impl RunDev {
 
         output_config_path
     }
+
+    fn cleanup(ctx: &Context) {
+        let database_dir_path = ctx.arg::<String>(DATABASE_PATH).expect(
+            "Expected DATABASE_PATH being set.",
+        );
+        let database_dir = Path::new(&database_dir_path);
+        if database_dir.exists() {
+            fs::remove_dir_all(Self::artifacts_directory(ctx)).expect(
+                "Expected DATABASE_PATH folder being removable.",
+            );
+        }
+    }
 }
 
 impl Command for RunDev {
@@ -240,10 +252,13 @@ impl Command for RunDev {
         mut context: Context,
         exts: &Fn(Context) -> Context,
     ) -> Feedback {
-        let node_config_path = Self::generate_config(commands, &context);
         let db_path = Self::artifacts_path("db", &context);
-        context.set_arg("NODE_CONFIG_PATH", node_config_path);
         context.set_arg(DATABASE_PATH, db_path);
+        Self::cleanup(&context);
+
+        let node_config_path = Self::generate_config(commands, &context);
+        context.set_arg("NODE_CONFIG_PATH", node_config_path);
+
         let new_context = exts(context);
         // TODO: clean up artifacts directory.
         commands

--- a/exonum/src/helpers/fabric/internal.rs
+++ b/exonum/src/helpers/fabric/internal.rs
@@ -14,8 +14,9 @@
 
 use std::fmt;
 use std::error::Error;
+use std::collections::HashMap;
 
-use super::{Context, CommandName, Argument, CommandExtension};
+use super::{Argument, CommandExtension, CommandName, Context};
 
 /// Used to take some additional information from executed command
 #[derive(Debug, PartialEq, Clone)]
@@ -45,7 +46,12 @@ pub trait Command {
     fn args(&self) -> Vec<Argument>;
     fn name(&self) -> CommandName;
     fn about(&self) -> &str;
-    fn execute(&self, context: Context, extension: &Fn(Context) -> Context) -> Feedback;
+    fn execute(
+        &self,
+        commands: &HashMap<CommandName, CollectedCommand>,
+        context: Context,
+        exts: &Fn(Context) -> Context,
+    ) -> Feedback;
 }
 
 /// We keep command internal state into `CollectedCommand`
@@ -89,8 +95,12 @@ impl CollectedCommand {
         }
     }
 
-    pub fn execute(&self, context: Context) -> Feedback {
-        self.command.execute(context, &|context| {
+    pub fn execute(
+        &self,
+        commands: &HashMap<CommandName, CollectedCommand>,
+        context: Context,
+    ) -> Feedback {
+        self.command.execute(commands, context, &|context| {
             // TODO: check duplicates, in services context keys (ECR-164)
             let mut new_context = context.clone();
             for ext in &self.exts {

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -232,6 +232,11 @@ impl Context {
         }
     }
 
+    /// Inserts value to the command line arguments map.
+    pub fn set_arg(&mut self, key: &str, value: String) {
+        self.args.insert(String::from(key), value);
+    }
+
     /// Gets multiple values of the command line argument.
     pub fn arg_multiple<T: FromStr>(&self, key: &str) -> Result<Vec<T>, Box<Error>>
     where
@@ -242,6 +247,11 @@ impl Context {
         } else {
             Err(Box::new(NotFoundInMap))
         }
+    }
+
+    /// Inserts multiple values to the command line arguments map.
+    pub fn set_arg_multiple(&mut self, key: &str, values: Vec<String>) {
+        self.multiple_args.insert(String::from(key), values);
     }
 
     /// Gets the variable from the context.

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -234,7 +234,7 @@ impl Context {
 
     /// Inserts value to the command line arguments map.
     pub fn set_arg(&mut self, key: &str, value: String) {
-        self.args.insert(String::from(key), value);
+        self.args.insert(key.into(), value);
     }
 
     /// Gets multiple values of the command line argument.
@@ -251,7 +251,7 @@ impl Context {
 
     /// Inserts multiple values to the command line arguments map.
     pub fn set_arg_multiple(&mut self, key: &str, values: Vec<String>) {
-        self.multiple_args.insert(String::from(key), values);
+        self.multiple_args.insert(key.into(), values);
     }
 
     /// Gets the variable from the context.

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -216,17 +216,21 @@ fn test_run_dev() {
     let db_dir = format!("{}/{}", artifacts_dir, "db");
     let full_db_dir = full_tmp_folder(&db_dir);
 
+    // Mock existence of old DB files that are supposed to be cleaned up.
     fs::create_dir_all(Path::new(&full_db_dir)).expect("Expected db temp folder to be created.");
     let old_db_file = full_tmp_name("1", &db_dir);
     touch(&old_db_file);
 
-    let result = panic::catch_unwind(|| { run_dev(artifacts_dir); });
+    let result = panic::catch_unwind(|| {
+        run_dev(artifacts_dir);
+
+        // Test cleaning up.
+        assert!(!Path::new(&old_db_file).exists());
+    });
+
+    fs::remove_dir_all(full_tmp_folder(artifacts_dir)).unwrap();
 
     if let Err(err) = result {
         panic::resume_unwind(err);
     }
-
-    // Test cleaning up.
-    assert!(!Path::new(&old_db_file).exists());
-    fs::remove_dir_all(full_tmp_folder(artifacts_dir)).unwrap();
 }


### PR DESCRIPTION
### Description

Implements `run-dev` mode for running node without configuring.

### What kind of change does this PR introduce?

- `run-dev` command is added

- `commands` vector of `NodeBuilder` is refactored to `HashMap` (maybe `BTreeMap` would be better?)

- command `execute` function now accepts the list of the commands (the aforementioned `HashMap`) in order to execute other subcommands for generating configs. I don't like this solution, it was the first straightforward way that came to my mind

- `Context` args setters were added. That's rather a crutch than a cool solution. (The problem is that the commands called inside `RunDev` depend on these args.) 

### Checklist:
- [x] Implement a working prototype of `run-dev` command
- [x] Cleanup artifacts folder
- [x] Add tests

### How can we test these changes?

Using `run-dev` command