### PR TITLE
markdownlint [ECR-427]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,6 +5,7 @@ Please describe your issue here.
 -->
 
 ## Specifications
-  - Platform:
-  - Rust version:
-  - Exonum version:
+
+- Platform:
+- Rust version:
+- Exonum version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 <!--
-Please describe the pull request motivation and changes here along with non-obvious things.
+****Please describe the pull request motivation and changes here
+along with non-obvious things.
 -->

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,6 @@
+{
+    "default": true,
+    "no-duplicate-header": false,
+    "first-header-h1": false,
+    "first-line-h1": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,8 @@ install:
     nvm use 8
     npm install -g cspell
     cspell --version
+    npm install -g markdownlint
+    markdownlint --version
     fi
 - |
   case "$FEATURE" in
@@ -109,7 +111,8 @@ script: |
       cd testkit && cargo fmt -- --write-mode=diff && cd .. &&
       cspell sandbox/{src,examples,tests}/**/*.rs &&
       cspell exonum/{src,benches,tests}/**/*.rs &&
-      cspell testkit/{src,examples,tests}/**/*.rs
+      cspell testkit/{src,examples,tests}/**/*.rs &&
+      find . -not -path "./3rdparty/*" -name "*.md" | xargs markdownlint --config .markdownlintrc
   ;;
   "clippy-core" )
       cd exonum && cargo clippy --verbose --features long_benchmarks -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
     nvm use 8
     npm install -g cspell
     cspell --version
-    npm install -g markdownlint
+    npm install -g markdownlint-cli
     markdownlint --version
     fi
 - |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,28 @@
 # Contributing to Exonum Core
 
-This contribution guide is partially derived from [Bitcoin Contribution Guide](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md)
+This contribution guide is partially derived from
+[Bitcoin Contribution Guide](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md)
 
-The Exonum Core project and its separate modules operate an open contributor model where anyone is welcome to contribute towards development in the form of peer review, testing and patches. This document explains the practical process and guidelines for contributing. The guidelines are the same for other Exonum repositories.
+The Exonum Core project and its separate modules operate an open contributor
+model where anyone is welcome to contribute towards development
+in the form of peer review, testing and patches.
+This document explains the practical process and guidelines for contributing.
+The guidelines are the same for other Exonum repositories.
 
-Firstly in terms of structure, there is no particular concept of "Core developers" in the sense of privileged people. Open source often naturally revolves around meritocracy where longer term contributors gain more trust from the developer community. However, some hierarchy is necessary for practical purposes. As such there are repository "maintainers" who are responsible for merging pull requests as well as a "lead maintainer" who is responsible for the release cycle, overall merging, moderation and appointment of maintainers.
+Firstly in terms of structure, there is no particular concept of
+"Core developers" in the sense of privileged people.
+Open source often naturally revolves around meritocracy where
+longer term contributors gain more trust from the developer community.
+However, some hierarchy is necessary for practical purposes.
+As such there are repository "maintainers" who are responsible for merging
+pull requests as well as a "lead maintainer" who is responsible
+for the release cycle, overall merging, moderation and appointment of maintainers.
 
 ## Contributor Workflow
 
-The codebase is maintained using the "contributor workflow" where everyone without exception contributes patch proposals using "pull requests". This facilitates social contribution, easy testing and peer review.
+The codebase is maintained using the "contributor workflow" where everyone
+without exception contributes patch proposals using "pull requests".
+This facilitates social contribution, easy testing and peer review.
 
 To contribute a patch, the workflow is as follows:
 
@@ -16,27 +30,43 @@ To contribute a patch, the workflow is as follows:
 - Create topic branch
 - Commit patches
 
-The project coding conventions in the **TODO: insert here a link to developer notes** [developer notes](doc/developer-notes.md) must be adhered to.
+The project coding conventions in the **TODO: insert here a link to developer notes**
+[developer notes](doc/developer-notes.md) must be adhered to.
 
-In general [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention) and diffs should be easy to read. For this reason do not mix any formatting fixes or code moves with actual code changes.
+In general [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention)
+and diffs should be easy to read. For this reason do not mix any
+formatting fixes or code moves with actual code changes.
 
