### PR TITLE
Fix `TestKitApi::send` signature

### DIFF
--- a/testkit/CHANGELOG.md
+++ b/testkit/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
  - Modified signature of the `TestKitApi::send` method, which 
- previosly did not accept `Box<Transaction>` (#505)
+ previously did not accept `Box<Transaction>` (#505)
 
 ## 0.5.0 - 2018-01-30
 

--- a/testkit/CHANGELOG.md
+++ b/testkit/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
- - Modified signature of the `TestKitApi::send` method, which 
- previously did not accept `Box<Transaction>` (#505)
+- Modified signature of the `TestKitApi::send` method, which
+  previously did not accept `Box<Transaction>` (#505)
 
 ## 0.5.0 - 2018-01-30
 

--- a/testkit/CHANGELOG.md
+++ b/testkit/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+ - Modified signature of the `TestKitApi::send` method, which 
+ previosly did not accept `Box<Transaction>` (#505)
+
 ## 0.5.0 - 2018-01-30
 
 ### Added

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -1182,8 +1182,11 @@ impl TestKitApi {
     }
 
     /// Sends a transaction to the node via `ApiSender`.
-    pub fn send<T: Transaction>(&self, transaction: T) {
-        self.api_sender.send(Box::new(transaction)).expect(
+    pub fn send<T>(&self, transaction: T)
+    where
+        T: Into<Box<Transaction>>,
+    {
+        self.api_sender.send(transaction.into()).expect(
             "Cannot send transaction",
         );
     }

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -24,6 +24,7 @@ extern crate serde_json;
 extern crate pretty_assertions;
 
 use exonum::crypto::{self, PublicKey, CryptoHash};
+use exonum::blockchain::Transaction;
 use exonum::helpers::Height;
 use exonum::messages::Message;
 use exonum::encoding::serialize::FromHex;
@@ -557,4 +558,18 @@ fn test_explorer_transaction() {
     } else {
         panic!("Transaction should be committed");
     }
+}
+
+// Make sure that boxed transaction can be used in the `TestKitApi::send`.
+#[test]
+fn test_boxed_tx() {
+    let (mut testkit, api) = init_testkit();
+
+    let tx = {
+        let (pubkey, key) = crypto::gen_keypair();
+        Box::new(TxIncrement::new(&pubkey, 5, &key)) as Box<Transaction>
+    };
+
+    api.send(tx);
+    testkit.create_block();
 }


### PR DESCRIPTION
This PR fixes problem with signature of `TestKitApi::send` method, which previosly did not accept `Box<Transaction>`.