### PR TITLE
Make log output more human readable

### DIFF
--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -12,6 +12,7 @@ btree
 bytearray
 byteorder
 checkpointed
+chrono
 clippy
 clonned
 compat
@@ -45,8 +46,8 @@ librocksdb
 libsnappy
 libsodium
 libssl
-markdownlint
 maintainer's
+markdownlint
 memorydb
 mempool
 Merkelized
@@ -119,7 +120,7 @@ unsync
 untagged
 usize
 validator
-validators
 validator's
+validators
 whitelisted
 writeln

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -70,9 +70,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Connect` message has been extended with a user agent string, which breaks
   binary compatibility with previous versions. (#362)
 
-- Log output becomed more human readable. Now it uses `rfc2822` for time formatting.
-  It will break scripts that analyze the log output.  
-  (#514)
+- Log output become more human-readable. Now it uses `rfc2822` for time formatting.
+  This change can break scripts that analyze the log output. (#514)
 
 ### New features
 

--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -70,6 +70,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Connect` message has been extended with a user agent string, which breaks
   binary compatibility with previous versions. (#362)
 
+- Log output becomed more human readable. Now it uses `rfc2822` for time formatting.
+  It will break scripts that analyze the log output.  
+  (#514)
+
 ### New features
 
 - `StorageKey` and `StorageValue` traits are implemented for `SystemTime`. (#456)

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -46,6 +46,7 @@ tokio-retry = "0.1.0"
 tokio-timer = "0.1.2"
 failure = "0.1.1"
 os_info = "0.7.0"
+chrono = "0.4.0"
 
 exonum_rocksdb = "0.7"
 exonum_sodiumoxide = "0.0.16"

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -16,11 +16,12 @@
 
 use std::env;
 use std::io::{self, Write};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use log::{Level, Record, SetLoggerError};
 use env_logger::{Builder, Formatter};
 use colored::*;
+use chrono::prelude::*;
 
 use blockchain::{GenesisConfig, ValidatorKeys};
 use node::NodeConfig;
@@ -104,10 +105,12 @@ fn has_colors() -> bool {
     }
 }
 
+fn format_time(time: SystemTime) -> String {
+    DateTime::<Local>::from(time).to_rfc2822()
+}
+
 fn format_log_record(buf: &mut Formatter, record: &Record) -> io::Result<()> {
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let secs = ts.as_secs().to_string();
-    let millis = (u64::from(ts.subsec_nanos()) / 1_000_000).to_string();
+    let time = format_time(SystemTime::now());
 
     let verbose_src_path = match env::var("RUST_VERBOSE_PATH") {
         Ok(val) => val.parse::<bool>().unwrap_or(false),
@@ -133,11 +136,10 @@ fn format_log_record(buf: &mut Formatter, record: &Record) -> io::Result<()> {
         };
         writeln!(
             buf,
-            "[{} : {:03}] - [ {} ] - {} - {}",
-            secs.bold(),
-            millis.bold(),
+            "{} {} {} {}",
+            time.dimmed(),
             level,
-            &source_path,
+            source_path.dimmed(),
             record.args()
         )
     } else {
@@ -150,9 +152,8 @@ fn format_log_record(buf: &mut Formatter, record: &Record) -> io::Result<()> {
         };
         writeln!(
             buf,
-            "[{} : {:03}] - [ {} ] - {} - {}",
-            secs,
-            millis,
+            "{} {} {} {}",
+            time,
             level,
             &source_path,
             record.args()

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -150,13 +150,6 @@ fn format_log_record(buf: &mut Formatter, record: &Record) -> io::Result<()> {
             Level::Debug => "DEBUG",
             Level::Trace => "TRACE",
         };
-        writeln!(
-            buf,
-            "{} {} {} {}",
-            time,
-            level,
-            &source_path,
-            record.args()
-        )
+        writeln!(buf, "{} {} {} {}", time, level, &source_path, record.args())
     }
 }

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -21,7 +21,7 @@ use std::time::SystemTime;
 use log::{Level, Record, SetLoggerError};
 use env_logger::{Builder, Formatter};
 use colored::*;
-use chrono::prelude::*;
+use chrono::{DateTime, Local};
 
 use blockchain::{GenesisConfig, ValidatorKeys};
 use node::NodeConfig;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -41,6 +41,7 @@ extern crate vec_map;
 extern crate env_logger;
 extern crate colored;
 extern crate term;
+extern crate chrono;
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
 extern crate hyper;


### PR DESCRIPTION
Use `rfc2822` for time formatting and also reduce visual noise.
Also this PR will break the benchmark scripts.

Here example of a new output:
![Example of a new output](https://habrastorage.org/webt/dd/nz/zp/ddnzzpiqfpdv5uozincgaseemmk.png)