### PR TITLE
Remove unneeded mutability

### DIFF
--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -220,7 +220,7 @@ enum NextIterValue {
 ///
 /// ```
 /// use exonum::storage::{Database, MemoryDB};
-/// 
+///
 /// // not declared as `mut db`!
 /// let db: Box<Database> = Box::new(MemoryDB::new());
 /// let mut fork = db.fork();

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -214,9 +214,24 @@ enum NextIterValue {
 /// and [`merge`] methods for indirect interaction. See [the module documentation](index.html)
 /// for more details.
 ///
+/// Note that `Database` effectively has [interior mutability][interior-mut];
+/// `merge` and `merge_sync` methods take a shared reference to the database (`&self`)
+/// rather than an exclusive one (`&mut self`). This means that the following code compiles:
+///
+/// ```
+/// use exonum::storage::{Database, MemoryDB};
+/// 
+/// // not declared as `mut db`!
+/// let db: Box<Database> = Box::new(MemoryDB::new());
+/// let mut fork = db.fork();
+/// fork.put("index_name", vec![1, 2, 3], vec![123]);
+/// db.merge(fork.into_patch()).unwrap();
+/// ```
+///
 /// [`snapshot`]: #tymethod.snapshot
 /// [`fork`]: #method.fork
 /// [`merge`]: #tymethod.merge
+/// [interior-mut]: https://doc.rust-lang.org/book/second-edition/ch15-05-interior-mutability.html
 pub trait Database: Send + Sync + 'static {
     /// Creates a new snapshot of the database from its current state.
     fn snapshot(&self) -> Box<Snapshot>;

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -133,7 +133,7 @@ impl Iterator for MemoryDBIter {
 
 #[test]
 fn test_memorydb_snapshot() {
-    let mut db = MemoryDB::new();
+    let db = MemoryDB::new();
     let idx_name = "idx_name";
     {
         let mut fork = db.fork();

--- a/exonum/src/storage/tests.rs
+++ b/exonum/src/storage/tests.rs
@@ -16,7 +16,7 @@ use super::{Database, Snapshot, Fork};
 
 const IDX_NAME: &'static str = "idx_name";
 
-fn fork_iter<T: Database>(mut db: T) {
+fn fork_iter<T: Database>(db: T) {
     let mut fork = db.fork();
 
     fork.put(IDX_NAME, vec![10], vec![10]);


### PR DESCRIPTION
This PR removes unnecessary mutability regarding `Database`, which happened due to #422. For some reason, it isn't picked up by `clippy`, although corresponding warnings *are* output by the compiler. Additionally, `Database` docs are updated to avoid similar mistakes in the future.

### What kind of change does this PR introduce?

Other (fixes Rust compiler warning).

### Checklist:

- [x] All commits are named based on our guideline (read CONTRIBUTING.md)
- [x] Tests for the changes have been added (a doc test)
- [x] Docs have been added / updated
- [ ] CHANGELOG.md have been updated

### How can we test these changes?

By looking at compilation results (e.g., in the Travis log): they should no longer contain warnings from the Rust compiler.