### PR TITLE
Make circleci's badge show only master branch status [ECR-815]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Status:**
 [![Travis Build Status](https://img.shields.io/travis/exonum/exonum/master.svg?label=Linux)](https://travis-ci.org/exonum/exonum)
-[![CircleCI Build Status](https://img.shields.io/circleci/project/github/exonum/exonum.svg?label=MacOS)](https://circleci.com/gh/exonum/exonum/tree/master)
+[![CircleCI Build Status](https://img.shields.io/circleci/project/github/exonum/exonum/master.svg?label=MacOS)](https://circleci.com/gh/exonum/exonum/tree/master)
 [![dependency status](https://deps.rs/repo/github/exonum/exonum/status.svg)](https://deps.rs/repo/github/exonum/exonum)
 
 **Project info:**


### PR DESCRIPTION
See https://github.com/exonum/exonum/pull/517#discussion_r170247779:

> https://img.shields.io/circleci/project/github/exonum/exonum.svg
> looks like we display the latest status of any build, not necessary of master branch.