### PR TITLE
Make MAX_MESSAGE_LEN configurable

### DIFF
--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -68,6 +68,11 @@ pub struct ConsensusConfig {
     pub timeout_adjuster: TimeoutAdjusterConfig,
 }
 
+impl ConsensusConfig {
+    /// Default value for max_message_len.
+    pub const DEFAULT_MESSAGE_MAX_LEN: u32 = 1024 * 1024; // 1 MB
+}
+
 impl Default for ConsensusConfig {
     fn default() -> Self {
         ConsensusConfig {
@@ -75,7 +80,7 @@ impl Default for ConsensusConfig {
             status_timeout: 5000,
             peers_timeout: 10_000,
             txs_block_limit: 1000,
-            max_message_len: 1024 * 1024, // 1 MB
+            max_message_len: Self::DEFAULT_MESSAGE_MAX_LEN,
             timeout_adjuster: TimeoutAdjusterConfig::Constant { timeout: 500 },
         }
     }

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -62,6 +62,8 @@ pub struct ConsensusConfig {
     pub peers_timeout: Milliseconds,
     /// Maximum number of transactions per block.
     pub txs_block_limit: u32,
+    /// Maximum message length (in bytes).
+    pub max_message_len: usize,
     /// `TimeoutAdjuster` configuration.
     pub timeout_adjuster: TimeoutAdjusterConfig,
 }
@@ -73,6 +75,7 @@ impl Default for ConsensusConfig {
             status_timeout: 5000,
             peers_timeout: 10_000,
             txs_block_limit: 1000,
+            max_message_len: 1024 * 1024, // 1 MB
             timeout_adjuster: TimeoutAdjusterConfig::Constant { timeout: 500 },
         }
     }

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -63,7 +63,7 @@ pub struct ConsensusConfig {
     /// Maximum number of transactions per block.
     pub txs_block_limit: u32,
     /// Maximum message length (in bytes).
-    pub max_message_len: usize,
+    pub max_message_len: u32,
     /// `TimeoutAdjuster` configuration.
     pub timeout_adjuster: TimeoutAdjusterConfig,
 }

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -24,7 +24,13 @@ use super::error::other_error;
 #[derive(Debug)]
 pub struct MessagesCodec {
     /// Maximum message length (in bytes), gets populated from `NetworkConfiguration`.
-    pub max_message_len: usize,
+    max_message_len: usize,
+}
+
+impl MessagesCodec {
+    pub fn new(max_message_len: usize) -> MessagesCodec {
+        MessagesCodec { max_message_len }
+    }
 }
 
 impl Decoder for MessagesCodec {

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -23,7 +23,7 @@ use super::error::other_error;
 
 #[derive(Debug)]
 pub struct MessagesCodec {
-    /// Maximum message length (in bytes), gets populated from `NetworkConfiguration`.
+    /// Maximum message length (in bytes), gets populated from `ConsensusConfig`.
     max_message_len: u32,
 }
 

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -21,10 +21,11 @@ use tokio_io::codec::{Decoder, Encoder};
 use messages::{HEADER_LENGTH, MessageBuffer, RawMessage};
 use super::error::other_error;
 
-pub const MAX_MESSAGE_LEN: usize = 1024 * 1024; // 1 MB
-
 #[derive(Debug)]
-pub struct MessagesCodec;
+pub struct MessagesCodec {
+    /// Maximum message length (in bytes), gets populated from `NetworkConfiguration`.
+    pub max_message_len: usize,
+}
 
 impl Decoder for MessagesCodec {
     type Item = RawMessage;
@@ -37,11 +38,11 @@ impl Decoder for MessagesCodec {
         }
         // Check payload len
         let total_len = LittleEndian::read_u32(&buf[6..10]) as usize;
-        if total_len > MAX_MESSAGE_LEN {
+        if total_len > self.max_message_len {
             return Err(other_error(format!(
                 "Received message is too long: {}, maximum allowed length is {}",
                 total_len,
-                MAX_MESSAGE_LEN
+                self.max_message_len,
             )));
         }
 

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -24,11 +24,11 @@ use super::error::other_error;
 #[derive(Debug)]
 pub struct MessagesCodec {
     /// Maximum message length (in bytes), gets populated from `NetworkConfiguration`.
-    max_message_len: usize,
+    max_message_len: u32,
 }
 
 impl MessagesCodec {
-    pub fn new(max_message_len: usize) -> MessagesCodec {
+    pub fn new(max_message_len: u32) -> MessagesCodec {
         MessagesCodec { max_message_len }
     }
 }
@@ -44,9 +44,9 @@ impl Decoder for MessagesCodec {
         }
         // Check payload len
         let total_len = LittleEndian::read_u32(&buf[6..10]) as usize;
-        if total_len > self.max_message_len {
+        if total_len as u32 > self.max_message_len {
             return Err(other_error(format!(
-                "Received message is too long: {}, maximum allowed length is {}",
+                "Received message is too long: {}, maximum allowed length is {} bytes",
                 total_len,
                 self.max_message_len,
             )));

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -62,7 +62,7 @@ pub struct NetworkConfiguration {
     pub tcp_connect_max_retries: u64,
     /// Maximum message length (in bytes), gets populated from `ConsensusConfig`.
     #[serde(skip)]
-    pub max_message_len: usize,
+    pub max_message_len: u32,
 }
 
 impl Default for NetworkConfiguration {

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -60,9 +60,6 @@ pub struct NetworkConfiguration {
     pub tcp_keep_alive: Option<u64>,
     pub tcp_connect_retry_timeout: Milliseconds,
     pub tcp_connect_max_retries: u64,
-    /// Maximum message length (in bytes), gets populated from `ConsensusConfig`.
-    #[serde(skip)]
-    pub max_message_len: u32,
 }
 
 impl Default for NetworkConfiguration {
@@ -74,7 +71,6 @@ impl Default for NetworkConfiguration {
             tcp_nodelay: true,
             tcp_connect_retry_timeout: 15_000,
             tcp_connect_max_retries: 10,
-            max_message_len: 1024 * 1024, // 1 MB
         }
     }
 }
@@ -84,6 +80,7 @@ pub struct NetworkPart {
     pub our_connect_message: Connect,
     pub listen_address: SocketAddr,
     pub network_config: NetworkConfiguration,
+    pub max_message_len: u32,
     pub network_requests: (mpsc::Sender<NetworkRequest>, mpsc::Receiver<NetworkRequest>),
     pub network_tx: mpsc::Sender<NetworkEvent>,
 }
@@ -119,6 +116,7 @@ impl ConnectionsPool {
     fn connect_to_peer(
         self,
         network_config: NetworkConfiguration,
+        max_message_len: u32,
         peer: SocketAddr,
         network_tx: mpsc::Sender<NetworkEvent>,
         handle: &Handle,
@@ -159,7 +157,7 @@ impl ConnectionsPool {
             .and_then(move |sock| {
                 trace!("Established connection with peer={}", peer);
 
-                let stream = sock.framed(MessagesCodec::new(network_config.max_message_len));
+                let stream = sock.framed(MessagesCodec::new(max_message_len));
                 let (sink, stream) = stream.split();
 
                 let writer = conn_rx
@@ -216,6 +214,7 @@ impl NetworkPart {
         let requests_handle = RequestHandler::new(
             self.our_connect_message,
             network_config,
+            self.max_message_len,
             self.network_tx.clone(),
             handle.clone(),
             self.network_requests.1,
@@ -224,6 +223,7 @@ impl NetworkPart {
         // TODO Don't use unwrap here!
         let server = Listener::bind(
             network_config,
+            self.max_message_len,
             self.listen_address,
             handle.clone(),
             &self.network_tx,
@@ -248,6 +248,7 @@ impl RequestHandler {
     fn new(
         connect_message: Connect,
         network_config: NetworkConfiguration,
+        max_message_len: u32,
         network_tx: mpsc::Sender<NetworkEvent>,
         handle: Handle,
         receiver: mpsc::Receiver<NetworkRequest>,
@@ -268,6 +269,7 @@ impl RequestHandler {
                                     .clone()
                                     .connect_to_peer(
                                         network_config,
+                                        max_message_len,
                                         peer,
                                         network_tx.clone(),
                                         &handle,
@@ -338,6 +340,7 @@ struct Listener(Box<Future<Item = (), Error = io::Error>>);
 impl Listener {
     fn bind(
         network_config: NetworkConfiguration,
+        max_message_len: u32,
         listen_address: SocketAddr,
         handle: Handle,
         network_tx: &mpsc::Sender<NetworkEvent>,
@@ -362,7 +365,7 @@ impl Listener {
                 return tobox(future::ok(()));
             }
             trace!("Accepted incoming connection with peer={}", addr);
-            let stream = sock.framed(MessagesCodec::new(network_config.max_message_len));
+            let stream = sock.framed(MessagesCodec::new(max_message_len));
             let (_, stream) = stream.split();
             let network_tx = network_tx.clone();
             let connection_handler = stream

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -159,9 +159,7 @@ impl ConnectionsPool {
             .and_then(move |sock| {
                 trace!("Established connection with peer={}", peer);
 
-                let stream = sock.framed(MessagesCodec {
-                    max_message_len: network_config.max_message_len,
-                });
+                let stream = sock.framed(MessagesCodec::new(network_config.max_message_len));
                 let (sink, stream) = stream.split();
 
                 let writer = conn_rx
@@ -364,9 +362,7 @@ impl Listener {
                 return tobox(future::ok(()));
             }
             trace!("Accepted incoming connection with peer={}", addr);
-            let stream = sock.framed(MessagesCodec {
-                max_message_len: network_config.max_message_len,
-            });
+            let stream = sock.framed(MessagesCodec::new(network_config.max_message_len));
             let (_, stream) = stream.split();
             let network_tx = network_tx.clone();
             let connection_handler = stream

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -162,6 +162,7 @@ impl TestEvents {
             our_connect_message: connect_message(self.listen_address),
             listen_address: self.listen_address,
             network_config,
+            max_message_len: ::blockchain::ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN,
             network_requests: channel.network_requests,
             network_tx: network_tx.clone(),
         };

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -28,6 +28,7 @@ use events::{NetworkEvent, NetworkRequest};
 use events::network::{NetworkConfiguration, NetworkPart};
 use events::error::log_error;
 use node::{EventsPoolCapacity, NodeChannel};
+use blockchain::ConsensusConfig;
 
 #[derive(Debug)]
 pub struct TestHandler {
@@ -162,7 +163,7 @@ impl TestEvents {
             our_connect_message: connect_message(self.listen_address),
             listen_address: self.listen_address,
             network_config,
-            max_message_len: ::blockchain::ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN,
+            max_message_len: ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN,
             network_requests: channel.network_requests,
             network_tx: network_tx.clone(),
         };
@@ -258,6 +259,36 @@ fn test_network_big_message() {
 
     e2.disconnect_with(first);
     assert_eq!(e2.wait_for_disconnect(), first);
+}
+
+#[test]
+fn test_network_max_message_len() {
+    let first = "127.0.0.1:17202".parse().unwrap();
+    let second = "127.0.0.1:17303".parse().unwrap();
+
+    let max_message_length = ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN as usize;
+    let max_payload_length = max_message_length - ::messages::HEADER_LENGTH -
+        ::crypto::SIGNATURE_LENGTH;
+    let acceptable_message = raw_message(15, max_payload_length);
+    let too_big_message = raw_message(16, max_payload_length + 1000);
+
+    let e1 = TestEvents::with_addr(first);
+    let e2 = TestEvents::with_addr(second);
+
+    let mut e1 = e1.spawn();
+    let mut e2 = e2.spawn();
+
+    e1.connect_with(second);
+    e2.wait_for_connect();
+
+    e2.connect_with(first);
+    e1.wait_for_connect();
+
+    e1.send_to(second, acceptable_message.clone());
+    assert_eq!(e2.wait_for_message(), acceptable_message);
+
+    e2.send_to(first, too_big_message.clone());
+    assert!(e1.wait_for_event().is_err());
 }
 
 #[test]

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -712,6 +712,7 @@ pub struct Node {
     network_config: NetworkConfiguration,
     handler: NodeHandler,
     channel: NodeChannel,
+    max_message_len: u32,
 }
 
 impl NodeChannel {
@@ -787,8 +788,7 @@ impl Node {
         };
         let api_state = SharedNodeState::new(node_cfg.api.state_update_timeout as u64);
         let system_state = Box::new(DefaultSystemState(node_cfg.listen_address));
-        let mut network_config = config.network;
-        network_config.max_message_len = node_cfg.genesis.consensus.max_message_len;
+        let network_config = config.network;
         let handler = NodeHandler::new(
             blockchain,
             external_address,
@@ -802,6 +802,7 @@ impl Node {
             handler,
             channel,
             network_config,
+            max_message_len: node_cfg.genesis.consensus.max_message_len,
         }
     }
 
@@ -922,6 +923,7 @@ impl Node {
             network_requests: self.channel.network_requests,
             network_tx: network_tx,
             network_config: self.network_config,
+            max_message_len: self.max_message_len,
         };
 
         let (internal_tx, internal_rx) = self.channel.internal_events;

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -787,7 +787,8 @@ impl Node {
         };
         let api_state = SharedNodeState::new(node_cfg.api.state_update_timeout as u64);
         let system_state = Box::new(DefaultSystemState(node_cfg.listen_address));
-        let network_config = config.network;
+        let mut network_config = config.network;
+        network_config.max_message_len = node_cfg.genesis.consensus.max_message_len;
         let handler = NodeHandler::new(
             blockchain,
             external_address,

--- a/exonum/tests/testdata/config/config01.toml
+++ b/exonum/tests/testdata/config/config01.toml
@@ -14,6 +14,7 @@ consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda7
 service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config02.toml
+++ b/exonum/tests/testdata/config/config02.toml
@@ -17,6 +17,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config03.toml
+++ b/exonum/tests/testdata/config/config03.toml
@@ -20,6 +20,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config04.toml
+++ b/exonum/tests/testdata/config/config04.toml
@@ -23,6 +23,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config0_pub.toml
+++ b/exonum/tests/testdata/config/config0_pub.toml
@@ -1,4 +1,5 @@
 [common.consensus_config]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config12.toml
+++ b/exonum/tests/testdata/config/config12.toml
@@ -17,6 +17,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config13.toml
+++ b/exonum/tests/testdata/config/config13.toml
@@ -20,6 +20,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config14.toml
+++ b/exonum/tests/testdata/config/config14.toml
@@ -23,6 +23,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config1_pub.toml
+++ b/exonum/tests/testdata/config/config1_pub.toml
@@ -1,4 +1,5 @@
 [common.consensus_config]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config23.toml
+++ b/exonum/tests/testdata/config/config23.toml
@@ -20,6 +20,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config24.toml
+++ b/exonum/tests/testdata/config/config24.toml
@@ -23,6 +23,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config2_pub.toml
+++ b/exonum/tests/testdata/config/config2_pub.toml
@@ -1,4 +1,5 @@
 [common.consensus_config]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config34.toml
+++ b/exonum/tests/testdata/config/config34.toml
@@ -23,6 +23,7 @@ consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58
 service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [genesis.consensus]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/config3_pub.toml
+++ b/exonum/tests/testdata/config/config3_pub.toml
@@ -1,4 +1,5 @@
 [common.consensus_config]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/exonum/tests/testdata/config/template.toml
+++ b/exonum/tests/testdata/config/template.toml
@@ -1,4 +1,5 @@
 [consensus_config]
+max_message_len = 1048576
 peers_timeout = 10000
 round_timeout = 3000
 status_timeout = 5000

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -596,6 +596,7 @@ pub fn sandbox_with_services_uninitialized(services: Vec<Box<Service>>) -> Sandb
         status_timeout: 600_000,
         peers_timeout: 600_000,
         txs_block_limit: 1000,
+        max_message_len: 1024 * 1024,
         timeout_adjuster: TimeoutAdjusterConfig::Constant { timeout: 200 },
     };
     let genesis = GenesisConfig::new_with_consensus(


### PR DESCRIPTION
### Description

This PR makes `MAX_MESSAGE_LEN` configurable, so we get rid of this hardcoded const.

~~**Important note.**
I had to duplicate this parameter in both configs: `ConsensusConfig` and `NetworkConfiguration`. The latter doesn't (de)serialize it, so we actually store it only in `genesis.consensus` section (as all nodes must share this value). This tricky workflow is needed for convenient passing it to `MessagesCodec`.~~