### PR TITLE
Remove 'allow(zero_prefixed_literal)' attribute

### DIFF
--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -16,10 +16,7 @@
 //!
 //! For more information see the project readme.
 
-#![deny(missing_debug_implementations)]
-#![deny(missing_docs)]
-
-#![cfg_attr(feature="cargo-clippy", allow(zero_prefixed_literal))]
+#![deny(missing_debug_implementations, missing_docs)]
 
 #![cfg_attr(feature="flame_profile", feature(plugin, custom_attribute))]
 #![cfg_attr(feature="flame_profile", plugin(exonum_flamer))]

--- a/exonum/src/storage/proof_map_index/key.rs
+++ b/exonum/src/storage/proof_map_index/key.rs
@@ -17,8 +17,8 @@ use std::cmp::min;
 use crypto::{Hash, PublicKey, HASH_SIZE};
 use super::super::StorageKey;
 
-pub const BRANCH_KEY_PREFIX: u8 = 00;
-pub const LEAF_KEY_PREFIX: u8 = 01;
+pub const BRANCH_KEY_PREFIX: u8 = 0;
+pub const LEAF_KEY_PREFIX: u8 = 1;
 
 /// Size in bytes of the `ProofMapKey`.
 pub const KEY_SIZE: usize = HASH_SIZE;


### PR DESCRIPTION
Field offsets [are now calculating automatically](https://github.com/exonum/exonum/pull/413), so we (probably) don't need to allow zero prefixed literals.