### PR TITLE
Storage key for signed ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file. The project
 
 ## [Unreleased]
 
+### Breaking changes
+- The `StorageKey` trait is re-implemented for signed integer types (`i8`, `i16`, `i32` and `i64`)
+  to achieve the natural ordering of produced keys. This change will break indices using
+  signed integers as keys. To emulate the old implementation, you may create a wrapper
+  around a type (e.g., `struct QuirkyI32Key(i32)`) and implement `StorageKey` for it
+  using big endian encoding. Then, use the wrapper instead of the int type in indices.
+  See the unit tests for `StorageKey` for an example.
+
 ## 0.5 - 2018-01-30
 
 ### Breaking changes

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -20,9 +20,9 @@ use crypto::{Hash, PublicKey, HASH_SIZE, PUBLIC_KEY_LENGTH};
 /// A type that can be (de)serialized as a key in the blockchain storage.
 ///
 /// Since keys are sorted in a serialized form, the big-endian encoding should be used
-/// with unsigned integer types. Note however that the big-endian encoding
-/// will **not** sort signed integer types in the natural order; a possible solution is
-/// mapping the type to a corresponding unsigned one as shown in the example below.
+/// with unsigned integer types. Note however that the big-endian encoding on its own
+/// will not sort signed integer types in the natural order; therefore, they are
+/// mapped to a corresponding unsigned type by adding a constant to a source value.
 ///
 /// # Examples
 ///
@@ -44,17 +44,13 @@ use crypto::{Hash, PublicKey, HASH_SIZE, PUBLIC_KEY_LENGTH};
 ///     }
 ///
 ///     fn write(&self, buffer: &mut [u8]) {
-///         // Maps `a` to the `u16` range in the natural order:
-///         // -32768 -> 0, -32767 -> 1, ..., 32767 -> 65535
-///         let mapped_a = self.a.wrapping_add(i16::min_value()) as u16;
-///         BigEndian::write_u16(&mut buffer[0..2], mapped_a);
-///         BigEndian::write_u32(&mut buffer[2..6], self.b);
+///         self.a.write(&mut buffer[0..2]);
+///         self.b.write(&mut buffer[2..6]);
 ///     }
 ///
 ///     fn read(buffer: &[u8]) -> Self {
-///         let mapped_a = BigEndian::read_u16(&buffer[0..2]);
-///         let a = mapped_a.wrapping_add(i16::min_value() as u16) as i16;
-///         let b = BigEndian::read_u32(&buffer[2..6]);
+///         let a = i16::read(&buffer[0..2]);
+///         let b = u32::read(&buffer[2..6]);
 ///         Key { a, b }
 ///     }
 /// }


### PR DESCRIPTION
This PR changes the `StorageKey` implementation for signed integer types in order to order them in the natural order. Previously, these type were encoded in big-endian, which means that say `-1i8` (encoded as `0xff`) was considered greater than `127i8` (encoded as `0x7f`).

After the change, the signed integer value is shifted to the range of the corresponding signed integer. It's easy to see that this is the *only* way to order signed ints in the natural order without increasing the size of allocated bytes for the int.

### What kind of change does this PR introduce?

Technically, this is a breaking change. However, I'm having doubts anyone has used `StorageKey` for signed ints because of the unnatural sorting order. Obviously, this needs to be discussed further.

### Checklist:

- [x] All commits are named based on our guideline (read CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] CHANGELOG.md have been updated

### How can we test these changes?

There are unit tests included into the PR. Maybe, it could make sense to create an integration test with a `MapIndex` with signed integer keys.