### PR TITLE
Specify Rust version for CI explicitelly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ addons:
     - librocksdb
 
 rust:
-  - stable
+  # Feel free to bump this version if you need features of newer Rust.
+  # Sync with badge in README.md
+  - 1.23.0
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/exonum/exonum.svg?branch=master)](https://travis-ci.org/exonum/exonum)
 [![Join the chat at https://gitter.im/exonum/exonum](https://badges.gitter.im/exonum/exonum.svg)](https://gitter.im/exonum/exonum)
+![rust 1.23+ required](https://img.shields.io/badge/rust-1.23+-blue.svg)
+<!--sync ^ with .travis.yml-->
 
 [Exonum](https://exonum.com/) is an extensible open-source framework for
 creating blockchain applications. Exonum can be used to create cryptographically


### PR DESCRIPTION
Let's pin a specific version of Rust, so that we *know* which is the minimal supported version.