### PR TITLE
Use failure for error handling

### DIFF
--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -15,6 +15,7 @@ byteorder
 checkpointed
 clippy
 clonned
+compat
 concat
 counterintuitive
 cryptocurrency

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -44,6 +44,21 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   - Remove `ID` constants.
   - Replace `TYPE` constants with a single `SERVICE_ID` constant.
 
+- Several variants were removed from `ApiError` enum. (#474)
+
+  Migration path:
+
+  - Use generic `ApiError::BadRequest` variant or create `IronError` directly.
+
+- `CommandExtension` uses `failure::Error` instead of `Box<std::error::Error>`
+  for errors. (#474)
+
+  Migration path:
+
+  - `std::error::Error` can be converted to `failure::Error` via `.into()` method.
+
+- `storage::Error` implements `failure::Fail` instead of `std::error::Error`. (#474)
+
 ### New features
 
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -63,6 +63,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)
 - `StorageValue` and `CryptoHash` traits are implemented for `bool`. (#385)
+- `Height` implements `std::str::FromStr`. (#474)
 
 ### Bug fixes
 

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -44,6 +44,8 @@ tokio-core = "0.1.9"
 tokio-io = "0.1.2"
 tokio-retry = "0.1.0"
 tokio-timer = "0.1.2"
+failure = "0.1.1"
+failure_derive = "0.1.1"
 
 exonum_rocksdb = "0.7"
 exonum_sodiumoxide = "0.0.16"

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -45,7 +45,6 @@ tokio-io = "0.1.2"
 tokio-retry = "0.1.0"
 tokio-timer = "0.1.2"
 failure = "0.1.1"
-failure_derive = "0.1.1"
 
 exonum_rocksdb = "0.7"
 exonum_sodiumoxide = "0.0.16"

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -277,7 +277,7 @@ where
     let fragment = params.find(name).ok_or_else(|| {
         ApiError::BadRequest(format!("Required parameter '{}' is missing", name))
     })?;
-    let value: T = T::from_str(fragment).map_err(|e| {
+    let value = T::from_str(fragment).map_err(|e| {
         ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e))
     })?;
     Ok(value)
@@ -291,7 +291,7 @@ where
     let map = request.get_ref::<params::Params>().unwrap();
     let value = match map.find(&[name]) {
         Some(&params::Value::String(ref param)) => {
-            let value: T = T::from_str(param).map_err(|e| {
+            let value = T::from_str(param).map_err(|e| {
                 ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e))
             })?;
             Some(value)

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -106,7 +106,7 @@ impl From<ApiError> for IronError {
             let mut map = BTreeMap::new();
             map.insert("debug", format!("{:?}", e));
             map.insert("description", e.to_string());
-            ::serde_json::to_string_pretty(&map).unwrap()
+            serde_json::to_string_pretty(&map).unwrap()
         };
         IronError::new(e.compat(), (code, body))
     }

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -282,7 +282,7 @@ pub trait Api {
 fn url_fragment<T>(request: &Request, name: &str) -> Result<T, ApiError>
 where
     T: FromStr,
-    T::Err: ::std::error::Error + Send + Sync + 'static,
+    T::Err: fmt::Display,
 {
     let params = request.extensions.get::<Router>().unwrap();
     let fragment = params.find(name).ok_or_else(|| {
@@ -297,7 +297,7 @@ where
 fn optional_param<T>(request: &mut Request, name: &str) -> Result<Option<T>, ApiError>
 where
     T: FromStr,
-    T::Err: ::std::error::Error + Send + Sync + 'static,
+    T::Err: fmt::Display,
 {
     let map = request.get_ref::<params::Params>().unwrap();
     let value = match map.find(&[name]) {
@@ -315,7 +315,7 @@ where
 fn required_param<T>(request: &mut Request, name: &str) -> Result<T, ApiError>
 where
     T: FromStr,
-    T::Err: ::std::error::Error + Send + Sync + 'static,
+    T::Err: fmt::Display,
 {
     optional_param(request, name)?.ok_or_else(|| {
         ApiError::BadRequest(format!("Required parameter '{}' is missing", name))

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -46,11 +46,17 @@ mod tests;
 pub enum ApiError {
     /// Storage error.
     #[fail(display = "Storage error: {}", _0)]
-    Storage(#[cause] storage::Error),
+    Storage(
+        #[cause]
+        storage::Error
+    ),
 
     /// Input/output error.
     #[fail(display = "IO error: {}", _0)]
-    Io(#[cause] ::std::io::Error),
+    Io(
+        #[cause]
+        ::std::io::Error
+    ),
 
     /// File not found.
     #[fail(display = "File not found")]
@@ -103,15 +109,15 @@ impl From<ApiError> for IronError {
             ApiError::FileNotFound(hash) => {
                 body.insert("hash", encode_hex(&hash));
                 status::Conflict
-            },
+            }
             ApiError::BadRequest(..) => status::BadRequest,
             ApiError::InternalError(..) => status::InternalServerError,
             _ => status::Conflict,
         };
-        IronError::new(
-            e.compat(),
-            (code, ::serde_json::to_string_pretty(&body).unwrap())
-        )
+        IronError::new(e.compat(), (
+            code,
+            ::serde_json::to_string_pretty(&body).unwrap(),
+        ))
     }
 }
 

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -59,8 +59,8 @@ pub enum ApiError {
     FileTooBig,
     /// File already exists.
     FileExists(Hash),
-    /// Incorrect request.
-    IncorrectRequest(Box<::std::error::Error + Send + Sync>),
+    /// Bad request.
+    BadRequest(Box<::std::error::Error + Send + Sync>),
     /// Unauthorized error.
     Unauthorized,
     /// Address parse error.
@@ -79,7 +79,7 @@ impl ::std::error::Error for ApiError {
     fn description(&self) -> &str {
         match *self {
             ApiError::Service(ref error) |
-            ApiError::IncorrectRequest(ref error) => error.description(),
+            ApiError::BadRequest(ref error) => error.description(),
             ApiError::Storage(ref error) => "storage error", //FIXME
             ApiError::FromHex(ref error) => error.description(),
             ApiError::Io(ref error) => error.description(),
@@ -130,7 +130,8 @@ impl From<ApiError> for IronError {
             ApiError::FileNotFound(hash) => {
                 body.insert("hash", encode_hex(&hash));
                 status::Conflict
-            }
+            },
+            ApiError::BadRequest(..) => status::BadRequest,
             _ => status::Conflict,
         };
         IronError {

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -62,8 +62,6 @@ pub enum ApiError {
     BadRequest(Box<::std::error::Error + Send + Sync>),
     /// Unauthorized error.
     Unauthorized,
-    /// Address parse error.
-    AddressParseError(::std::net::AddrParseError),
     /// Serialize error,
     Serialize(Box<::std::error::Error + Send + Sync>),
 }
@@ -71,12 +69,6 @@ pub enum ApiError {
 impl fmt::Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl From<::std::net::AddrParseError> for ApiError {
-    fn from(e: ::std::net::AddrParseError) -> ApiError {
-        ApiError::AddressParseError(e)
     }
 }
 

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -78,7 +78,7 @@ pub enum ApiError {
 
     /// Bad request.
     #[fail(display = "Bad request: {}", _0)]
-    BadRequest(Box<::std::error::Error + Send + Sync>),
+    BadRequest(String),
 
     /// Internal error.
     #[fail(display = "Internal server error: {}", _0)]
@@ -286,10 +286,10 @@ where
 {
     let params = request.extensions.get::<Router>().unwrap();
     let fragment = params.find(name).ok_or_else(|| {
-        ApiError::BadRequest(format!("Required parameter '{}' is missing", name).into())
+        ApiError::BadRequest(format!("Required parameter '{}' is missing", name))
     })?;
     let value: T = T::from_str(fragment).map_err(|e| {
-        ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e).into())
+        ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e))
     })?;
     Ok(value)
 }
@@ -303,7 +303,7 @@ where
     let value = match map.find(&[name]) {
         Some(&params::Value::String(ref param)) => {
             let value: T = T::from_str(param).map_err(|e| {
-                ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e).into())
+                ApiError::BadRequest(format!("Invalid '{}' parameter: {}", name, e))
             })?;
             Some(value)
         }
@@ -318,6 +318,6 @@ where
     T::Err: ::std::error::Error + Send + Sync + 'static,
 {
     optional_param(request, name)?.ok_or_else(|| {
-        ApiError::BadRequest(format!("Required parameter '{}' is missing", name).into())
+        ApiError::BadRequest(format!("Required parameter '{}' is missing", name))
     })
 }

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -47,9 +47,9 @@ pub enum ApiError {
     /// Service error.
     Service(Box<::std::error::Error + Send + Sync>),
     /// Storage error.
-    Storage(storage::Error),
+    Storage(#[cause] storage::Error),
     /// Input/output error.
-    Io(::std::io::Error),
+    Io(#[cause]::std::io::Error),
     /// File not found.
     FileNotFound(Hash),
     /// Not found.

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -44,32 +44,41 @@ mod tests;
 /// List of possible Api errors.
 #[derive(Fail, Debug)]
 pub enum ApiError {
-    /// Service error.
-    Service(Box<::std::error::Error + Send + Sync>),
     /// Storage error.
+    #[fail(display = "Storage error: {}", _0)]
     Storage(#[cause] storage::Error),
-    /// Input/output error.
-    Io(#[cause]::std::io::Error),
-    /// File not found.
-    FileNotFound(Hash),
-    /// Not found.
-    NotFound,
-    /// File too big.
-    FileTooBig,
-    /// File already exists.
-    FileExists(Hash),
-    /// Bad request.
-    BadRequest(Box<::std::error::Error + Send + Sync>),
-    /// Unauthorized error.
-    Unauthorized,
-    /// Serialize error,
-    Serialize(Box<::std::error::Error + Send + Sync>),
-}
 
-impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
+    /// Input/output error.
+    #[fail(display = "IO error: {}", _0)]
+    Io(#[cause] ::std::io::Error),
+
+    /// File not found.
+    #[fail(display = "File not found")]
+    FileNotFound(Hash),
+
+    /// Not found.
+    #[fail(display = "Not found")]
+    NotFound,
+
+    /// File too big.
+    #[fail(display = "File too big")]
+    FileTooBig,
+
+    /// File already exists.
+    #[fail(display = "File exists")]
+    FileExists(Hash),
+
+    /// Bad request.
+    #[fail(display = "Bad request: {}", _0)]
+    BadRequest(Box<::std::error::Error + Send + Sync>),
+
+    /// Internal error.
+    #[fail(display = "Internal server error: {}", _0)]
+    InternalError(Box<::std::error::Error + Send + Sync>),
+
+    /// Unauthorized error.
+    #[fail(display = "Unauthorized")]
+    Unauthorized,
 }
 
 impl From<io::Error> for ApiError {
@@ -96,6 +105,7 @@ impl From<ApiError> for IronError {
                 status::Conflict
             },
             ApiError::BadRequest(..) => status::BadRequest,
+            ApiError::InternalError(..) => status::InternalServerError,
             _ => status::Conflict,
         };
         IronError::new(

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -48,8 +48,6 @@ pub enum ApiError {
     Service(Box<::std::error::Error + Send + Sync>),
     /// Storage error.
     Storage(storage::Error),
-    /// Converting from hex error.
-    FromHex(FromHexError),
     /// Input/output error.
     Io(::std::io::Error),
     /// File not found.
@@ -91,12 +89,6 @@ impl From<io::Error> for ApiError {
 impl From<storage::Error> for ApiError {
     fn from(e: storage::Error) -> ApiError {
         ApiError::Storage(e)
-    }
-}
-
-impl From<FromHexError> for ApiError {
-    fn from(e: FromHexError) -> ApiError {
-        ApiError::FromHex(e)
     }
 }
 

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -21,7 +21,7 @@ use iron::prelude::*;
 use crypto::PublicKey;
 use node::{ExternalMessage, ApiSender};
 use blockchain::{Service, Blockchain, SharedNodeState};
-use api::{self, Api, ApiError};
+use api::{Api, ApiError};
 use messages::{TEST_NETWORK_ID, PROTOCOL_MAJOR_VERSION};
 
 #[derive(Serialize, Clone, Debug)]
@@ -162,7 +162,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let peer_add = move |req: &mut Request| -> IronResult<Response> {
-            let addr: SocketAddr = api::required_param(req, "ip")?;
+            let addr: SocketAddr = self_.required_param(req, "ip")?;
             self_.node_channel.peer_add(addr).map_err(ApiError::from)?;
             self_.ok_response(&::serde_json::to_value("Ok").unwrap())
         };
@@ -187,7 +187,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let consensus_enabled_set = move |req: &mut Request| -> IronResult<Response> {
-            let enabled: bool = api::required_param(req, "enabled")?;
+            let enabled: bool = self_.required_param(req, "enabled")?;
             self_.set_consensus_enabled_info(enabled)?;
             self_.ok_response(&::serde_json::to_value("Ok").unwrap())
         };

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -176,7 +176,7 @@ impl Api for SystemApi {
                     self_.ok_response(&::serde_json::to_value("Ok").unwrap())
                 }
                 _ => {
-                    Err(ApiError::IncorrectRequest(
+                    Err(ApiError::BadRequest(
                         "Required parameter of peer 'ip' is missing".into(),
                     ))?
                 }
@@ -210,7 +210,7 @@ impl Api for SystemApi {
                     self_.ok_response(&::serde_json::to_value("Ok").unwrap())
                 }
                 _ => {
-                    Err(ApiError::IncorrectRequest(
+                    Err(ApiError::BadRequest(
                         "Required boolean parameter 'enabled' is missing".into(),
                     ))?
                 }

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -21,7 +21,7 @@ use iron::prelude::*;
 use crypto::PublicKey;
 use node::{ExternalMessage, ApiSender};
 use blockchain::{Service, Blockchain, SharedNodeState};
-use api::{Api, ApiError, required_param};
+use api::{self, Api, ApiError};
 use messages::{TEST_NETWORK_ID, PROTOCOL_MAJOR_VERSION};
 
 #[derive(Serialize, Clone, Debug)]
@@ -162,7 +162,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let peer_add = move |req: &mut Request| -> IronResult<Response> {
-            let addr: SocketAddr = required_param(req, "ip")?;
+            let addr: SocketAddr = api::required_param(req, "ip")?;
             self_.node_channel.peer_add(addr).map_err(ApiError::from)?;
             self_.ok_response(&::serde_json::to_value("Ok").unwrap())
         };
@@ -187,7 +187,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let consensus_enabled_set = move |req: &mut Request| -> IronResult<Response> {
-            let enabled: bool = required_param(req, "enabled")?;
+            let enabled: bool = api::required_param(req, "enabled")?;
             self_.set_consensus_enabled_info(enabled)?;
             self_.ok_response(&::serde_json::to_value("Ok").unwrap())
         };

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -17,7 +17,7 @@ use iron::prelude::*;
 
 use blockchain::{Blockchain, Block};
 use explorer::{BlockInfo, BlockchainExplorer};
-use api::{Api, ApiError, url_fragment, required_param, optional_param};
+use api::{self, Api, ApiError};
 use helpers::Height;
 
 const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
@@ -61,17 +61,17 @@ impl Api for ExplorerApi {
 
         let self_ = self.clone();
         let blocks = move |req: &mut Request| -> IronResult<Response> {
-            let count: u64 = required_param(req, "count")?;
-            let latest: Option<u64> = optional_param(req, "latest")?;
-            let skip_empty_blocks: bool =
-                optional_param(req, "skip_empty_blocks")?.unwrap_or(false);
+            let count: u64 = api::required_param(req, "count")?;
+            let latest: Option<u64> = api::optional_param(req, "latest")?;
+            let skip_empty_blocks: bool = api::optional_param(req, "skip_empty_blocks")?
+                .unwrap_or(false);
             let info = self_.get_blocks(count, latest, skip_empty_blocks)?;
             self_.ok_response(&::serde_json::to_value(info).unwrap())
         };
 
         let self_ = self.clone();
         let block = move |req: &mut Request| -> IronResult<Response> {
-            let height: u64 = url_fragment(req, "height")?;
+            let height: u64 = api::url_fragment(req, "height")?;
             let info = self_.get_block(Height(height))?;
             self_.ok_response(&::serde_json::to_value(info).unwrap())
         };

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::ParseIntError;
-use std::str::ParseBoolError;
-
-use params::{Params, Value};
 use router::Router;
 use iron::prelude::*;
 
 use blockchain::{Blockchain, Block};
 use explorer::{BlockInfo, BlockchainExplorer};
-use api::{Api, ApiError, url_fragment};
+use api::{Api, ApiError, url_fragment, required_param, optional_param};
 use helpers::Height;
 
 const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
@@ -67,35 +63,10 @@ impl Api for ExplorerApi {
 
         let self_ = self.clone();
         let blocks = move |req: &mut Request| -> IronResult<Response> {
-            let map = req.get_ref::<Params>().unwrap();
-            let count: u64 = match map.find(&["count"]) {
-                Some(&Value::String(ref count_str)) => {
-                    count_str.parse().map_err(|e: ParseIntError| {
-                        ApiError::BadRequest(Box::new(e))
-                    })?
-                }
-                _ => {
-                    return Err(ApiError::BadRequest(
-                        "Required parameter of blocks 'count' is missing".into(),
-                    ))?;
-                }
-            };
-            let latest: Option<u64> = match map.find(&["latest"]) {
-                Some(&Value::String(ref from_str)) => {
-                    Some(from_str.parse().map_err(|e: ParseIntError| {
-                        ApiError::BadRequest(Box::new(e))
-                    })?)
-                }
-                _ => None,
-            };
-            let skip_empty_blocks: bool = match map.find(&["skip_empty_blocks"]) {
-                Some(&Value::String(ref skip_str)) => {
-                    skip_str.parse().map_err(|e: ParseBoolError| {
-                        ApiError::BadRequest(Box::new(e))
-                    })?
-                }
-                _ => false,
-            };
+            let count: u64 = required_param(req, "count")?;
+            let latest: Option<u64> = optional_param(req, "latest")?;
+            let skip_empty_blocks: bool =
+                optional_param(req, "skip_empty_blocks")?.unwrap_or(false);
             let info = self_.get_blocks(count, latest, skip_empty_blocks)?;
             self_.ok_response(&::serde_json::to_value(info).unwrap())
         };

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -45,7 +45,7 @@ impl ExplorerApi {
         skip_empty_blocks: bool,
     ) -> Result<Vec<Block>, ApiError> {
         if count > MAX_BLOCKS_PER_REQUEST {
-            return Err(ApiError::IncorrectRequest(
+            return Err(ApiError::BadRequest(
                 format!(
                     "Max block count per request exceeded ({})",
                     MAX_BLOCKS_PER_REQUEST
@@ -71,11 +71,11 @@ impl Api for ExplorerApi {
             let count: u64 = match map.find(&["count"]) {
                 Some(&Value::String(ref count_str)) => {
                     count_str.parse().map_err(|e: ParseIntError| {
-                        ApiError::IncorrectRequest(Box::new(e))
+                        ApiError::BadRequest(Box::new(e))
                     })?
                 }
                 _ => {
-                    return Err(ApiError::IncorrectRequest(
+                    return Err(ApiError::BadRequest(
                         "Required parameter of blocks 'count' is missing".into(),
                     ))?;
                 }
@@ -83,7 +83,7 @@ impl Api for ExplorerApi {
             let latest: Option<u64> = match map.find(&["latest"]) {
                 Some(&Value::String(ref from_str)) => {
                     Some(from_str.parse().map_err(|e: ParseIntError| {
-                        ApiError::IncorrectRequest(Box::new(e))
+                        ApiError::BadRequest(Box::new(e))
                     })?)
                 }
                 _ => None,
@@ -91,7 +91,7 @@ impl Api for ExplorerApi {
             let skip_empty_blocks: bool = match map.find(&["skip_empty_blocks"]) {
                 Some(&Value::String(ref skip_str)) => {
                     skip_str.parse().map_err(|e: ParseBoolError| {
-                        ApiError::IncorrectRequest(Box::new(e))
+                        ApiError::BadRequest(Box::new(e))
                     })?
                 }
                 _ => false,
@@ -106,13 +106,13 @@ impl Api for ExplorerApi {
             match params.find("height") {
                 Some(height_str) => {
                     let height: u64 = height_str.parse().map_err(|e: ParseIntError| {
-                        ApiError::IncorrectRequest(Box::new(e))
+                        ApiError::BadRequest(Box::new(e))
                     })?;
                     let info = self_.get_block(Height(height))?;
                     self_.ok_response(&::serde_json::to_value(info).unwrap())
                 }
                 None => {
-                    Err(ApiError::IncorrectRequest(
+                    Err(ApiError::BadRequest(
                         "Required parameter of block 'height' is missing".into(),
                     ))?
                 }

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -17,7 +17,7 @@ use iron::prelude::*;
 
 use blockchain::{Blockchain, Block};
 use explorer::{BlockInfo, BlockchainExplorer};
-use api::{self, Api, ApiError};
+use api::{Api, ApiError};
 use helpers::Height;
 
 const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
@@ -61,9 +61,10 @@ impl Api for ExplorerApi {
 
         let self_ = self.clone();
         let blocks = move |req: &mut Request| -> IronResult<Response> {
-            let count: u64 = api::required_param(req, "count")?;
-            let latest: Option<u64> = api::optional_param(req, "latest")?;
-            let skip_empty_blocks: bool = api::optional_param(req, "skip_empty_blocks")?
+            let count: u64 = self_.required_param(req, "count")?;
+            let latest: Option<u64> = self_.optional_param(req, "latest")?;
+            let skip_empty_blocks: bool = self_
+                .optional_param(req, "skip_empty_blocks")?
                 .unwrap_or(false);
             let info = self_.get_blocks(count, latest, skip_empty_blocks)?;
             self_.ok_response(&::serde_json::to_value(info).unwrap())
@@ -71,7 +72,7 @@ impl Api for ExplorerApi {
 
         let self_ = self.clone();
         let block = move |req: &mut Request| -> IronResult<Response> {
-            let height: u64 = api::url_fragment(req, "height")?;
+            let height: u64 = self_.url_fragment(req, "height")?;
             let info = self_.get_block(Height(height))?;
             self_.ok_response(&::serde_json::to_value(info).unwrap())
         };

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -41,12 +41,10 @@ impl ExplorerApi {
         skip_empty_blocks: bool,
     ) -> Result<Vec<Block>, ApiError> {
         if count > MAX_BLOCKS_PER_REQUEST {
-            return Err(ApiError::BadRequest(
-                format!(
-                    "Max block count per request exceeded ({})",
-                    MAX_BLOCKS_PER_REQUEST
-                ).into(),
-            ));
+            return Err(ApiError::BadRequest(format!(
+                "Max block count per request exceeded ({})",
+                MAX_BLOCKS_PER_REQUEST
+            )));
         }
         let explorer = BlockchainExplorer::new(&self.blockchain);
         Ok(explorer.blocks_range(count, from, skip_empty_blocks))

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -19,7 +19,7 @@ use node::state::TxPool;
 use blockchain::{Blockchain, SharedNodeState};
 use crypto::Hash;
 use explorer::{BlockchainExplorer, TxInfo};
-use api::{self, Api, ApiError};
+use api::{Api, ApiError};
 
 #[derive(Serialize)]
 struct MemPoolTxInfo {
@@ -107,7 +107,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let transaction = move |req: &mut Request| -> IronResult<Response> {
-            let hash: Hash = api::url_fragment(req, "hash")?;
+            let hash: Hash = self_.url_fragment(req, "hash")?;
             let info = self_.get_transaction(&hash)?;
             let result = match info {
                 MemPoolResult::Unknown => Self::not_found_response,

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -87,7 +87,7 @@ impl SystemApi {
                 },
                 |o| {
                     Ok(MemPoolResult::MemPool(MemPoolTxInfo {
-                        content: o.serialize_field().map_err(ApiError::Serialize)?,
+                        content: o.serialize_field().map_err(ApiError::InternalError)?,
                     }))
                 },
             )

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -120,7 +120,7 @@ impl Api for SystemApi {
                     result(&self_, &::serde_json::to_value(info).unwrap())
                 }
                 None => {
-                    Err(ApiError::IncorrectRequest(
+                    Err(ApiError::BadRequest(
                         "Required parameter of transaction 'hash' is missing".into(),
                     ))?
                 }

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -19,7 +19,7 @@ use node::state::TxPool;
 use blockchain::{Blockchain, SharedNodeState};
 use crypto::Hash;
 use explorer::{BlockchainExplorer, TxInfo};
-use api::{Api, ApiError, url_fragment};
+use api::{self, Api, ApiError};
 
 #[derive(Serialize)]
 struct MemPoolTxInfo {
@@ -107,7 +107,7 @@ impl Api for SystemApi {
 
         let self_ = self.clone();
         let transaction = move |req: &mut Request| -> IronResult<Response> {
-            let hash: Hash = url_fragment(req, "hash")?;
+            let hash: Hash = api::url_fragment(req, "hash")?;
             let info = self_.get_transaction(&hash)?;
             let result = match info {
                 MemPoolResult::Unknown => Self::not_found_response,

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -112,9 +112,7 @@ impl Api for SystemApi {
             match params.find("hash") {
                 Some(hash_str) => {
                     let hash = Hash::from_hex(hash_str).map_err(|e| {
-                        ApiError::BadRequest(
-                            format!("Invalid transaction hash, {}", e).into()
-                        )
+                        ApiError::BadRequest(format!("Invalid transaction hash, {}", e).into())
                     })?;
 
                     let info = self_.get_transaction(&hash)?;

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -71,7 +71,9 @@ impl<'a> BlockchainExplorer<'a> {
             None => None,
             Some(raw_tx) => {
                 let box_transaction = self.blockchain.tx_from_raw(raw_tx.clone()).ok_or_else(|| {
-                    ApiError::InternalError(format!("Service not found for tx: {:?}", raw_tx).into())
+                    ApiError::InternalError(
+                        format!("Service not found for tx: {:?}", raw_tx).into(),
+                    )
                 })?;
                 let content = box_transaction.serialize_field().map_err(
                     ApiError::InternalError,

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -71,10 +71,10 @@ impl<'a> BlockchainExplorer<'a> {
             None => None,
             Some(raw_tx) => {
                 let box_transaction = self.blockchain.tx_from_raw(raw_tx.clone()).ok_or_else(|| {
-                    ApiError::Service(format!("Service not found for tx: {:?}", raw_tx).into())
+                    ApiError::InternalError(format!("Service not found for tx: {:?}", raw_tx).into())
                 })?;
                 let content = box_transaction.serialize_field().map_err(
-                    ApiError::Serialize,
+                    ApiError::InternalError,
                 )?;
 
                 let location = schema.tx_location_by_tx_hash().get(tx_hash).expect(

--- a/exonum/src/helpers/fabric/internal.rs
+++ b/exonum/src/helpers/fabric/internal.rs
@@ -15,7 +15,6 @@
 // spell-checker:ignore exts
 
 use std::fmt;
-use std::error::Error;
 use std::collections::HashMap;
 
 use super::{Argument, CommandExtension, CommandName, Context};
@@ -27,20 +26,6 @@ pub enum Feedback {
     RunNode(Context),
     /// Do nothing
     None,
-}
-#[derive(Clone, Debug, Copy)]
-pub struct NotFoundInMap;
-
-impl Error for NotFoundInMap {
-    fn description(&self) -> &str {
-        "Expected Some in getting context."
-    }
-}
-
-impl fmt::Display for NotFoundInMap {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
 }
 
 /// `Command` trait is used to create sub-command for `NodeBuilder`.

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -15,6 +15,8 @@
 //! Common widely used type definitions.
 
 use std::fmt;
+use std::str::FromStr;
+use std::num::ParseIntError;
 
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
@@ -321,6 +323,14 @@ impl<'de> Deserialize<'de> for Height {
     {
 
         Ok(Height(u64::deserialize(deserializer)?))
+    }
+}
+
+impl FromStr for Height {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Height, ParseIntError> {
+        u64::from_str(s).map(Height)
     }
 }
 

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -58,6 +58,8 @@ extern crate tokio_timer;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_retry;
+#[macro_use]
+extern crate failure;
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -15,7 +15,7 @@
 //! An implementation of `Error` type.
 
 /// The error type for I/O operations with storage.
-#[derive(Fail, Debug)]
+#[derive(Fail, Debug, Clone)]
 #[fail(display = "{}", message)]
 pub struct Error {
     message: String,

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -14,11 +14,9 @@
 
 //! An implementation of `Error` type.
 
-use std::fmt;
-use std::error;
-
 /// The error type for I/O operations with storage.
-#[derive(Debug, Clone)]
+#[derive(Fail, Debug)]
+#[fail(display = "{}", message)]
 pub struct Error {
     message: String,
 }
@@ -35,17 +33,5 @@ impl Error {
     /// ```
     pub fn new<T: Into<String>>(message: T) -> Error {
         Error { message: message.into() }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Storage error: {}", self.message)
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        &self.message
     }
 }

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -143,8 +143,8 @@ impl CounterApi {
                 let json = TransactionResponse { tx_hash };
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
-            Ok(None) => Err(ApiError::IncorrectRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::IncorrectRequest(Box::new(e)))?,
+            Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
+            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
         }
     }
 
@@ -168,8 +168,8 @@ impl CounterApi {
                 let json = TransactionResponse { tx_hash };
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
-            Ok(None) => Err(ApiError::IncorrectRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::IncorrectRequest(Box::new(e)))?,
+            Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
+            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
         }
     }
 

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -144,7 +144,7 @@ impl CounterApi {
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
             Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
+            Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
         }
     }
 
@@ -169,7 +169,7 @@ impl CounterApi {
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
             Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
+            Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
         }
     }
 

--- a/testkit/tests/currency/cryptocurrency.rs
+++ b/testkit/tests/currency/cryptocurrency.rs
@@ -199,7 +199,7 @@ impl CryptocurrencyApi {
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
             Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
+            Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
         }
     }
 

--- a/testkit/tests/currency/cryptocurrency.rs
+++ b/testkit/tests/currency/cryptocurrency.rs
@@ -219,11 +219,7 @@ impl CryptocurrencyApi {
         if let Some(wallet) = self.wallet(&public_key) {
             self.ok_response(&serde_json::to_value(wallet).unwrap())
         } else {
-            Ok(Response::with((
-                Status::NotFound,
-                Header(ContentType::json()),
-                "\"Wallet not found\"",
-            )))
+            self.not_found_response(&serde_json::to_value("Wallet not found").unwrap())
         }
     }
 

--- a/testkit/tests/currency/cryptocurrency.rs
+++ b/testkit/tests/currency/cryptocurrency.rs
@@ -210,7 +210,7 @@ impl CryptocurrencyApi {
         let path = req.url.path();
         let wallet_key = path.last().unwrap();
         let public_key = PublicKey::from_hex(wallet_key).map_err(|e| {
-            IronError::new(ApiError::FromHex(e), (
+            IronError::new(e, (
                 Status::BadRequest,
                 Header(ContentType::json()),
                 "\"Invalid request param: `pub_key`\"",
@@ -219,7 +219,7 @@ impl CryptocurrencyApi {
         if let Some(wallet) = self.wallet(&public_key) {
             self.ok_response(&serde_json::to_value(wallet).unwrap())
         } else {
-            Err(IronError::new(ApiError::NotFound, (
+            Ok(Response::with((
                 Status::NotFound,
                 Header(ContentType::json()),
                 "\"Wallet not found\"",

--- a/testkit/tests/currency/cryptocurrency.rs
+++ b/testkit/tests/currency/cryptocurrency.rs
@@ -198,8 +198,8 @@ impl CryptocurrencyApi {
                 let json = TransactionResponse { tx_hash };
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
-            Ok(None) => Err(ApiError::IncorrectRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::IncorrectRequest(Box::new(e)))?,
+            Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
+            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
         }
     }
 

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -222,11 +222,7 @@ impl CryptocurrencyApi {
             self.ok_response(&serde_json::to_value(wallet.actual_balance(height))
                 .unwrap())
         } else {
-            Ok(Response::with((
-                Status::NotFound,
-                Header(ContentType::json()),
-                "\"Wallet not found\"",
-            )))
+            self.not_found_response(&serde_json::to_value("Wallet not found").unwrap())
         }
     }
 }

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -200,7 +200,7 @@ impl CryptocurrencyApi {
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
             Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
+            Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
         }
     }
 

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -211,7 +211,7 @@ impl CryptocurrencyApi {
         let path = req.url.path();
         let wallet_key = path.last().unwrap();
         let public_key = PublicKey::from_hex(wallet_key).map_err(|e| {
-            IronError::new(ApiError::FromHex(e), (
+            IronError::new(e, (
                 Status::BadRequest,
                 Header(ContentType::json()),
                 "\"Invalid request param: `pub_key`\"",
@@ -222,7 +222,7 @@ impl CryptocurrencyApi {
             self.ok_response(&serde_json::to_value(wallet.actual_balance(height))
                 .unwrap())
         } else {
-            Err(IronError::new(ApiError::NotFound, (
+            Ok(Response::with((
                 Status::NotFound,
                 Header(ContentType::json()),
                 "\"Wallet not found\"",

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -199,8 +199,8 @@ impl CryptocurrencyApi {
                 let json = TransactionResponse { tx_hash };
                 self.ok_response(&serde_json::to_value(&json).unwrap())
             }
-            Ok(None) => Err(ApiError::IncorrectRequest("Empty request body".into()))?,
-            Err(e) => Err(ApiError::IncorrectRequest(Box::new(e)))?,
+            Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
+            Err(e) => Err(ApiError::BadRequest(Box::new(e)))?,
         }
     }
 


### PR DESCRIPTION
This switches error handling from `std::Error` to the [`failure`](https://github.com/withoutboats/failure) crate.

How to use failure (abridged edition):
- use `failure::Error` instead of `Box<Error>`,
- to define an error, add `derive(Fail)` to a struct/enum. Consider adding `#[cause]` and `#[fail(display="format")` attributes,
- consider using `.context` method to improve error messages for enduser-visible expected errors.

Here's the high-level list of changes in the PR:

1) `storage::Error` implements `Fail` (I've also changed the naming inside storage module to `module::Item` style)

2) The `fabric` module uses `failure::Error` instead of `Box<Error>`. This is a breaking change. We also should get slightly better error messages when reading config fails due to IO errors (message now includes the file name).

3) `ApiError` implements fail. This is the bulk of the changes from this PR. The sole purpose of `ApiError` is to be converted to `IronResponse`, so I've removed couple of variants like `FromHex`, and replaced them with `BadRequest`. I've also tweaked the way we generate status codes for ApiError: looks like previously we used a single HTTP code for all errors. I've also extracted some code duplicates from the `api` module so as to have a single place to tweak error handling. 


Note that serialization infra still uses `Box<Error>`. @vldm is furiously refactoring serialization, so I tried to avoid touching it =)

I'll write a changelog now :-)