-Commit messages should be verbose by default consisting of a short subject line (50 chars max), a blank line and detailed explanatory text as separate paragraph(s); unless the title alone is self-explanatory (like "Corrected typo in init.rs") then a single title line is sufficient. Commit messages should be helpful to people reading your code in the future, so explain the reasoning for your decisions. Further explanation [here](http://chris.beams.io/posts/git-commit/).
+Commit messages should be verbose by default consisting of a short subject line
+(50 chars max), a blank line and detailed explanatory text as separate paragraph(s);
+unless the title alone is self-explanatory (like "Corrected typo in init.rs")
+then a single title line is sufficient. Commit messages should be helpful
+to people reading your code in the future, so explain the reasoning for your decisions.
+Further explanation [here](http://chris.beams.io/posts/git-commit/).
 
-If a particular commit references another issue, please add the reference, for example `refs #1234`, or `fixes #4321`. Using the `fixes` or `closes` keywords will cause the corresponding issue to be closed when the pull request is merged.
+If a particular commit references another issue, please add the reference,
+for example `refs #1234`, or `fixes #4321`.
+Using the `fixes` or `closes` keywords will cause the corresponding issue
+to be closed when the pull request is merged.
 
-Please refer to the [Git manual](https://git-scm.com/doc) for more information about Git.
+Please refer to the [Git manual](https://git-scm.com/doc)
+for more information about Git.
 
 - Push changes to your fork
 - Create pull request
 
-The title of the pull request should be prefixed by the component or area that the pull request affects. Valid areas as:
+The title of the pull request should be prefixed by the component or
+area that the pull request affects. Valid areas as:
 
 - _Consensus_ for changes to consensus algorithm
 - _Docs_ for changes to the documentation
 - _Net_ or _P2P_ for changes to the peer-to-peer network code
 - _API_ for changes to the external APIs
 - _Tests_ for changes to the Exonum unit tests or QA tests
-- _Trivial_ should **only** be used for PRs that do not change generated executable code. Notably, refactors (change of function arguments and code reorganization) and changes in behavior should **not** be marked as trivial. Examples of trivial PRs are changes to:
+- _Trivial_ should **only** be used for PRs that do not change generated
+    executable code. Notably, refactors (change of function arguments and code
+    reorganization) and changes in behavior should **not** be marked as trivial.
+    Examples of trivial PRs are changes to:
 
   - comments
   - whitespace
@@ -47,72 +77,90 @@ The title of the pull request should be prefixed by the component or area that t
 
 Examples:
 
-```
+```text
 Consensus: Move timespec from block to precommit
 Doc: Update leveldb templates documentation
 Tests: Add sandbox tests for #1234
 Trivial: Fix typo in init.rs
 ```
 
-If a pull request is specifically not to be considered for merging (yet) please prefix the title with [WIP] or use [Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists) in the body of the pull request to indicate tasks are pending.
+If a pull request is specifically not to be considered
+for merging (yet) please prefix the title with [WIP] or use
+[Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists)
+in the body of the pull request to indicate tasks are pending.
 
-The body of the pull request should contain enough description about what the patch does together with any justification/reasoning. You should include references to any discussions.
+The body of the pull request should contain enough description about
+what the patch does together with any justification/reasoning.
+You should include references to any discussions.
 
-At this stage one should expect comments and review from other contributors. You can add more commits to your pull request by committing them locally and pushing to your fork until you have satisfied all feedback.
+At this stage one should expect comments and review from other contributors.
+You can add more commits to your pull request by committing them locally
+and pushing to your fork until you have satisfied all feedback.
 
 ## Commit writing
 
 Good commit messages serve at least three important purposes:
 
-* To speed up the reviewing process.
+- To speed up the reviewing process.
 
-* To help us write a good release note.
+- To help us write a good release note.
 
-* To help the future maintainers of Exonum (it could be you!), say five years into the future, to find out why a particular change was made to the code or why a specific feature was added.
+- To help the future maintainers of Exonum (it could be you!),
+    say five years into the future, to find out why a particular change
+    was made to the code or why a specific feature was added.
 
 Structure your commit message like this:
 
-From: [[http://git-scm.com/book/ch5-2.html]]
+From: <http://git-scm.com/book/ch5-2.html>
 
-> ```
+> ```text
 > Short (50 chars or less) summary of changes
-> 
+>
 > More detailed explanatory text, if necessary.  Wrap it to about 72
 > characters or so.  In some contexts, the first line is treated as the
 > subject of an email and the rest of the text as the body.  The blank
 > line separating the summary from the body is critical (unless you omit
 > the body entirely); tools like rebase can get confused if you run the
 > two together.
-> 
+>
 > Further paragraphs come after blank lines.
-> 
+>
 >   - Bullet points are okay, too
-> 
+>
 >   - Typically a hyphen or asterisk is used for the bullet, preceded by a
 >     single space, with blank lines in between, but conventions vary here
 > ```
 
-
-* Write the summary line and description of what you have done in the imperative mode, that is as if you were commanding someone. Start the line with "Fix", "Add", "Change" instead of "Fixed", "Added", "Changed".
-* Always leave the second line blank.
-* Line break the commit message (to make the commit message readable without having to scroll horizontally in `gitk`).
-* Don't end the summary line with a period - it's a title and titles don't end with a period.
+- Write the summary line and description of what you have done in
+    the imperative mode, that is as if you were commanding someone.
+    Start the line with "Fix", "Add", "Change" instead of "Fixed",
+    "Added", "Changed".
+- Always leave the second line blank.
+- Line break the commit message (to make the commit message readable
+    without having to scroll horizontally in `gitk`).
+- Don't end the summary line with a period - it's a title
+    and titles don't end with a period.
 
 ### Tips
-* If it seems difficult to summarize what your commit does, it may be because it includes several logical changes or bug fixes, and it would be better to split it up into several commits using `git add -p`.
+
+- If it seems difficult to summarize what your commit does, it may be
+    because it includes several logical changes or bug fixes,
+    and it would be better to split it up into several commits using `git add -p`.
 
 ### References
 
-The following blog post has a good story how changes in naming of commit messages, help maintain the project:
+The following blog post has a good story how changes in naming of commit messages,
+help maintain the project:
 
-"How to Write a Git Commit Message": https://chris.beams.io/posts/git-commit/
-
+"How to Write a Git Commit Message": <https://chris.beams.io/posts/git-commit/>
 
 ## Squashing Commits
 
-If your pull request is accepted for merging, you may be asked by a maintainer to squash and or [rebase](https://git-scm.com/docs/git-rebase) your commits before it will be merged. The basic squashing workflow is shown below.
+If your pull request is accepted for merging, you may be asked by a maintainer
+to squash and or [rebase](https://git-scm.com/docs/git-rebase) your commits
+before it will be merged. The basic squashing workflow is shown below.
 
-```
+```sh
 git checkout your_branch_name
 git rebase -i HEAD~n
 # n is normally the number of commits in the pull
@@ -122,55 +170,92 @@ git rebase -i HEAD~n
 git push -f # (force push to GitHub)
 ```
 
-Please refrain from creating several pull requests for the same change. Use the pull request that is already open (or was created earlier) to amend changes. This preserves the discussion and review that happened earlier for the respective change set.
+Please refrain from creating several pull requests for the same change.
+Use the pull request that is already open (or was created earlier) to amend changes.
+This preserves the discussion and review that happened earlier
+for the respective change set.
 
-The length of time required for peer review is unpredictable and will vary from pull request to pull request.
+The length of time required for peer review is unpredictable and will vary
+from pull request to pull request.
 
 ## Pull Request Philosophy
 
-Patchsets should always be focused. For example, a pull request could add a feature, fix a bug, or refactor code; but not a mixture. Please also avoid super pull requests which attempt to do too much, are overly large, or overly complex as this makes review difficult.
+Patchsets should always be focused. For example, a pull request could add a feature,
+fix a bug, or refactor code; but not a mixture.
+Please also avoid super pull requests which attempt to do too much,
+are overly large, or overly complex as this makes review difficult.
 
 ### Features
 
-When adding a new feature, thought must be given to the long term technical debt and maintenance that feature may require after inclusion. Before proposing a new feature that will require maintenance, please consider if you are willing to maintain it (including bug fixing). If features get orphaned with no maintainer in the future, they may be removed by the Repository Maintainer.
+When adding a new feature, thought must be given to the long term technical debt
+and maintenance that feature may require after inclusion.
+Before proposing a new feature that will require maintenance,
+please consider if you are willing to maintain it (including bug fixing).
+If features get orphaned with no maintainer in the future, they may be removed
+by the Repository Maintainer.
 
 ### Refactoring
 
-Refactoring is a necessary part of any software project's evolution. The following guidelines cover refactoring pull requests for the project.
+Refactoring is a necessary part of any software project's evolution.
+The following guidelines cover refactoring pull requests for the project.
 
-There are three categories of refactoring, code only moves, code style fixes, code refactoring. In general refactoring pull requests should not mix these three kinds of activity in order to make refactoring pull requests easy to review and uncontroversial. In all cases, refactoring PRs must not change the behaviour of code within the pull request (bugs must be preserved as is).
+There are three categories of refactoring, code only moves,
+code style fixes, code refactoring.
+In general refactoring pull requests should not mix these three kinds
+of activity in order to make refactoring pull requests easy to
+review and uncontroversial. In all cases, refactoring PRs must not change
+the behaviour of code within the pull request (bugs must be preserved as is).
 
-Project maintainers aim for a quick turnaround on refactoring pull requests, so where possible keep them short, uncomplex and easy to verify.
+Project maintainers aim for a quick turnaround on refactoring pull requests,
+so where possible keep them short, uncomplex and easy to verify.
 
 ## "Decision Making" Process
 
-The following applies to code changes to the Exonum Core project and related projects such as Exonum BTC Anchoring Service.
+The following applies to code changes to the Exonum Core project and related
+projects such as Exonum BTC Anchoring Service.
 
-Whether a pull request is merged into Exonum Core rests with the project merge maintainers and ultimately the project lead.
+Whether a pull request is merged into Exonum Core rests with the project merge
+maintainers and ultimately the project lead.
 
-Maintainers will take into consideration if a patch is in line with the general principles of the project; meets the minimum standards for inclusion; and will judge the general consensus of contributors.
+Maintainers will take into consideration if a patch is in line with the general
+principles of the project; meets the minimum standards for inclusion;
+and will judge the general consensus of contributors.
 
 In general, all pull requests must:
 
-- have a clear use case, fix a demonstrable bug or serve the greater good of the project (for example refactoring for modularisation);
+- have a clear use case, fix a demonstrable bug or serve the greater good
+    of the project (for example refactoring for modularisation);
 - be well peer reviewed;
 - have unit tests and sandbox tests where appropriate;
 - follow code style guidelines;
 - not break the existing test suite;
-- where bugs are fixed, where possible, there should be unit tests demonstrating the bug and also proving the fix. This helps prevent regression.
+- where bugs are fixed, where possible, there should be unit tests demonstrating
+    the bug and also proving the fix. This helps prevent regression.
 
 ### Peer Review
 
-Anyone may participate in peer review which is expressed by comments in the pull request. Typically reviewers will review the code for obvious errors, as well as test out the patch set and opine on the technical merits of the patch. Project maintainers take into account the peer review when determining if there is consensus to merge a pull request. The following language is used within pull-request comments:
+Anyone may participate in peer review which is expressed by comments
+in the pull request. Typically reviewers will review the code for obvious errors,
+as well as test out the patch set and opine on the technical merits of the patch.
+Project maintainers take into account the peer review when determining
+if there is consensus to merge a pull request.
+The following language is used within pull-request comments:
 
 - LGTM means "Looks Good To Me";
 - Concept LGTM means "I agree in the general principle of this pull request".
 
 Reviewers should include the commit hash which they reviewed in their comments.
 
-Project maintainers reserve the right to weigh the opinions of peer reviewers using common sense judgement and also may weight based on meritocracy: Those that have demonstrated a deeper commitment and understanding towards the project (over time) or have clear domain expertise may naturally have more weight, as one would expect in all walks of life.
+Project maintainers reserve the right to weigh the opinions of peer reviewers
+using common sense judgement and also may weight based on meritocracy:
+Those that have demonstrated a deeper commitment and understanding towards
+the project (over time) or have clear domain expertise may naturally
+have more weight, as one would expect in all walks of life.
 
-Where a patch set affects consensus critical code, the bar will be set much higher in terms of discussion and peer review requirements, keeping in mind that mistakes could be very costly to the wider community. This includes refactoring of consensus critical code.
+Where a patch set affects consensus critical code, the bar will be set
+much higher in terms of discussion and peer review requirements,
+keeping in mind that mistakes could be very costly to the wider community.
+This includes refactoring of consensus critical code.
 
 ## Release Policy
 
@@ -178,4 +263,7 @@ The project leader is the release manager for each Exonum Core release.
 
 ## Copyright
 
-By contributing to this repository, you agree to license your work under the Apache v.2 license unless specified otherwise at the top of the file itself. Any work contributed where you are not the original author must contain its license header with the original author(s) and source.
+By contributing to this repository, you agree to license your work under
+the Apache v.2 license unless specified otherwise at the top of the file itself.
+Any work contributed where you are not the original author must contain
+its license header with the original author(s) and source.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,66 +1,95 @@
 # Build instructions
+
 First of all, you need to install system dependencies.
 
-# Installing system dependencies
+## Installing system dependencies
+
 The crate uses these system libraries:
+
 * [rocksdb](https://github.com/facebook/rocksdb)
 * [libsodium](https://download.libsodium.org/doc/)
 * [openssl](https://www.openssl.org)
 
-Below you can find instructions on how to obtain them for the different operating systems:
+Below you can find instructions on how to obtain them for the different
+operating systems:
 
-## macOS 
+### macOS
+
 If you use `homebrew` you can simply install needed libraries with the command:
+
 ```shell
 brew install libsodium rocksdb openssl
 ```
 
-## Linux
+### Linux
+
 For deb based systems like Debian or Ubuntu you need the following packages:
+
 ```shell
-apt install build-essential libsodium-dev librocksdb-dev libsnappy-dev libssl-dev pkg-config
+apt install build-essential libsodium-dev librocksdb-dev libsnappy-dev \
+    libssl-dev pkg-config
 ```
+
 Other linux users may find the packages with similar names in their package managers.
 
-## Windows
+### Windows
+
 Building and workability is not guaranteed yet.
 
+## Adding environment variables
 
-#Adding environment variables:
 This variables needed for linking with the `rocksdb` and `snappy` libraries.
-## macOS
+
+### macOS
+
 ```shell
 export ROCKSDB_LIB_DIR=/usr/local/lib
 export SNAPPY_LIB_DIR=/usr/local/lib
 ```
-## Linux
+
+### Linux
+
 ```shell
 export ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
 export SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu
 ```
-# Installing Rust
-The project uses a stable Rust version that can be installed by using the [rustup](https://www.rustup.rs) utility.
+
+## Installing Rust
+
+The project uses a stable Rust version that can be installed by using
+the [rustup](https://www.rustup.rs) utility.
 
 ```shell
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable
 ```
 
-Nightly (`2017-07-05`) version is used for [clippy](https://github.com/Manishearth/rust-clippy). You can install it with the following command:
+Nightly (`2017-07-05`) version is used for
+[clippy](https://github.com/Manishearth/rust-clippy).
+You can install it with the following command:
+
 ```shell
 rustup toolchain install nightly-2017-07-05
 ```
+
 And run Clippy checks this way:
+
 ```shell
 cargo +nightly-2017-07-05 clippy
 ```
 
-# Compiling the project 
-You can verify that you installed everything correctly by compiling the `exonum` crate and run tests suite with the command:
+## Compiling the project
+
+You can verify that you installed everything correctly by compiling
+the `exonum` crate and run tests suite with the command:
+
 ```shell
 cargo test --manifest-path exonum/Cargo.toml
 ```
+
 You may want to launch the extended tests suite which is named `sandbox`.
+
 ```shell
 cargo test --manifest-path sandbox/Cargo.toml
 ```
+
 After all this you can learn how to create your own blockchain solution.

--- a/README.md
+++ b/README.md
@@ -3,19 +3,25 @@
 [![Build Status](https://travis-ci.org/exonum/exonum.svg?branch=master)](https://travis-ci.org/exonum/exonum)
 [![Join the chat at https://gitter.im/exonum/exonum](https://badges.gitter.im/exonum/exonum.svg)](https://gitter.im/exonum/exonum)
 
-[Exonum](https://exonum.com/) is an extensible open-source framework for creating blockchain
-applications. Exonum can be used to create cryptographically powered distributed ledgers in
-virtually any problem domain, including FinTech, GovTech, and LegalTech. The Exonum framework is
-oriented towards creating permissioned blockchains, that is, blockchains with the known set of
-blockchain infrastructure providers.
+[Exonum](https://exonum.com/) is an extensible open-source framework for
+creating blockchain applications. Exonum can be used to create cryptographically
+powered distributed ledgers in virtually any problem domain, including FinTech,
+GovTech, and LegalTech. The Exonum framework is oriented towards creating
+permissioned blockchains, that is, blockchains with the known set of blockchain
+infrastructure providers.
 
 This is the main Exonum repository that includes
+
 * [Exonum core library](https://github.com/exonum/exonum/blob/master/exonum/README.md).
 * [Exonum testing framework](https://github.com/exonum/exonum/blob/master/testkit/README.md).
 * Services:
-  * Configuration service (currently in [exonum-configuration](https://github.com/exonum/exonum-configuration) repository).
-  * Time service (currently in [exonum-time](https://github.com/exonum/exonum-time) repository).
+  * Configuration service (currently in [exonum-configuration] repository).
+  * Time service (currently in [exonum-time] repository).
 * Demos
-  * Cryprocurrency (currently in [cryptocurrency](https://github.com/exonum/cryptocurrency) repository).
-  
+  * Cryprocurrency (currently in [cryptocurrency] repository).
+
 See individual projects' readme for the details.
+
+[exonum-configuration]: https://github.com/exonum/exonum-configuration
+[exonum-time]: https://github.com/exonum/exonum-time
+[cryptocurrency]: https://github.com/exonum/cryptocurrency

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -1,93 +1,133 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. The project adheres to
-[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+All notable changes to this project will be documented in this file.
+The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Breaking changes
-- `exonum::crypto::CryptoHash` trait is introduced, and `StorageValue::hash` and `Message::hash` methods are removed. (#442)
-   Migration path:
-     - For implementations of `StorageValue`, move the `hash` method to `CryptoHash` implementation instead.
-     - For implementations of `Message` simply remove `hash` method, there's a blanket impl of `CryptoHash`
-       for `Message`.
-     - Add `use exonum::crypto::CryptoHash` to use the `hash` method.
-- The `StorageKey` trait is re-implemented for signed integer types (`i8`, `i16`, `i32` and `i64`)
-  to achieve the natural ordering of produced keys. This change will break indices using
-  signed integers as keys. To emulate the old implementation, you may create a wrapper
-  around a type (e.g., `struct QuirkyI32Key(i32)`) and implement `StorageKey` for it
-  using big endian encoding. Then, use the wrapper instead of the int type in indices.
-  See the unit tests for `StorageKey` for an example. (#443)
-  
+
+- `exonum::crypto::CryptoHash` trait is introduced, and `StorageValue::hash`
+  and `Message::hash` methods are removed. (#442)
+
+  Migration path:
+
+  - For implementations of `StorageValue`, move the `hash` method
+    to `CryptoHash` implementation instead.
+  - For implementations of `Message` simply remove `hash` method,
+    there's a blanket impl of `CryptoHash` for `Message`.
+  - Add `use exonum::crypto::CryptoHash` to use the `hash` method.
+
+- The `StorageKey` trait is re-implemented for signed integer types
+  (`i8`, `i16`, `i32` and `i64`) to achieve the natural ordering of produced keys.
+  (#443)
+
+  This change will break indices using signed integers as keys.
+  To emulate the old implementation, you may create a wrapper around a type
+  (e.g., `struct QuirkyI32Key(i32)`) and implement `StorageKey` for it using
+  big endian encoding. Then, use the wrapper instead of the int type in indices.
+  See the unit tests for `StorageKey` for an example.
+
 ### New features
+
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)
 
 ### Bug fixes
+
 - `ExonumJsonDeserialize` trait is implemented for `F32` and `F64`. (#461)
 
 ## 0.5.1 - 2018-02-01
 
 ### Bug fixes
+
 - Fixed logger output (#451)
 
 ## 0.5 - 2018-01-30
 
 ### Breaking changes
-- The order of bytes and bits in the `DBKey` keys of `ProofMapIndex` became consistent. The change influences how
-  Merkle Patricia trees are built for `ProofMapIndex`: the bits in each byte of a `DBKey` are now enumerated from the
-  least significant bit (LSB) to the most significant bit (MSB), compared to MSB-to-LSB ordering used before. Note:
-  this change will break old storages using map proofs. (#419)
-- The `Database` trait is simplified: it is no longer required to implement state-sharing `clone` method.
+
+- The order of bytes and bits in the `DBKey` keys of `ProofMapIndex` became
+  consistent. (#419)
+
+  The change influences how Merkle Patricia trees are built
+  for `ProofMapIndex`: the bits in each byte of a `DBKey` are now enumerated
+  from the least significant bit (LSB) to the most significant bit (MSB),
+  compared to MSB-to-LSB ordering used before.
+  Note: this change will break old storages using map proofs.
+- The `Database` trait is simplified: it is no longer required
+  to implement state-sharing `clone` method.
   Instead, the `merge` method now takes a shared reference to `self`. (#422)
-- `message!` and `encoding_struct!` no longer require manual `SIZE` and offset specification. (#413)
-- `from_raw(raw: RawMessage)`  method is moved to the `Message` trait. To migrate, add `use exonum::messages::Message`.
-  (#427)
-- Changed iterators over `Patch` and `Changes` data into custom types instead of standard collection iterators. (#393)
+- `message!` and `encoding_struct!` no longer require manual `SIZE`
+  and offset specification. (#413)
+- `from_raw(raw: RawMessage)`  method is moved to the `Message` trait.
+  To migrate, add `use exonum::messages::Message`. (#427)
+- Changed iterators over `Patch` and `Changes` data into custom types instead
+  of standard collection iterators. (#393)
 - Fixed typo in `SparceListIndexKeys` and `SparceListIndexValues`. (#398)
 - Removed default `state_hash` implementation in the `Service` trait. (#399)
 - Removed `info` method from the `Transaction`. (#402)
-- Replaced config param `timeout_events_capacity` with `internal_events_capacity`. (#388)
+- Replaced config param `timeout_events_capacity` with
+  `internal_events_capacity`. (#388)
 - The `Transaction` trait now inherits from `ExonumJson`. (#402)
-- Renamed `DBKey` to `ProofPath` and moved a part of its functionality to the `BitsRange` trait. (#420)
+- Renamed `DBKey` to `ProofPath` and moved a part of its functionality
+  to the `BitsRange` trait. (#420)
 
 ### New features
+
 - Added `patch` method to the `Fork` structure. (#393)
 - Added a public `healthcheck` endpoint. (#405)
-- Added serialization support of floating point types through special wrapper (`F32` and `F64`). This feature is hidden
-  behind `float_serialize` gate. Note: special values (Infinity and NaN) aren't supported. (#384)
-- Added a possibility to set maximum message size (`pub max_message_len` field in `ConsensusConfig`). (#426)
+- Added serialization support of floating point types through special wrapper
+  (`F32` and `F64`). This feature is hidden behind `float_serialize` gate.
+  Note: special values (Infinity and NaN) aren't supported. (#384)
+- Added a possibility to set maximum message size (`pub max_message_len`
+  field in `ConsensusConfig`). (#426)
 - Added support for CORS. (#406)
-- Added `run-dev` command that performs a simplified node launch for testing purposes. (#423)
+- Added `run-dev` command that performs a simplified node launch
+  for testing purposes. (#423)
 
 ### Bug fixes
+
 - Fixed consensus on the threshold of 1/3 sleeping validators. (#388)
 - Fixed a bunch of inconsistencies and mistakes in the docs. (#439)
 - Fixed a bug with message header validation. (#430)
 
 ### Internal improvements
-- The list of peer connections is now restored to the latest state after the process is restarted. (#378)
-- Log dependency was updated to 0.4, which can cause issues with the previous versions. (#433)
+
+- The list of peer connections is now restored to the latest state
+  after the process is restarted. (#378)
+- Log dependency was updated to 0.4, which can cause issues
+  with the previous versions. (#433)
 - Better error reporting for configs in the `.toml` format. (#429)
 
 ## 0.4 - 2017-12-08
 
 ### Added
+
 - Allow creating auditor node from command line. (#364)
-- Added a new function `merge_sync`. In this function a write will be flushed from the operating system buffer cache
+- Added a new function `merge_sync`. In this function a write will be flushed
+  from the operating system buffer cache
   before the write is considered complete. (#368)
-- Added conversion into boxed values for values which implement `Service` or `Transaction` traits. (#366)
-- Added constructor for the `ServiceContext` which can be useful for the alternative node implementations. (#366)
-- Implemented `AsRef<RawMessage>` for any Exonum messages that were created using the `message!` macro. (#372)
+- Added conversion into boxed values for values which implement `Service`
+  or `Transaction` traits. (#366)
+- Added constructor for the `ServiceContext` which can be useful
+  for the alternative node implementations. (#366)
+- Implemented `AsRef<RawMessage>` for any Exonum messages that were
+  created using the `message!` macro. (#372)
 - Implemented additional checks for conversion from raw message. (#372)
 
 ### Changed
-- Changed a signature of `open` function in a `rocksdb` module. `RocksDBOptions` should pass by the reference. (#369)
+
+- Changed a signature of `open` function in a `rocksdb` module.
+  `RocksDBOptions` should pass by the reference. (#369)
 - `ValidatorState` in the `ServiceContext` replaced by the `ValidatorId`. (#366)
-- `add_transaction` in the `ServiceContext` replaced by the `transaction_sender` which implements the `TransactionSend`
-  trait. (#366)
-- The `Node` constructor now requires `db` and `services` variables instead of `blockchain` instance. (#366)
-- The `Blockchain` constructor now requires services keypair and an `ApiSender` instance. (#366)
-- `mount_*_api` methods in `Blockchain` instance now do not require `ApiContext`. (#366)
+- `add_transaction` in the `ServiceContext` replaced by the `transaction_sender`
+  which implements the `TransactionSend` trait. (#366)
+- The `Node` constructor now requires `db` and `services` variables
+  instead of `blockchain` instance. (#366)
+- The `Blockchain` constructor now requires services keypair
+  and an `ApiSender` instance. (#366)
+- `mount_*_api` methods in `Blockchain` instance now
+  do not require `ApiContext`. (#366)
 - Rename method `last_height` to `height` in `Schema`. (#379)
 - `last_block` now returns `Block` instead of `Option<Block>`. (#379)
 - Replaced `rocksdb` commandline parameter to more generic `db-path`. (#376)
@@ -96,30 +136,39 @@ All notable changes to this project will be documented in this file. The project
 - Help text is displayed if required argument is not specified. (#390)
 
 ### Removed
+
 - Removed `round` method from the `ServiceContext`. (#366)
 - Removed redundant `FromRaw` trait. (#372)
 - Removed redundant `current_height` method in `Schema`. (#379)
 
 ### Fixed
-- Fixed `crate_authors!` macro usage, this macro can't return static string in new clap version. (#370)
+
+- Fixed `crate_authors!` macro usage, this macro can't return static string
+  in new clap version. (#370)
 - Fixed mistake in description of the height getter in the `ServiceContext`. (#366)
 - Fixed #15 consensus on the threshold of 1/3 sleeping validators. (#388)
 
 ## 0.3 - 2017-11-02
 
 ### Added
-- New events implementation based on the `tokio` with the separated queues for network events and timeouts and
-  different threads for the network and node code (#300)
-- Added a new index `SparseListIndex`. It is a list of items stored in sequential order. Similar to `ListIndex` but it
-  may contain indexes without elements (#312)
+
+- New events implementation based on the `tokio` with the separated queues
+  for network events and timeouts and different threads for the network
+  and node code (#300)
+- Added a new index `SparseListIndex`. It is a list of items stored
+  in sequential order. Similar to `ListIndex` but it may contain
+  indexes without elements (#312)
 - Implement `FromStr` and `ToString` traits for public sodium types (#318)
 - Add a new macro `metric!` for collecting statistical information (#329)
 - Make type `DBKey` public because it is used in `MapProof` (#306)
 
 ### Changed
+
 - `RocksDB` is a default storage (#178)
-- Field `events_pool_capacity` in `MemoryPoolConfig` replaced by the new `EventsPoolCapacity` configuration (#300)
-- Changed a build method `new` and added a new build method `with_prefix` for indexes (#178)
+- Field `events_pool_capacity` in `MemoryPoolConfig` replaced
+  by the new `EventsPoolCapacity` configuration (#300)
+- Changed a build method `new` and added a new build method `with_prefix`
+  for indexes (#178)
 - Changed a signature of `gen_prefix` function in a `schema` module (#178)
 - `NodeBuilder` works with `ServiceFactory` as trait object instead (#357)
 - Debug formatting for crypto types are improved (#353)
@@ -127,15 +176,18 @@ All notable changes to this project will be documented in this file. The project
 - Clarified `Transaction.info()` usage (#345)
 
 ### Removed
+
 - Support of `LevelDB` is removed (#178)
 
 ### Fixed
+
 - Fix the issue causing timeouts are ignored when the event pool is full (#300)
 - Fix network failure due to incorrect processing of the incoming buffer (#322)
 
 ## 0.2 - 2017-09-13
 
 ### Added
+
 - Add `RockDB` support (#273)
 - Add `TimeoutAdjusterConfig`, `Constant` and `Dynamic` timeout adjusters (#256)
 - Add stream hashing and signing: `HashStream` and `SignStream` (#254)
@@ -144,23 +196,29 @@ All notable changes to this project will be documented in this file. The project
 - Public export of `PROOF_MAP_KEY_SIZE` constant (#270)
 
 ### Changed
-- `MapProof` variant fields are renamed: `left_hash` and `right_hash` to `left_node` and
-  `right_node` (#286)
-- `RequestBlock` is renamed to `BlockRequest` and `Block` is renamed to `BlockResponse` (#287)
+
+- `MapProof` variant fields are renamed: `left_hash` and `right_hash`
+  to `left_node` and `right_node` (#286)
+- `RequestBlock` is renamed to `BlockRequest` and `Block`
+  is renamed to `BlockResponse` (#287)
 - All request messages are renamed: `RequestFoo` to `FooRequest` (#287)
 - Improve log formatting (#291 #294)
 - Make panic message during command line arguments parsing cleaner (#257)
 
 ### Fixed
-- Fix network discover failure due to incorrect processing of the incoming buffer (#299)
+
+- Fix network discover failure due to incorrect processing
+  of the incoming buffer (#299)
 - Fix snapshot behavior for `MemoryDB` (#292)
 - Dissalow generate-testnet with 0 nodes (#258)
 
 ## 0.1.1 - 2017-09-13
 
 ### Fixed
+
 - Fix segfault when `LevelDBSnapshot` is destroyed after `LevelDB` (#285)
-- Fix panic during `BlockResponse` message processing if the transaction pool is full (#264)
+- Fix panic during `BlockResponse` message processing
+  if the transaction pool is full (#264)
 - Fix panic during deseralizaion of malformed messages (#278 #297)
 
 ## 0.1 - 2017-07-17

--- a/exonum/README.md
+++ b/exonum/README.md
@@ -3,11 +3,12 @@
 [![Build Status](https://travis-ci.org/exonum/exonum.svg?branch=master)](https://travis-ci.org/exonum/exonum)
 [![Join the chat at https://gitter.im/exonum/exonum](https://badges.gitter.im/exonum/exonum.svg)](https://gitter.im/exonum/exonum)
 
-[Exonum](https://exonum.com/) is an extensible open-source framework for creating blockchain
-applications. Exonum can be used to create cryptographically powered distributed ledgers in
-virtually any problem domain, including FinTech, GovTech, and LegalTech. The Exonum framework is
-oriented towards creating permissioned blockchains, that is, blockchains with the known set of
-blockchain infrastructure providers.
+[Exonum](https://exonum.com/) is an extensible open-source framework for
+creating blockchain applications. Exonum can be used to create cryptographically
+powered distributed ledgers in virtually any problem domain, including FinTech,
+GovTech, and LegalTech. The Exonum framework is oriented towards creating
+permissioned blockchains, that is, blockchains with the known set of blockchain
+infrastructure providers.
 
 * [What is Exonum?](https://exonum.com/doc/get-started/what-is-exonum/)
 * [Design Overview](https://exonum.com/doc/get-started/design-overview/)
@@ -21,4 +22,7 @@ blockchain infrastructure providers.
 
 ## LICENSE
 
-Exonum core library is licensed under the Apache License (Version 2.0). See [LICENSE](https://github.com/exonum/exonum/blob/master/LICENSE) for details.
+Exonum core library is licensed under the Apache License (Version 2.0).
+See [LICENSE] for details.
+
+[LICENSE]: https://github.com/exonum/exonum/blob/master/LICENSE

--- a/testkit/CHANGELOG.md
+++ b/testkit/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 0.5.0 - 2018-01-30
 
 ### Added
+
 - Added `rollback()` method for `TestKit` allowing to rollback blocks added to
   the testkit blockchain. (#8)
 - Added `TestKit::create_block_with_transaction()` method. (#13)
@@ -25,7 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Added missing documentation for `ApiKind` and improved documentation quality. (#15)
-- Fixed `TestKitApi::get_private` method, which wrongly used public API previously. (#25)
+- Fixed `TestKitApi::get_private` method, which wrongly used public API
+    previously. (#25)
 
 ## 0.1.1 - 2017-12-14
 

--- a/testkit/README.md
+++ b/testkit/README.md
@@ -5,9 +5,10 @@
 [![Build status][appveyor-image]][appveyor-url]
 [![Gitter][gitter-image]][gitter-url]
 
-Testkit for Exonum blockchain is a framework that allows to test operation of the whole service.
-Specifically, it allows to test transaction execution and APIs in the synchronous environment
-(without consensus algorithm) and in the same system process.
+Testkit for Exonum blockchain is a framework that allows to test operation
+of the whole service. Specifically, it allows to test transaction execution
+and APIs in the synchronous environment (without consensus algorithm)
+and in the same system process.
 
 ## Usage
 
@@ -22,8 +23,8 @@ exonum-testkit = "0.5.0"
 
 ## Examples
 
-See the [**tests**](tests) and [**examples**](examples) folders for examples of building a
-service and then testing it with the testkit.
+See the [**tests**](tests) and [**examples**](examples) folders for examples
+of building a service and then testing it with the testkit.
 
 ## License
 


### PR DESCRIPTION
This PR adds [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) pass to travis builds.

[Initial list of warnings](https://gist.github.com/anonymous/923155c83e6a2c7f9470fc9d8f4969c0) (before any fixes)

Most of the warnings were fixed, though some were disabled through the config as not fitting to our use case:

- no-duplicate-header - causes problems in changelogs
- first-header-h1 and first-line-h1 - cause problems with issue/PR templates

The linter is lauched using the following command:

`find . -not -path "./3rdparty/*" -name "*.md" | xargs markdownlint --config .markdownlintrc`

`./3rdparty` directory is ignored.