### PR TITLE
Make `cargo test` work on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "sandbox",
     "testkit",
 ]
+exclude = [ "3rdparty" ]


### PR DESCRIPTION
`cargo test` in the root equivalent to `cargo test --all` which tries to build
all members of the workspace. However, 3rdparty crates are totally optional and
don't work with stable, so let's exclude them.