### PR TITLE
Make `from_raw` method generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `Transaction` trait now inherit `ExonumJson`. (#402)
 - The list of peer connections is now restored to the last state after the process is restarted. (#378)
 - `message!` and `encoding_struct!` no longer require manual `SIZE` and offset specification.
+- `from_raw(raw: RawMessage)` method is not part of the `Message` trait, and not an inherent method. (#427)
 
 ### Removed
 - Removed default `state_hash` implementation in the `Service` trait. (#399)

--- a/exonum/src/messages/raw.rs
+++ b/exonum/src/messages/raw.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 use byteorder::{ByteOrder, LittleEndian};
 
 use crypto::{hash, sign, verify, Hash, PublicKey, SecretKey, Signature, SIGNATURE_LENGTH};
-use encoding::{CheckedOffset, Field, Offset, Result as StreamStructResult};
+use encoding::{self, CheckedOffset, Field, Offset, Result as StreamStructResult};
 
 /// Length of the message header.
 pub const HEADER_LENGTH: usize = 10;
@@ -258,6 +258,11 @@ impl MessageWriter {
 
 /// Represents generic message interface.
 pub trait Message: Debug + Send + Sync {
+    /// Converts the raw message into the specific one.
+    fn from_raw(raw: RawMessage) -> Result<Self, encoding::Error>
+    where
+        Self: Sized;
+
     /// Returns raw message.
     fn raw(&self) -> &RawMessage;
 
@@ -273,6 +278,10 @@ pub trait Message: Debug + Send + Sync {
 }
 
 impl Message for RawMessage {
+    fn from_raw(raw: RawMessage) -> Result<Self, encoding::Error> {
+        Ok(raw)
+    }
+
     fn raw(&self) -> &RawMessage {
         self
     }

--- a/exonum/src/messages/tests.rs
+++ b/exonum/src/messages/tests.rs
@@ -14,7 +14,7 @@
 
 use crypto::{PublicKey, SecretKey, Signature, gen_keypair};
 use messages::raw::MessageBuffer;
-use messages::RawMessage;
+use messages::{Message, RawMessage};
 use encoding::serialize::FromHex;
 
 message! {


### PR DESCRIPTION
While working on the `protocol!` macro, I've noticed that we use inherent associated functions for constructing transactions. I think putting this function inside the `Message` trait is more natural, and allows to work with messages generically. 

This is a breaking change, because the users will have to add `use exonum::encoding::Message` to use `from_raw`. If we want, we can provide an inherent method with the same name for backwards compatibility, but I'd rather not do this. 