### PR TITLE
[Fix] Implement ExonumJsonDeserialize for floats

### DIFF
--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file. The project
 ### New features
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)
 
+### Bug fixes
+- `ExonumJsonDeserialize` trait is implemented for `F32` and `F64`. (#461)
+
 ## 0.5.1 - 2018-02-01
 
 ### Bug fixes

--- a/exonum/src/encoding/float.rs
+++ b/exonum/src/encoding/float.rs
@@ -357,4 +357,37 @@ mod tests {
             assert!(!validate_constructor(|v| F64::new(v), value, &buf, 8));
         }
     }
+
+    #[test]
+    #[allow(dead_code)]
+    fn test_f32_struct() {
+        encoding_struct!(
+            struct Msg {
+                single_float: F32,
+                vec: Vec<F32>,
+            }
+        );
+        let test_vec = vec![F32::new(0.0), F32::new(3.14), F32::new(5.82)];
+
+        let msg = Msg::new(F32::new(0.0), test_vec.clone());
+        assert_eq!(msg.single_float().get(), 0.0);
+        assert_eq!(msg.vec(), test_vec);
+    }
+
+    #[test]
+    #[allow(dead_code)]
+    fn test_f64_struct() {
+        encoding_struct!(
+            struct Msg {
+                single_float: F64,
+                vec: Vec<F64>,
+            }
+        );
+
+        let test_vec = vec![F64::new(0.0), F64::new(3.14), F64::new(5.82)];
+
+        let msg = Msg::new(F64::new(0.0), test_vec.clone());
+        assert_eq!(msg.single_float().get(), 0.0);
+        assert_eq!(msg.vec(), test_vec);
+    }
 }


### PR DESCRIPTION
This fix will allow to use `Vec<F32>` and `Vec<F64>` in `message!` macros.