### PR TITLE
.travis.yml: Remove sandbox/target from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ cache:
   - $HOME/.cargo
   - $HOME/.local
   - $TRAVIS_BUILD_DIR/target
-  - $TRAVIS_BUILD_DIR/sandbox/target
 
 dist: trusty
 sudo: required


### PR DESCRIPTION
We don't actually need to cache it, because sandbox is in the workspace, right?