### PR TITLE
Introduce CryptoHash trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file. The project
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `exonum::crypto::CryptoHash` trait is introduced, and `StorageValue::hash` and `Message::hash` methods are removed.
+   Migration path:
+     - For implementations of `StorageValue`, move the `hash` method to `CryptoHash` implementation instead.
+     - For implementations of `Message` simply remove `hash` method, there's a blanket impl of `CryptoHash`
+       for `Message`.
+     - Add `use exonum::crypto::CryptoHash` to use the `hash` method.
+
 ## 0.5 - 2018-01-30
 
 ### Breaking changes

--- a/exonum/benches/block.rs
+++ b/exonum/benches/block.rs
@@ -28,10 +28,9 @@ mod tests {
     use tempdir::TempDir;
     use futures::sync::mpsc;
     use test::Bencher;
-    use exonum::storage::{Database, Fork, Patch, ProofMapIndex, StorageValue, RocksDB,
-                          RocksDBOptions};
+    use exonum::storage::{Database, Fork, Patch, ProofMapIndex, RocksDB, RocksDBOptions};
     use exonum::blockchain::{Blockchain, Transaction};
-    use exonum::crypto::{gen_keypair, Hash, PublicKey, SecretKey};
+    use exonum::crypto::{gen_keypair, CryptoHash, Hash, PublicKey, SecretKey};
     use exonum::messages::Message;
     use exonum::helpers::{Height, ValidatorId};
     use exonum::node::ApiSender;

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -20,7 +20,7 @@ use serde::de::Error;
 use serde_json::{self, Error as JsonError};
 
 use storage::StorageValue;
-use crypto::{hash, PublicKey, Hash};
+use crypto::{hash, CryptoHash, PublicKey, Hash};
 use helpers::{Height, Milliseconds};
 
 /// Public keys of a validator.
@@ -157,6 +157,13 @@ impl StoredConfiguration {
     }
 }
 
+impl CryptoHash for StoredConfiguration {
+    fn hash(&self) -> Hash {
+        let vec_bytes = self.try_serialize().unwrap();
+        hash(&vec_bytes)
+    }
+}
+
 impl StorageValue for StoredConfiguration {
     fn into_bytes(self) -> Vec<u8> {
         self.try_serialize().unwrap()
@@ -164,11 +171,6 @@ impl StorageValue for StoredConfiguration {
 
     fn from_bytes(v: ::std::borrow::Cow<[u8]>) -> Self {
         StoredConfiguration::try_deserialize(v.as_ref()).unwrap()
-    }
-
-    fn hash(&self) -> Hash {
-        let vec_bytes = self.try_serialize().unwrap();
-        hash(&vec_bytes)
     }
 }
 

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crypto::{PublicKey, Hash};
+use crypto::{PublicKey, Hash, CryptoHash};
 use messages::{Precommit, RawMessage, Connect};
 use storage::{Fork, ListIndex, MapIndex, MapProof, ProofListIndex, ProofMapIndex, Snapshot,
-              StorageKey, StorageValue};
+              StorageKey};
 use helpers::Height;
 use super::{Block, BlockProof, Blockchain};
 use super::config::StoredConfiguration;

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -20,7 +20,7 @@ use rand::{thread_rng, Rng};
 use serde_json;
 
 use blockchain::{Blockchain, Schema, Transaction};
-use crypto::{gen_keypair, Hash};
+use crypto::{gen_keypair, CryptoHash, Hash};
 use storage::{Database, Error, Fork, ListIndex};
 use messages::Message;
 use helpers::{Height, ValidatorId};

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -130,6 +130,12 @@ macro_rules! encoding_struct {
             }
         }
 
