### PR TITLE
Make CI stricter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     environment:
       - ROCKSDB_LIB_DIR: /usr/local/lib
       - SNAPPY_LIB_DIR: /usr/local/lib
+      - RUSTFLAGS: -D warnings
     steps:
       - checkout
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,12 +97,12 @@ jobs:
     install:
     - cargo clippy --version | grep $CLIPPY_VERS || cargo install clippy --force --vers $CLIPPY_VERS
     script:
-    - cargo clippy --all
+    - cargo clippy --all -- -D warnings
 
   # Tests
   - env: FEATURE=test
     script:
-    - cargo test --all
+    - RUSTFLAGS="$RUSTFLAGS -D warnings" cargo test --all
     - cargo run -p exonum-testkit --example timestamping
     - cargo run -p exonum-testkit --example configuration_change
     - cargo run -p exonum-time --example simple_service

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
   - OUTDATED_VERS=0.7.0
   - SODIUM_VERS=1.0.13
   - CARGO_INCREMENTAL=1
-  - RUSTFLAGS="-C link-dead-code"
+  - RUSTFLAGS="-C link-dead-code -D warnings"
   - CODECOV_TOKEN=90006bf6-e4b7-4825-b880-8d19c4e21c21
   - ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
   - SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu
@@ -102,7 +102,7 @@ jobs:
   # Tests
   - env: FEATURE=test
     script:
-    - RUSTFLAGS="$RUSTFLAGS -D warnings" cargo test --all
+    - cargo test --all
     - cargo run -p exonum-testkit --example timestamping
     - cargo run -p exonum-testkit --example configuration_change
     - cargo run -p exonum-time --example simple_service

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -256,7 +256,7 @@ impl Blockchain {
                     "BUG: Cannot find transaction in pool.",
                 );
 
-                execute_transaction(tx, height, index, &mut fork);
+                execute_transaction(tx.as_ref(), height, index, &mut fork);
             }
 
             // Get tx & state hash
@@ -458,7 +458,7 @@ impl Clone for Blockchain {
     }
 }
 
-fn execute_transaction(tx: &Box<Transaction>, height: Height, index: usize, fork: &mut Fork) {
+fn execute_transaction(tx: &Transaction, height: Height, index: usize, fork: &mut Fork) {
     fork.checkpoint();
 
     let catch_result = panic::catch_unwind(panic::AssertUnwindSafe(|| tx.execute(fork)));


### PR DESCRIPTION
This PR returns missing `-D warnings` argument for clippy, and denies warnings from the Rust compiler as well.