### PR TITLE
Experimental: automatically generate `/transactions` endpoint

### DIFF
--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "exonum/exonum" }
 [dependencies]
 log = "0.3.8"
 byteorder = "1.1.0"
+bodyparser = "0.8.0"
 hex = "0.3.0"
 bit-vec = "0.4.4"
 vec_map = "0.8.0"

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -51,7 +51,7 @@ pub use self::block::{Block, BlockProof, SCHEMA_MAJOR_VERSION};
 pub use self::schema::{gen_prefix, Schema, TxLocation};
 pub use self::genesis::GenesisConfig;
 pub use self::config::{ConsensusConfig, StoredConfiguration, TimeoutAdjusterConfig, ValidatorKeys};
-pub use self::service::{ApiContext, Service, ServiceContext, SharedNodeState, Transaction, Srv, TransactionSet, TransactionResponse};
+pub use self::service::{ApiContext, Service, ServiceContext, SharedNodeState, Transaction, TransactionService, TransactionSet, TransactionResponse, ObserverService};
 
 mod block;
 mod schema;

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -51,11 +51,12 @@ pub use self::block::{Block, BlockProof, SCHEMA_MAJOR_VERSION};
 pub use self::schema::{gen_prefix, Schema, TxLocation};
 pub use self::genesis::GenesisConfig;
 pub use self::config::{ConsensusConfig, StoredConfiguration, TimeoutAdjusterConfig, ValidatorKeys};
-pub use self::service::{ApiContext, Service, ServiceContext, SharedNodeState, Transaction};
+pub use self::service::{ApiContext, Service, ServiceContext, SharedNodeState, Transaction, Srv, TransactionSet, TransactionResponse};
 
 mod block;
 mod schema;
 mod genesis;
+#[macro_use]
 mod service;
 #[cfg(test)]
 mod tests;

--- a/exonum/src/blockchain/service/mod.rs
+++ b/exonum/src/blockchain/service/mod.rs
@@ -32,6 +32,8 @@ use node::{ApiSender, Node, State, TransactionSend};
 use blockchain::{Blockchain, ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys};
 use helpers::{Height, Milliseconds, ValidatorId};
 
+mod srv;
+
 /// A trait that describes transaction processing rules (a group of sequential operations
 /// with the Exonum storage) for the given `Message`.
 pub trait Transaction: Message + ExonumJson + 'static {

--- a/exonum/src/blockchain/service/mod.rs
+++ b/exonum/src/blockchain/service/mod.rs
@@ -32,7 +32,9 @@ use node::{ApiSender, Node, State, TransactionSend};
 use blockchain::{Blockchain, ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys};
 use helpers::{Height, Milliseconds, ValidatorId};
 
+#[macro_use]
 mod srv;
+pub use self::srv::{Srv, TransactionSet, TransactionResponse};
 
 /// A trait that describes transaction processing rules (a group of sequential operations
 /// with the Exonum storage) for the given `Message`.

--- a/exonum/src/blockchain/service/mod.rs
+++ b/exonum/src/blockchain/service/mod.rs
@@ -34,7 +34,7 @@ use helpers::{Height, Milliseconds, ValidatorId};
 
 #[macro_use]
 mod srv;
-pub use self::srv::{Srv, TransactionSet, TransactionResponse};
+pub use self::srv::{TransactionService, TransactionSet, TransactionResponse, ObserverService};
 
 /// A trait that describes transaction processing rules (a group of sequential operations
 /// with the Exonum storage) for the given `Message`.

--- a/exonum/src/blockchain/service/srv.rs
+++ b/exonum/src/blockchain/service/srv.rs
@@ -1,0 +1,96 @@
+use serde_json::Value;
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+
+use iron::Handler;
+
+use storage::{Fork, Snapshot};
+use messages::{Message, RawTransaction};
+use encoding::Error as MessageError;
+use crypto::Hash;
+
+use super::{Transaction, ServiceContext, ApiContext, Service};
+
+
+trait TransactionSet: DeserializeOwned {
+    fn tx_from_raw(raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;
+}
+
+enum NoTransactions {
+}
+
+impl TransactionSet for NoTransactions {
+    fn tx_from_raw(raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+        unimplemented!()
+    }
+}
+
+impl<'de> Deserialize<'de> for NoTransactions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where
+        D: Deserializer<'de> {
+        unimplemented!()
+    }
+}
+
+trait Srv: Send + Sync + 'static {
+    type Transactions: TransactionSet;
+    const ID: u16;
+    const NAME: &'static str;
+
+    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash>;
+
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;
+
+    fn initialize(&self, fork: &mut Fork) -> Value {
+        Value::Null
+    }
+
+    fn handle_commit(&self, context: &ServiceContext) {}
+
+    fn public_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
+        None
+    }
+
+    fn private_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
+        None
+    }
+
+    fn into_service(self) -> Box<Service> where Self: Sized {
+        Box::new(SrvService(self))
+    }
+}
+
+struct SrvService<S>(S);
+
+impl<S: Srv> Service for SrvService<S> {
+    fn service_id(&self) -> u16 {
+        S::ID
+    }
+
+    fn service_name(&self) -> &'static str {
+        S::NAME
+    }
+
+    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash> {
+        self.0.state_hash(snapshot)
+    }
+
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+        S::Transactions::tx_from_raw(raw)
+    }
+
+    fn initialize(&self, fork: &mut Fork) -> Value {
+        self.0.initialize(fork)
+    }
+
+    fn handle_commit(&self, context: &ServiceContext) {
+        self.0.handle_commit(context)
+    }
+
+    fn public_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
+        self.0.public_api_handler(context)
+    }
+
+    fn private_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
+        self.0.private_api_handler(context)
+    }
+}

