### PR TITLE
Don't add inherent `hash` method in encoding_struct!

### DIFF
--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -44,7 +44,7 @@ use vec_map::VecMap;
 use byteorder::{ByteOrder, LittleEndian};
 use mount::Mount;
 
-use crypto::{self, Hash, PublicKey, SecretKey};
+use crypto::{self, Hash, CryptoHash, PublicKey, SecretKey};
 use messages::{CONSENSUS as CORE_SERVICE, Precommit, RawMessage, Connect};
 use storage::{Database, Error, Fork, Patch, Snapshot};
 use helpers::{Height, ValidatorId};

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -132,7 +132,7 @@ macro_rules! encoding_struct {
 
         impl $crate::crypto::CryptoHash for $name {
             fn hash(&self) -> $crate::crypto::Hash {
-                $name::hash(self)
+                $crate::crypto::hash(self.raw.as_ref())
             }
         }
 
@@ -161,11 +161,6 @@ macro_rules! encoding_struct {
                     $( ($(#[$field_attr])*, $field_name, $field_type) )*
                 );
                 $name { raw: buf }
-            }
-
-            /// Hashes data as a raw byte array and returns the resulting hash.
-            pub fn hash(&self) -> $crate::crypto::Hash {
-                $crate::crypto::hash(self.raw.as_ref())
             }
 
             __ex_for_each_field!(

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -36,7 +36,7 @@ use futures::{Future, Sink};
 use futures::sync::mpsc;
 use tokio_core::reactor::Core;
 
-use crypto::{self, Hash, PublicKey, SecretKey};
+use crypto::{self, Hash, CryptoHash, PublicKey, SecretKey};
 use blockchain::{Blockchain, GenesisConfig, Schema, SharedNodeState, Transaction, Service};
 use api::{private, public, Api};
 use messages::{Connect, Message, RawMessage};


### PR DESCRIPTION
A **refactoring** RP. Follow up upon #442: remove inherent impl from `encoding_struuct`, which is covered by `trait CryptoHash` anyway. 

I believe the changes here covered by changelog entry for #422.