### PR TITLE
Clean up after #496

### DIFF
--- a/services/configuration/CHANGELOG.md
+++ b/services/configuration/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- cspell:ignore ZEROVOTE -->
+
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
@@ -7,7 +9,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- Most types renamed to avoid [stuttering] (#496):
+- Most types renamed to avoid stuttering (see [here][stuttering] for
+  an explanation of the term) (#496):
 
   - `ConfigurationService` to `Service`
   - `ConfigurationServiceFactory` to `ServiceFactory`
@@ -19,6 +22,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
   Check the crate documentation for more details.
 
+  **Migration path:** Rename imported types from the crate, using aliases
+  or qualified names if necessary: `use exonum_configuration::Service as ConfigService`.
+
 [stuttering]: https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356]
 
 - Multiple APIs are no longer public (#496):
@@ -29,7 +35,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
   Check the crate documentation for more details.
 
-- `ZEROVOTE` structure is replaced with the `MaybeVote` type, which is now used
+  **Migration path:** The restrictions are security-based and should not
+  influence intended service use.
+
+- `ZEROVOTE` is replaced with the `MaybeVote` type, which is now used
   instead of `Vote` in the schema method signatures. The storage format itself
   is unchanged (#496).
 

--- a/services/configuration/CHANGELOG.md
+++ b/services/configuration/CHANGELOG.md
@@ -7,10 +7,35 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- `CONFIG_SERVICE` constant has been renamed to `CONFIGURATION_SERVICE_ID`.
+- Most types renamed to avoid [stuttering] (#496):
 
-- `CONFIG_PROPOSE_MESSAGE_ID` and `CONFIG_VOTE_MESSAGE_ID` constants are no
-  longer public.
+  - `ConfigurationService` to `Service`
+  - `ConfigurationServiceFactory` to `ServiceFactory`
+  - `TxConfigPropose` to `Propose`
+  - `TxConfigVote` to `Vote`
+  - `ConfigurationSchema` to `Schema`
+  - `StorageValueConfigProposeData` to `ProposeData`
+  - `CONFIG_SERVICE` constant to `SERVICE_ID`
+
+  Check the crate documentation for more details.
+
+[stuttering]: https://doc.rust-lang.org/1.0.0/style/style/naming/README.html#avoid-redundant-prefixes-[rfc-356]
+
+- Multiple APIs are no longer public (#496):
+
+  - Message identifiers
+  - Mutating methods of the service schema
+  - Module implementing HTTP API of the service
+
+  Check the crate documentation for more details.
+
+- `ZEROVOTE` structure is replaced with the `MaybeVote` type, which is now used
+  instead of `Vote` in the schema method signatures. The storage format itself
+  is unchanged (#496).
+
+### New features
+
+- Implemented error handling based on error codes (#496).
 
 ## 0.5 - 2018-01-30
 

--- a/services/configuration/CHANGELOG.md
+++ b/services/configuration/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-<!-- cspell:ignore ZEROVOTE -->
-
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
@@ -38,15 +36,20 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   **Migration path:** The restrictions are security-based and should not
   influence intended service use.
 
+<!-- cspell:disable -->
+
 - `ZEROVOTE` is replaced with the `MaybeVote` type, which is now used
   instead of `Vote` in the schema method signatures. The storage format itself
   is unchanged (#496).
+
+<!-- cspell:enable -->
 
 ### New features
 
 - Information about configurations by `/v1/configs/actual`, `/v1/configs/following`
   and `/v1/configs/committed` endpoints is extended with the hash of the corresponding
   proposal and votes for the proposal (#481).
+
 - Implemented error handling based on error codes (#496).
 
 ## 0.5 - 2018-01-30

--- a/services/configuration/CHANGELOG.md
+++ b/services/configuration/CHANGELOG.md
@@ -44,6 +44,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### New features
 
+- Information about configurations by `/v1/configs/actual`, `/v1/configs/following`
+  and `/v1/configs/committed` endpoints is extended with the hash of the corresponding
+  proposal and votes for the proposal (#481).
 - Implemented error handling based on error codes (#496).
 
 ## 0.5 - 2018-01-30

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -32,10 +32,10 @@ transactions! {
         ///
         /// # Notes
         ///
-        /// See [`ProposeErrorCode`] for the description of error codes emitted by the `execute()`
+        /// See [`ErrorCode`] for the description of error codes emitted by the `execute()`
         /// method.
         ///
-        /// [`ProposeErrorCode`]: enum.ProposeErrorCode.html
+        /// [`ErrorCode`]: enum.ErrorCode.html
         struct Propose {
             /// Sender of the transaction.
             ///
@@ -55,11 +55,11 @@ transactions! {
         /// The stored version of the transaction has a special variant corresponding to absence
         /// of a vote. See [`MaybeVote`] for details.
         ///
-        /// See [`VoteErrorCode`] for the description of error codes emitted by the `execute()`
+        /// See [`ErrorCode`] for the description of error codes emitted by the `execute()`
         /// method.
         ///
         /// [`MaybeVote`]: struct.MaybeVote.html
-        /// [`VoteErrorCode`]: enum.VoteErrorCode.html
+        /// [`ErrorCode`]: enum.ErrorCode.html
         struct Vote {
             /// Sender of the transaction.
             ///


### PR DESCRIPTION
This PR cleans up some mistakes in #496, such as incorrect documentation of transactions. It also provides the changelog.

The documentation errors was noticed by [the `deadlinks` lint](https://travis-ci.org/exonum/exonum/jobs/344503829#L1732). Unfortunately, it seems that the documentation for `Option::as_ref` method (mentioned on the `MaybeVote` page because it implements `Deref<Target = Option<Vote>>`) is copied verbatim from the `std` docs, which leads to 3 more incorrect links discovered by `deadlinks`. Honestly, I don't know how to best fix this.

I can't help but notice that the changelog does not describe #481 (and possibly other changes as well). Should I include them as well, or will they be dealt with separately?