--- a/exonum/src/blockchain/service/srv.rs
+++ b/exonum/src/blockchain/service/srv.rs
@@ -1,63 +1,108 @@
+extern crate core;
+
 use serde_json::Value;
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};
 
+use iron::prelude::*;
 use iron::Handler;
+use bodyparser;
+use router::Router;
+
+use serde_json;
 
 use storage::{Fork, Snapshot};
-use messages::{Message, RawTransaction};
+use messages::RawTransaction;
 use encoding::Error as MessageError;
 use crypto::Hash;
+use api::{ApiError, Api};
+use node::{TransactionSend, ApiSender};
+
 
 use super::{Transaction, ServiceContext, ApiContext, Service};
+use std::marker::PhantomData;
 
-
-trait TransactionSet: DeserializeOwned {
+/// TODO
+pub trait TransactionSet: DeserializeOwned + Into<Box<Transaction>> + Clone {
+    /// TODO
     fn tx_from_raw(raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;
 }
 
-enum NoTransactions {
-}
+#[macro_export]
+macro_rules! transaction_set {
+    ( $name:ident { $($tx:ident),* } ) => {
+        #[derive(Deserialize, Clone)]
+        #[serde(untagged)] // :(
+        pub enum $name {
+            $($tx($tx),)*
+        }
 
-impl TransactionSet for NoTransactions {
-    fn tx_from_raw(raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
-        unimplemented!()
+        impl $crate::blockchain::TransactionSet for $name {
+            fn tx_from_raw(raw: RawTransaction) -> Result<Box<$crate::blockchain::Transaction>, $crate::encoding::Error> {
+                let message_type = raw.message_type();
+                $(
+                    if $tx::message_id() == message_type {
+                        return Ok(Box::new($tx::from_raw(raw)?));
+                    }
+                )*
+
+                return Err($crate::encoding::Error::IncorrectMessageType { message_type })
+            }
+        }
+
+        impl Into<Box<Transaction>> for $name {
+            fn into(self) -> Box<Transaction> {
+                match self {$(
+                   $name::$tx(tx) => Box::new(tx),
+                )*}
+            }
+        }
     }
 }
 
-impl<'de> Deserialize<'de> for NoTransactions {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where
-        D: Deserializer<'de> {
-        unimplemented!()
-    }
+/// The structure returned by the REST API.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TransactionResponse {
+    /// TODO
+    pub tx_hash: Hash,
 }
 
-trait Srv: Send + Sync + 'static {
+
+/// TODO
+pub trait Srv: Send + Sync + 'static {
+    /// TODO
     type Transactions: TransactionSet;
+    // = NoTransactions
+    /// TODO
     const ID: u16;
+    /// TODO
     const NAME: &'static str;
 
+    /// TODOk
     fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash>;
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;
-
-    fn initialize(&self, fork: &mut Fork) -> Value {
+    /// TODO
+    fn initialize(&self, _fork: &mut Fork) -> Value {
         Value::Null
     }
 
-    fn handle_commit(&self, context: &ServiceContext) {}
+    /// TODO
+    fn handle_commit(&self, _context: &ServiceContext) {}
 
-    fn public_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
-        None
+    /// TODO
+    fn wire_public_api(&self, router: &mut Router, ctx: &ApiContext) {
     }
 
-    fn private_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
-        None
+    /// TODO
+    fn wire_private_api(&self, router: &mut Router, ctx: &ApiContext) {
     }
 
+    /// TODO
     fn into_service(self) -> Box<Service> where Self: Sized {
         Box::new(SrvService(self))
     }
 }
+
+
 
 struct SrvService<S>(S);
 
@@ -87,10 +132,53 @@ impl<S: Srv> Service for SrvService<S> {
     }
 
     fn public_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
-        self.0.public_api_handler(context)
+        let api = SrvApi::<S> {
+            srv: PhantomData,
+            api_sender: context.node_channel().clone()
+        };
+        let mut router = Router::new();
+        api.wire(&mut router);
+        self.0.wire_public_api(&mut router, context);
+        Some(Box::new(router))
     }
 
     fn private_api_handler(&self, context: &ApiContext) -> Option<Box<Handler>> {
-        self.0.private_api_handler(context)
+        let mut router = Router::new();
+        self.0.wire_private_api(&mut router, context);
+        Some(Box::new(router))
+    }
+}
+
+struct SrvApi<S> {
+    srv: PhantomData<S>,
+    api_sender: ApiSender,
+}
+
+impl<S> Clone for SrvApi<S> {
+    fn clone(&self) -> Self {
+        SrvApi { srv: PhantomData, api_sender: self.api_sender.clone() }
+    }
+}
+
+impl<S: Srv> Api for SrvApi<S> {
+    fn wire<'b>(&self, router: &'b mut Router) {
+        let self_ = self.clone(); // TODO: whyyyy do we need this?
+        router.post(
+            "/transactions",
+            move |req: &mut Request| -> IronResult<Response> {
+                match req.get::<bodyparser::Struct<S::Transactions>>() {
+                    Ok(None) => Err(ApiError::IncorrectRequest("Empty request body".into()))?,
+                    Err(e) => Err(ApiError::IncorrectRequest(Box::new(e)))?,
+                    Ok(Some(transaction)) => {
+                        let transaction: Box<Transaction> = transaction.into();
+                        let tx_hash = transaction.hash();
+                        self_.api_sender.send(transaction).map_err(ApiError::from)?;
+                        let json = TransactionResponse { tx_hash };
+                        self_.ok_response(&serde_json::to_value(&json).unwrap())
+                    }
+                }
+            },
+            "transaction",
+        );
     }
 }

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -51,6 +51,7 @@ extern crate clap;
 extern crate hyper;
 extern crate iron;
 extern crate iron_cors;
