### PR TITLE
Fix hoedown/pulldown cargo-doc warnings [ECR-687]

### DIFF
--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -154,6 +154,7 @@ pub trait Service: Send + Sync + 'static {
     /// transactions that may come from byzantine nodes.
     ///
     /// Service should return an error in the following cases (see `MessageError` for more details):
+    ///
     /// - Incorrect transaction identifier.
     /// - Incorrect data layout.
     ///

--- a/exonum/src/encoding/mod.rs
+++ b/exonum/src/encoding/mod.rs
@@ -57,7 +57,7 @@
 //! Then the internal buffer of `student` is as follows:
 //!
 //! | Position | Stored data | Hexadecimal form | Comment |
-//! |:--------|:------:|:---------------------|:------------------------------------------|
+//! |--------|------|---------------------|------------------------------------------|
 //! | `0  => 4`  | 16    | `10 00 00 00`            | LE-encoded segment pointer to the data |
 //! | `4  => 8`  | 6     | `06 00 00 00`            | LE-encoded segment size |
 //! | `8  => 16` | 23    | `17 00 00 00 00 00 00 00` | number in little endian |
@@ -70,7 +70,7 @@
 //! Primitive types are all fixed-sized, and located fully in the header.
 //!
 //! | Type name | Size in Header | Info |
-//! |:--------|:---------------------|:--------------------------------------------------|
+//! |--------|---------------------|--------------------------------------------------|
 //! | `u8`     | 1    | Regular byte  |
 //! | `i8`     | 1    | Signed byte  |
 //! | `u16`    | 2    | Short unsigned integer stored in little endian  |

