### PR TITLE
Fix `TransactionInfo` JSON serialization

### DIFF
--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -26,7 +26,7 @@ use helpers::Height;
 const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
 
 #[derive(Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(tag = "type", rename_all = "kebab-case")]
 enum TransactionInfo {
     Unknown,
     InPool { content: JsonValue },

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -59,6 +59,7 @@ pub struct TxInfo {
 
 /// Transaction execution status. Simplified version of `TransactionResult`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
 pub enum TxStatus {
     /// Successful transaction execution.
     Success,

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -94,6 +94,8 @@ impl Transaction for TxIncrement {
         self.verify_signature(self.author())
     }
 
+    // This method purposely does not check counter overflow in order to test
+    // behavior of panicking transactions.
     fn execute(&self, fork: &mut Fork) -> ExecutionResult {
         if self.by() == 0 {
             Err(ExecutionError::with_description(

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -19,7 +19,7 @@ extern crate iron;
 extern crate router;
 
 use exonum::blockchain::{ApiContext, Blockchain, Service, Transaction, TransactionSet,
-                         ExecutionResult};
+                         ExecutionError, ExecutionResult};
 use exonum::messages::{Message, RawTransaction};
 use exonum::node::{ApiSender, TransactionSend};
 use exonum::storage::{Entry, Fork, Snapshot};
@@ -95,6 +95,13 @@ impl Transaction for TxIncrement {
     }
 
     fn execute(&self, fork: &mut Fork) -> ExecutionResult {
+        if self.by() == 0 {
+            Err(ExecutionError::with_description(
+                0,
+                "Adding zero does nothing!".to_string(),
+            ))?;
+        }
+
         let mut schema = CounterSchema::new(fork);
         schema.inc_count(self.by());
         Ok(())

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -567,6 +567,6 @@ fn test_explorer_transaction() {
                 .is_ok()
         );
     } else {
-        // Already proven false by `assert_contains_all`
+        panic!("Invalid transaction info format, object expected");
     }
 }

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -510,11 +510,7 @@ fn test_explorer_transaction() {
         }
     }
 
-    let mut testkit = TestKitBuilder::validator()
-        .with_validators(4)
-        .with_service(CounterService)
-        .create();
-    let api = testkit.api();
+    let (mut testkit, api) = init_testkit();
 
     let tx = {
         let (pubkey, key) = crypto::gen_keypair();
@@ -587,10 +583,7 @@ fn test_explorer_transaction_statuses() {
         }
     }
 
-    let mut testkit = TestKitBuilder::validator()
-        .with_validators(4)
-        .with_service(CounterService)
-        .create();
+    let (mut testkit, api) = init_testkit();
 
     let tx = {
         let (pubkey, key) = crypto::gen_keypair();
@@ -611,16 +604,15 @@ fn test_explorer_transaction_statuses() {
         panicking_tx.clone(),
     ]);
 
-    let api = testkit.api();
-    assert_status(&api, &tx, &json!({"type": "success"}));
+    assert_status(&api, &tx, &json!({ "type": "success" }));
     assert_status(
         &api,
         &error_tx,
-        &json!({"type": "error", "code": 0, "description": "Adding zero does nothing!"}),
+        &json!({ "type": "error", "code": 0, "description": "Adding zero does nothing!" }),
     );
     assert_status(
         &api,
         &panicking_tx,
-        &json!({"type": "panic", "description": ""}),
+        &json!({ "type": "panic", "description": "" }),
     );
 }

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -497,12 +497,12 @@ fn test_explorer_transaction() {
     use exonum::storage::ListProof;
     use serde_json::Value;
 
-    /// Asserts that all properties from `subobj` are equal to the corresponding properties
+    /// Asserts that all properties from `sub` are equal to the corresponding properties
     /// in `obj`.
-    fn assert_contains_all(obj: &Value, subobj: &Value) {
-        if let (&Value::Object(ref obj), &Value::Object(ref subobj)) = (obj, subobj) {
-            for (key, value) in subobj {
-                assert_eq!(obj.get(key), Some(value));
+    fn assert_contains_all(obj: &Value, sub: &Value) {
+        if let (&Value::Object(ref obj), &Value::Object(ref sub)) = (obj, sub) {
+            for (key, value) in sub {
+                assert_eq!(obj[key], *value);
             }
         } else {
             panic!("Two objects expected");
@@ -519,7 +519,7 @@ fn test_explorer_transaction() {
         let (pubkey, key) = crypto::gen_keypair();
         TxIncrement::new(&pubkey, 5, &key)
     };
-    let info: serde_json::Value = api.get_err(
+    let info: Value = api.get_err(
         ApiKind::Explorer,
         &format!("v1/transactions/{}", &tx.hash().to_string()),
     );
@@ -528,7 +528,7 @@ fn test_explorer_transaction() {
     api.send(tx.clone());
     testkit.poll_events();
 
-    let info: serde_json::Value = api.get(
+    let info: Value = api.get(
         ApiKind::Explorer,
         &format!("v1/transactions/{}", &tx.hash().to_string()),
     );


### PR DESCRIPTION
This PR fixes the format of transaction information returned by the blockchain explorer, to use `"type": "unknown" | "in-pool" | "committed"` tag instead of returning data like `{ "in-pool": { "content": ... } }`.