+        impl $crate::crypto::CryptoHash for $name {
+            fn hash(&self) -> $crate::crypto::Hash {
+                $name::hash(self)
+            }
+        }
+
         impl $crate::storage::StorageValue for $name {
             fn into_bytes(self) -> Vec<u8> {
                 self.raw
@@ -139,10 +145,6 @@ macro_rules! encoding_struct {
                 $name {
                     raw: v.into_owned()
                 }
-            }
-
-            fn hash(&self) -> $crate::crypto::Hash {
-                $name::hash(self)
             }
         }
 

--- a/exonum/src/messages/spec.rs
+++ b/exonum/src/messages/spec.rs
@@ -290,10 +290,6 @@ macro_rules! message {
         }
 
         impl $crate::storage::StorageValue for $name {
-            fn hash(&self) -> $crate::crypto::Hash {
-                $crate::messages::Message::hash(self)
-            }
-
             fn into_bytes(self) -> Vec<u8> {
                 self.raw.as_ref().as_ref().to_vec()
             }

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use crypto::{Hash, PublicKey};
+use crypto::{Hash, CryptoHash, PublicKey};
 use blockchain::{Schema, Transaction};
 use messages::{BlockRequest, BlockResponse, ConsensusMessage, Message, Precommit, Prevote,
                PrevotesRequest, Propose, ProposeRequest, RawTransaction, TransactionsRequest};

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 use bit_vec::BitVec;
 
 use messages::{Message, Propose, Prevote, Precommit, ConsensusMessage, Connect};
-use crypto::{PublicKey, SecretKey, Hash};
+use crypto::{CryptoHash, PublicKey, SecretKey, Hash};
 use storage::{Patch, Snapshot};
 use blockchain::{ValidatorKeys, ConsensusConfig, StoredConfiguration, Transaction,
                  TimeoutAdjusterConfig};

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -14,8 +14,8 @@
 
 use rand::{thread_rng, Rng};
 
-use crypto::{Hash, hash};
-use storage::{Database, StorageValue};
+use crypto::{CryptoHash, Hash, hash};
+use storage::Database;
 use encoding::serialize::json::reexport::{to_string, from_str};
 use encoding::serialize::reexport::Serialize;
 use super::{ProofListIndex, ListProof, pair_hash};

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -17,7 +17,7 @@
 use std::marker::PhantomData;
 use std::fmt;
 
-use crypto::{Hash, HashStream};
+use crypto::{Hash, CryptoHash, HashStream};
 use super::{BaseIndex, BaseIndexIter, Fork, Snapshot, StorageValue};
 use self::key::{BitsRange, ChildKind, LEAF_KEY_PREFIX};
 use self::node::{BranchNode, Node};

--- a/exonum/src/storage/proof_map_index/node.rs
+++ b/exonum/src/storage/proof_map_index/node.rs
@@ -14,7 +14,7 @@
 
 use std::borrow::Cow;
 
-use crypto::{hash, Hash, HASH_SIZE};
+use crypto::{hash, CryptoHash, Hash, HASH_SIZE};
 
 use super::super::{StorageKey, StorageValue};
 use super::key::{ChildKind, ProofPath, PROOF_PATH_SIZE};
@@ -79,6 +79,12 @@ impl BranchNode {
     }
 }
 
+impl CryptoHash for BranchNode {
+    fn hash(&self) -> Hash {
+        hash(&self.raw)
+    }
+}
+
 impl StorageValue for BranchNode {
     fn into_bytes(self) -> Vec<u8> {
         self.raw
@@ -86,10 +92,6 @@ impl StorageValue for BranchNode {
 
     fn from_bytes(value: Cow<[u8]>) -> Self {
         BranchNode { raw: value.into_owned() }
-    }
-
-    fn hash(&self) -> Hash {
-        hash(&self.raw)
     }
 }
 

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -23,7 +23,7 @@ use std::marker::PhantomData;
 
 use byteorder::{BigEndian, ByteOrder};
 
-use crypto::{hash, Hash};
+use crypto::{hash, CryptoHash, Hash};
 use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -43,11 +43,13 @@ impl SparseListSize {
     }
 }
 
-impl StorageValue for SparseListSize {
+impl CryptoHash for SparseListSize {
     fn hash(&self) -> Hash {
         hash(&self.to_array())
     }
+}
 
+impl StorageValue for SparseListSize {
     fn into_bytes(self) -> Vec<u8> {
         self.to_array().to_vec()
     }

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -33,7 +33,7 @@ use exonum::blockchain::{Block, BlockProof, Blockchain, ConsensusConfig, Genesis
                          Transaction, ValidatorKeys};
 use exonum::storage::{MapProof, MemoryDB};
 use exonum::messages::{Any, Connect, Message, RawMessage, RawTransaction, Status};
-use exonum::crypto::{gen_keypair_from_seed, Hash, PublicKey, SecretKey, Seed};
+use exonum::crypto::{gen_keypair_from_seed, CryptoHash, Hash, PublicKey, SecretKey, Seed};
 #[cfg(test)]
 use exonum::crypto::gen_keypair;
 use exonum::helpers::{Height, Milliseconds, Round, ValidatorId};

--- a/sandbox/src/sandbox_tests_helper.rs
+++ b/sandbox/src/sandbox_tests_helper.rs
@@ -22,7 +22,7 @@ use bit_vec::BitVec;
 use exonum::messages::{RawTransaction, Message, Propose, Prevote, Precommit, ProposeRequest,
                        PrevotesRequest};
 use exonum::blockchain::{Block, SCHEMA_MAJOR_VERSION};
-use exonum::crypto::{Hash, HASH_SIZE};
+use exonum::crypto::{CryptoHash, Hash, HASH_SIZE};
 use exonum::storage::Database;
 use exonum::helpers::{Height, Round, ValidatorId, Milliseconds};
 

--- a/sandbox/tests/consensus.rs
+++ b/sandbox/tests/consensus.rs
@@ -27,7 +27,7 @@ use rand::{thread_rng, Rng};
 use bit_vec::BitVec;
 use exonum::messages::{RawMessage, Message, Propose, Prevote, Precommit, ProposeRequest,
                        TransactionsRequest, PrevotesRequest, CONSENSUS, Connect, PeersRequest};
-use exonum::crypto::{Hash, Seed, gen_keypair, gen_keypair_from_seed};
+use exonum::crypto::{CryptoHash, Hash, Seed, gen_keypair, gen_keypair_from_seed};
 use exonum::blockchain::{Blockchain, Schema};
 use exonum::node::state::{PREVOTES_REQUEST_TIMEOUT, PROPOSE_REQUEST_TIMEOUT,
                           TRANSACTIONS_REQUEST_TIMEOUT};

--- a/sandbox/tests/old.rs
+++ b/sandbox/tests/old.rs
@@ -17,9 +17,9 @@ extern crate sandbox;
 
 use std::time::Duration;
 
-use exonum::messages::{Message, Propose, Prevote, Precommit};
+use exonum::messages::{Propose, Prevote, Precommit};
 use exonum::blockchain::{Block, SCHEMA_MAJOR_VERSION};
-use exonum::crypto::Hash;
+use exonum::crypto::{CryptoHash, Hash};
 use exonum::helpers::{Height, Round};
 
 use sandbox::timestamping_sandbox;


### PR DESCRIPTION
A **refactoring** PR.

Problem:

`Message::hash` and `StorageValue::hash` are two different functions which must behave the same nonetheless, which introduces a non-trivial invariant into the code. 

Solution:

Extract `hash` method to a separate small trait and use it everywhere. 

Questions:

- What is the best name for this trait? The natural choice is `Hash`, but it clashes both with the `Hash` struct and with `std::hash::Hash`. Another alternative is `Digest`, but it doesn't match the `fn hash` name. And changing `fn hash` to `fn digest` requires a much larger diff, and `fn hash(&self) -> Hash` reads better than `fn digest(&self) -> Hash`. My preferred solution is to use the current `CryptoHash`.

- Quite a few types implement an inherent version of the `hash` method (for example, all of `encoding_struct!` generated types). Should they only implement a trait instead? I would say yes, but I want to gather consensus before doing this larger refactoring.

This is better be merged after the release :) 