+extern crate bodyparser;
 extern crate router;
 extern crate params;
 extern crate cookie;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -49,9 +49,9 @@ extern crate term;
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
 extern crate hyper;
-extern crate iron;
+pub extern crate iron;
 extern crate iron_cors;
-extern crate bodyparser;
+pub extern crate bodyparser;
 extern crate router;
 extern crate params;
 extern crate cookie;


### PR DESCRIPTION
This is **an experimental** PR to fix ECR-294 (getting rid of [boilerplate](https://github.com/exonum/cryptocurrency/blob/7ddba70423be5f7272d5ca9c13963301bedf7acd/src/lib.rs#L250-L265) required to define a service accepting transactions). I'd like to gauge consensus about the general approach before embarking onto the production-quality implementation. 

Problem: when defining a service, there are two pieces of boilerplate

*  deserializing transaction from an http request.
* deserializing transaction from a raw message (and we have a real bug in this boilerplate in one of our services).

The proposed solution is to allow a service to declare a set of transactions it accepts, and then automatically implement `tx_from_raw` method of service and a single `/transactions` HTTP endpoint for POSTing all trasactions. The endpoint thing is open for a debate: it can be argued that `/transactions` is not RESTfull and is more akin to RPC (on the other way, transactions are nouns in REST sense, and `GET /transactions/{tx_hash}` might be useful). 

However, to associated several types of transactions with a type of a service, we need to solve "Trait Objects with associated types" problem, so this PR proposes an approach to this as well.

Here are the major moving parts:

* `TransactionSet` trait and `transaction_set!` macro allows to create a type-level set of trasactions. They abstract away [this pattern](https://github.com/exonum/exonum-testkit/blob/73cb36995f0dc2117291dd5e441d0688383daedc/tests/currency/cryptocurrency.rs#L200-L203)

* The definition of `Service` is not changed, but it's purpose is a bit different now: it is a **low-level** object (in a dynamic-dispatch sense) that is used by the exonum core. While service implementors *could* implement `Service` directly for maximum control and flexibility, it is advisable to implement a higher level trait.

* `TransactionService` is such trait: it uses fancy associated types and constants to simplify the definition of the service, and it can be converted to `Box<Service>`.

* `ObserverService` is another flavor of such trait: it's a simple service *without* transactions. I included only to make sure that it is possible to provide different *base traits* for service authors. Note that `TransactionService` and `ObsercerService` don't have any supertraits, and are only loosely coupled to `Services`, and can co-evolve independently. 

