### PR TITLE
Employ 'bodyparser' crate [ECR-688]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Breaking changes
+
+#### Exonum core
+
+- POST-requests are now handled with `bodyparser` crate,
+  so all the parameters must be passed in the body.
+
 ## 0.6 - 2018-03-06
 
 ### Breaking changes

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -47,6 +47,7 @@ tokio-timer = "0.1.2"
 failure = "0.1.1"
 os_info = "0.7.0"
 chrono = "0.4.0"
+bodyparser = "0.8.0"
 
 exonum_rocksdb = "0.7"
 exonum_sodiumoxide = "0.0.16"

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -33,6 +33,7 @@ use serde_json;
 use serde::{Serialize, Serializer};
 use serde::de::{self, Visitor, Deserialize, Deserializer};
 use failure::Fail;
+use bodyparser;
 
 use crypto::{PublicKey, SecretKey};
 use encoding::serialize::{FromHex, FromHexError, ToHex, encode_hex};
@@ -226,6 +227,18 @@ pub trait Api {
         self.optional_param(request, name)?.ok_or_else(|| {
             ApiError::BadRequest(format!("Required parameter '{}' is missing", name))
         })
+    }
+
+    /// Deserializes request's body as a struct of type `T`.
+    fn parse_body<T: 'static>(&self, req: &mut Request) -> Result<T, ApiError>
+    where
+        T: Clone + for<'de> Deserialize<'de>,
+    {
+        match req.get::<bodyparser::Struct<T>>() {
+            Ok(Some(param)) => Ok(param),
+            Ok(None) => Err(ApiError::BadRequest("Body is empty".into())),
+            Err(e) => Err(ApiError::BadRequest(format!("Invalid struct: {}", e))),
+        }
     }
 
     /// Loads hex value from the cookies.

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -154,8 +154,13 @@ impl SystemApi {
 
     fn handle_peer_add(self, router: &mut Router) {
         let peer_add = move |request: &mut Request| -> IronResult<Response> {
-            let address: SocketAddr = self.required_param(request, "ip")?;
-            self.node_channel.peer_add(address).map_err(ApiError::from)?;
+            #[derive(Serialize, Deserialize, Clone, Debug)]
+            struct PeerAddInfo {
+                ip: SocketAddr,
+            }
+
+            let PeerAddInfo { ip } = self.parse_body(request)?;
+            self.node_channel.peer_add(ip).map_err(ApiError::from)?;
             self.ok_response(&serde_json::to_value("Ok").unwrap())
         };
 
@@ -186,7 +191,12 @@ impl SystemApi {
 
     fn handle_set_consensus_enabled(self, router: &mut Router) {
         let consensus_enabled_set = move |request: &mut Request| -> IronResult<Response> {
-            let enabled: bool = self.required_param(request, "enabled")?;
+            #[derive(Serialize, Deserialize, Clone, Debug)]
+            struct EnabledInfo {
+                enabled: bool,
+            }
+
+            let EnabledInfo { enabled } = self.parse_body(request)?;
             let message = ExternalMessage::Enable(enabled);
             self.node_channel.send_external_message(message).map_err(
                 ApiError::from,

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -67,6 +67,7 @@ extern crate failure;
 extern crate lazy_static;
 #[cfg(test)]
 extern crate tempdir;
+extern crate bodyparser;
 
 #[macro_use]
 pub mod encoding;


### PR DESCRIPTION
This PR employs `bodyparser` crate for parsing data sections of POST-requests.

Motivation: https://github.com/exonum/exonum/pull/446/files#r166044729

Should I add a changelog item?