### PR TITLE
Remove TODO comment [ECR-588]

### DIFF
--- a/exonum/src/encoding/mod.rs
+++ b/exonum/src/encoding/mod.rs
@@ -68,7 +68,6 @@
 //! ## Primitive types
 //!
 //! Primitive types are all fixed-sized, and located fully in the header.
-// TODO explain how a signed integer is stored in memory (what codding) (ECR-155)
 //!
 //! | Type name | Size in Header | Info |
 //! |:--------|:---------------------|:--------------------------------------------------|


### PR DESCRIPTION
I propose to remove the comment at all: "TODO" are ugly and we are waiting for a new format anyway.