### PR TITLE
Make TransactionInfo public

### DIFF
--- a/exonum/CHANGELOG.md
+++ b/exonum/CHANGELOG.md
@@ -103,6 +103,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Added `v1/shutdown` endpoint for graceful node termination. (#526)
 
+- `TransactionInfo` from the public api module became public. (#537)
+
 ### Bug fixes
 
 - `ExonumJsonDeserialize` trait is implemented for `F32` and `F64`. (#461)

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -31,7 +31,7 @@ const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
 pub enum TransactionInfo {
     /// Transaction with the given id is absent in the blockchain.
     Unknown,
-    /// Transaction in the memory pool but not yet committed to the blockchain.
+    /// Transaction is in the memory pool, but not yet committed to the blockchain.
     InPool {
         /// Json representation of the given transaction.
         content: JsonValue,
@@ -77,7 +77,7 @@ impl ExplorerApi {
     }
 
     fn transaction_info(&self, hash: &Hash) -> Result<TransactionInfo, ApiError> {
-        if let Some(tx) = self.pool.read().expect("Uanble to read pool").get(hash) {
+        if let Some(tx) = self.pool.read().expect("Unable to read pool").get(hash) {
             Ok(TransactionInfo::InPool {
                 content: tx.serialize_field().map_err(ApiError::InternalError)?,
             })

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -25,11 +25,18 @@ use helpers::Height;
 
 const MAX_BLOCKS_PER_REQUEST: u64 = 1000;
 
-#[derive(Serialize)]
+/// Information about the transaction.
+#[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
-enum TransactionInfo {
+pub enum TransactionInfo {
+    /// Transaction with the given id is absent in the blockchain.
     Unknown,
-    InPool { content: JsonValue },
+    /// Transaction in the memory pool but not yet committed to the blockchain.
+    InPool { 
+        /// Json representation of the given transaction.
+        content: JsonValue 
+    },
+    /// Transaction is already committed to the blockchain.
     Committed(TxInfo),
 }
 

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -32,9 +32,9 @@ pub enum TransactionInfo {
     /// Transaction with the given id is absent in the blockchain.
     Unknown,
     /// Transaction in the memory pool but not yet committed to the blockchain.
-    InPool { 
+    InPool {
         /// Json representation of the given transaction.
-        content: JsonValue 
+        content: JsonValue,
     },
     /// Transaction is already committed to the blockchain.
     Committed(TxInfo),

--- a/exonum/src/api/public/mod.rs
+++ b/exonum/src/api/public/mod.rs
@@ -15,9 +15,7 @@
 //! Public part of the Exonum rest api.
 
 pub use self::system::{SystemApi, HealthCheckInfo};
-pub use self::blockchain_explorer::ExplorerApi;
+pub use self::blockchain_explorer::{ExplorerApi, TransactionInfo};
 
 mod system;
 mod blockchain_explorer;
-
-pub use self::blockchain_explorer::TransactionInfo;

--- a/exonum/src/api/public/mod.rs
+++ b/exonum/src/api/public/mod.rs
@@ -19,3 +19,5 @@ pub use self::blockchain_explorer::ExplorerApi;
 
 mod system;
 mod blockchain_explorer;
+
+pub use self::blockchain_explorer::TransactionInfo;


### PR DESCRIPTION
This enum is useful for `testkit` and other purposes.
