### PR TITLE
Removed the `'static` bound from the `Service::service_name` result. [EEN-182]

### DIFF
--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -59,6 +59,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `storage::Error` implements `failure::Fail` instead of `std::error::Error`. (#474)
 
+- Removed the `'static` bound from the return value
+  of the `blockchain::Service::service_name()` method. (#485)
+
 ### New features
 
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -61,7 +61,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `CryptoHash` for `()` now correctly calculates a hash of an empty byte array
   instead of returning `Hash::zero()`. (#483)
-  
+
 - Removed the `'static` bound from the return value of the
   `blockchain::Service::service_name()` method. (#485)
 

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -133,7 +133,7 @@ pub trait Service: Send + Sync + 'static {
 
     /// A comprehensive string service name. Must be unique within the
     /// blockchain.
-    fn service_name(&self) -> &'static str;
+    fn service_name(&self) -> &str;
 
     /// Returns a list of root hashes of tables that determine the current state
     /// of the service database. These hashes are collected from all the services in a common

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -39,7 +39,7 @@ impl Service for CommitWatcherService {
         255
     }
 
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "commit_watcher"
     }
 

--- a/sandbox/src/config_updater.rs
+++ b/sandbox/src/config_updater.rs
@@ -57,7 +57,7 @@ impl Transaction for TxConfig {
 }
 
 impl Service for ConfigUpdateService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "sandbox_config_updater"
     }
 

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -828,7 +828,7 @@ mod tests {
     struct HandleCommitService;
 
     impl Service for HandleCommitService {
-        fn service_name(&self) -> &'static str {
+        fn service_name(&self) -> &str {
             "handle_commit"
         }
 

--- a/sandbox/src/timestamping.rs
+++ b/sandbox/src/timestamping.rs
@@ -93,7 +93,7 @@ impl TimestampingService {
 }
 
 impl Service for TimestampingService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "sandbox_timestamping"
     }
 

--- a/services/time/examples/simple_service.rs
+++ b/services/time/examples/simple_service.rs
@@ -104,7 +104,7 @@ impl Transaction for TxMarker {
 struct MarkerService;
 
 impl Service for MarkerService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         SERVICE_NAME
     }
 

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -401,7 +401,7 @@ impl TimeService {
 }
 
 impl Service for TimeService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         SERVICE_NAME
     }
 

--- a/testkit/examples/timestamping.rs
+++ b/testkit/examples/timestamping.rs
@@ -53,7 +53,7 @@ impl Transaction for TxTimestamp {
 }
 
 impl Service for TimestampingService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "timestamping"
     }
 

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -58,7 +58,7 @@
 //! }
 //!
 //! impl Service for TimestampingService {
-//!     fn service_name(&self) -> &'static str {
+//!     fn service_name(&self) -> &str {
 //!         "timestamping"
 //!     }
 //!
@@ -363,7 +363,7 @@ impl From<TestNode> for ValidatorKeys {
 /// # use exonum_testkit::TestKitBuilder;
 /// # pub struct MyService;
 /// # impl Service for MyService {
-/// #    fn service_name(&self) -> &'static str {
+/// #    fn service_name(&self) -> &str {
 /// #        "documentation"
 /// #    }
 /// #    fn state_hash(&self, _: &exonum::storage::Snapshot) -> Vec<exonum::crypto::Hash> {
@@ -589,7 +589,7 @@ impl TestKit {
     /// # type FromRawResult = Result<Box<Transaction>, encoding::Error>;
     /// # pub struct MyService;
     /// # impl Service for MyService {
-    /// #    fn service_name(&self) -> &'static str {
+    /// #    fn service_name(&self) -> &str {
     /// #        "documentation"
     /// #    }
     /// #    fn state_hash(&self, _: &exonum::storage::Snapshot) -> Vec<exonum::crypto::Hash> {

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -203,7 +203,7 @@ impl Api for CounterApi {
 pub struct CounterService;
 
 impl Service for CounterService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "counter"
     }
 

--- a/testkit/tests/currency/cryptocurrency.rs
+++ b/testkit/tests/currency/cryptocurrency.rs
@@ -256,7 +256,7 @@ pub struct CurrencyService;
 
 /// Implement a `Service` trait for the service.
 impl Service for CurrencyService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "cryptocurrency"
     }
 

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -251,7 +251,7 @@ pub struct CurrencyService;
 
 /// Implement a `Service` trait for the service.
 impl Service for CurrencyService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "cryptocurrency"
     }
 

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -46,7 +46,7 @@ impl Transaction for TxAfterCommit {
 pub struct HandleCommitService;
 
 impl Service for HandleCommitService {
-    fn service_name(&self) -> &'static str {
+    fn service_name(&self) -> &str {
         "handle_commit"
     }
 


### PR DESCRIPTION
[#EEN-182]

The value returned from the `Service::service_name` method is not stored anywhere, so there is no need for such a strict bound.
With such a strict restriction, there is no way to use the values produced at run-time (frankly, it is still possible to use a mutable `static`, but this doesn't cover all scenarios).