### PR TITLE
Add a hack to ignore a warning from cargo-deadlinks [ECR-445]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ jobs:
     - cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
     script:
     - cargo doc --no-deps
+    - touch target/doc/exonum/encoding/serialize/trait.Serialize.html  # TODO: a tmp hack to ignore a warning about missing page
     - cargo deadlinks --dir target/doc
     - cargo outdated --exit-code 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ jobs:
     - cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
     script:
     - cargo doc --no-deps
-    - touch target/doc/exonum/encoding/serialize/trait.Serialize.html  # TODO: a tmp hack to ignore a warning about missing page
+    - touch target/doc/exonum/encoding/serialize/trait.Serialize.html  # TODO: a tmp hack to ignore a warning about missing page [ECR-703]
     - cargo deadlinks --dir target/doc
     - cargo outdated --exit-code 1
 


### PR DESCRIPTION
```text
$ cargo deadlinks --dir target/doc
Linked file at path /home/travis/build/exonum/exonum/target/doc/exonum/encoding/serialize/trait.Serialize.html does not exist!
```

I don't see an easy way to fix the error itself (as it comes from relative paths in serde's docs + reexporting of these types in our code) so it seems easier to ignore it for now. `cargo-deadlinks` has no built-in functionality for ignoring certain warnings, but we can just create a dummy page.