--- a/exonum/src/messages/raw.rs
+++ b/exonum/src/messages/raw.rs
@@ -115,7 +115,7 @@ impl MessageBuffer {
     ///
     /// ```
     /// use exonum::messages::MessageBuffer;
-    ///;
+    ///
     /// let message_buffer = MessageBuffer::from_vec(vec![]);
     /// assert!(message_buffer.is_empty());
     /// ```

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -766,6 +766,7 @@ impl State {
     /// transactions now.
     ///
     /// Transaction is ignored if the following criteria are fulfilled:
+    ///
     /// - transactions pool size is exceeded
     /// - transaction isn't contained in unknown transaction list of any propose
     /// - transaction isn't a part of block

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -28,6 +28,7 @@ use super::{StorageKey, StorageValue, Snapshot, Fork, Iter};
 /// `BaseIndex` requires that the keys implement the [`StorageKey`] trait and the values implement
 /// [`StorageValue`] trait. However, this structure is not bound to specific types and allows the
 /// use of *any* types as keys or values.
+///
 /// [`StorageKey`]: ../trait.StorageKey.html
 /// [`StorageValue`]: ../trait.StorageValue.html
 #[derive(Debug)]
@@ -60,6 +61,7 @@ impl<T> BaseIndex<T> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     pub fn new<S: AsRef<str>>(name: S, view: T) -> Self {
@@ -78,6 +80,7 @@ impl<T> BaseIndex<T> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     pub fn with_prefix<S: AsRef<str>>(name: S, prefix: Vec<u8>, view: T) -> Self {

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -22,6 +22,7 @@ use super::{BaseIndex, Snapshot, Fork, StorageValue};
 /// An index that may only contain one element.
 ///
 /// A value should implement [`StorageValue`] trait.
+///
 /// [`StorageValue`]: trait.StorageValue.html
 #[derive(Debug)]
 pub struct Entry<T, V> {
@@ -35,6 +36,7 @@ impl<T, V> Entry<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: trait.Snapshot.html
     /// [`&mut Fork`]: struct.Fork.html
     ///

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -23,6 +23,7 @@ use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageKey};
 ///
 /// `KeySetIndex` implements a set, storing the elements as keys with empty values.
 /// `KeySetIndex` requires that the elements implement the [`StorageKey`] trait.
+///
 /// [`StorageKey`]: ../trait.StorageKey.html
 #[derive(Debug)]
 pub struct KeySetIndex<T, K> {
@@ -49,6 +50,7 @@ impl<T, K> KeySetIndex<T, K> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -76,6 +78,7 @@ impl<T, K> KeySetIndex<T, K> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -23,6 +23,7 @@ use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
 ///
 /// `ListIndex` implements an array list, storing the element as values and using `u64` as an index.
 /// `ListIndex` requires that the elements implement the [`StorageValue`] trait.
+///
 /// [`StorageValue`]: ../trait.StorageValue.html
 #[derive(Debug)]
 pub struct ListIndex<T, V> {
@@ -50,6 +51,7 @@ impl<T, V> ListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -78,6 +80,7 @@ impl<T, V> ListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -23,6 +23,7 @@ use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageKey, StorageValue};
 ///
 /// `MapIndex` requires that the keys implement the [`StorageKey`] trait and the values implement
 /// [`StorageValue`] trait.
+///
 /// [`StorageKey`]: ../trait.StorageKey.html
 /// [`StorageValue`]: ../trait.StorageValue.html
 #[derive(Debug)]
@@ -77,6 +78,7 @@ impl<T, K, V> MapIndex<T, K, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -105,6 +107,7 @@ impl<T, K, V> MapIndex<T, K, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -34,6 +34,7 @@ mod proof;
 ///
 /// `ProofListIndex` implements a Merkle tree, storing elements as leaves and using `u64` as
 /// an index. `ProofListIndex` requires that the elements implement the [`StorageValue`] trait.
+///
 /// [`StorageValue`]: ../trait.StorageValue.html
 #[derive(Debug)]
 pub struct ProofListIndex<T, V> {
@@ -61,6 +62,7 @@ impl<T, V> ProofListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -94,6 +96,7 @@ impl<T, V> ProofListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -40,6 +40,7 @@ mod proof;
 ///
 /// **The size of the proof map keys must be exactly 32 bytes and the keys must have a uniform
 /// distribution.** Usually [`Hash`] and [`PublicKey`] are used as types of proof map keys.
+///
 /// [`ProofMapKey`]: trait.ProofMapKey.html
 /// [`StorageValue`]: ../trait.StorageValue.html
 /// [`Hash`]: ../../crypto/struct.Hash.html
@@ -104,6 +105,7 @@ impl<T, K, V> ProofMapIndex<T, K, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -137,6 +139,7 @@ impl<T, K, V> ProofMapIndex<T, K, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -69,6 +69,7 @@ impl StorageValue for SparseListSize {
 /// `SparseListIndex` implements an array list, storing the element as values and using `u64`
 /// as an index.
 /// `SparseListIndex` requires that the elements implement the [`StorageValue`] trait.
+///
 /// [`StorageValue`]: ../trait.StorageValue.html
 /// [`ListIndex`]: <../list_index/struct.ListIndex.html>
 #[derive(Debug)]
@@ -122,6 +123,7 @@ impl<T, V> SparseListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -150,6 +152,7 @@ impl<T, V> SparseListIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -23,6 +23,7 @@ use super::{BaseIndex, BaseIndexIter, Snapshot, Fork, StorageValue};
 ///
 /// `ValueSetIndex` implements a set, storing the element as values using its hash as a key.
 /// `ValueSetIndex` requires that the elements implement the [`StorageValue`] trait.
+///
 /// [`StorageValue`]: ../trait.StorageValue.html
 #[derive(Debug)]
 pub struct ValueSetIndex<T, V> {
@@ -62,6 +63,7 @@ impl<T, V> ValueSetIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///
@@ -89,6 +91,7 @@ impl<T, V> ValueSetIndex<T, V> {
     /// Storage view can be specified as [`&Snapshot`] or [`&mut Fork`]. In the first case only
     /// immutable methods are available. In the second case both immutable and mutable methods are
     /// available.
+    ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
     ///


### PR DESCRIPTION
This PR prepares exonum for https://github.com/rust-lang/rust/pull/48274.

Example of fixed warnings: https://travis-ci.org/exonum/exonum/jobs/339060721#L791