### PR TITLE
Rename DEFAULT_MAX_MESSAGE_LEN constant

### DIFF
--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -70,7 +70,7 @@ pub struct ConsensusConfig {
 
 impl ConsensusConfig {
     /// Default value for max_message_len.
-    pub const DEFAULT_MESSAGE_MAX_LEN: u32 = 1024 * 1024; // 1 MB
+    pub const DEFAULT_MAX_MESSAGE_LEN: u32 = 1024 * 1024; // 1 MB
 }
 
 impl Default for ConsensusConfig {
@@ -80,7 +80,7 @@ impl Default for ConsensusConfig {
             status_timeout: 5000,
             peers_timeout: 10_000,
             txs_block_limit: 1000,
-            max_message_len: Self::DEFAULT_MESSAGE_MAX_LEN,
+            max_message_len: Self::DEFAULT_MAX_MESSAGE_LEN,
             timeout_adjuster: TimeoutAdjusterConfig::Constant { timeout: 500 },
         }
     }

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -164,7 +164,7 @@ impl TestEvents {
             our_connect_message: connect_message(self.listen_address),
             listen_address: self.listen_address,
             network_config,
-            max_message_len: ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN,
+            max_message_len: ConsensusConfig::DEFAULT_MAX_MESSAGE_LEN,
             network_requests: channel.network_requests,
             network_tx: network_tx.clone(),
         };
@@ -273,7 +273,7 @@ fn test_network_max_message_len() {
     let first = "127.0.0.1:17202".parse().unwrap();
     let second = "127.0.0.1:17303".parse().unwrap();
 
-    let max_message_length = ConsensusConfig::DEFAULT_MESSAGE_MAX_LEN as usize;
+    let max_message_length = ConsensusConfig::DEFAULT_MAX_MESSAGE_LEN as usize;
     let max_payload_length = max_message_length - ::messages::HEADER_LENGTH -
         ::crypto::SIGNATURE_LENGTH;
     let acceptable_message = raw_message(15, max_payload_length);


### PR DESCRIPTION
For the sake of consistency