### PR TITLE
travis: Remove non-fatal-checks, move cargo-deadlinks to 'lints' job [ECR-822]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ rust:
   - 1.23.0
 
 matrix:
-  allow_failures:
-  - env: FEATURE=non-fatal-checks
   fast_finish: true
 
 cache:
@@ -73,6 +71,7 @@ jobs:
   - env: FEATURE=lints
     install:
     - cargo-audit -V || cargo install cargo-audit --force
+    - cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
     - rustfmt -V | grep $RUSTFMT_VERS || cargo install rustfmt --vers $RUSTFMT_VERS --force
     - nvm install 8 && nvm use 8
     - npm install cspell
@@ -90,6 +89,15 @@ jobs:
     - ./node_modules/.bin/cspell examples/cryptocurrency/{src,examples,tests}/**/*.rs
     - find . -not -path "./3rdparty/*" -and -not -path "./node_modules/*" -name "*.md" | xargs ./node_modules/.bin/cspell
     - find . -not -path "./3rdparty/*" -and -not -path "./node_modules/*" -name "*.md" | xargs ./node_modules/.bin/markdownlint --config .markdownlintrc
+    - cargo doc --no-deps
+    # TODO: a tmp hack to ignore warnings about missing pages [ECR-703]
+    - mkdir -p target/std/string
+    - touch target/std/primitive.usize.html
+    - touch target/std/string/struct.String.html
+    - touch target/doc/exonum/encoding/serialize/trait.Serialize.html
+    - touch target/doc/exonum_configuration/enum.Option.html
+    - cargo deadlinks --dir target/doc
+
 
   # Clippy linting
   - env: FEATURE=clippy
@@ -132,15 +140,6 @@ jobs:
     rust: nightly-2018-03-06
     script:
     - RUST_LOG=off cargo bench --verbose --manifest-path exonum/Cargo.toml --features long_benchmarks --no-run
-
-  # Non-fatal checks
-  - env: FEATURE=non-fatal-checks
-    install:
-    - cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
-    script:
-    - cargo doc --no-deps
-    - touch target/doc/exonum/encoding/serialize/trait.Serialize.html  # TODO: a tmp hack to ignore a warning about missing page [ECR-703]
-    - cargo deadlinks --dir target/doc
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ rust:
   # Sync with badge in README.md
   - 1.23.0
 
-matrix:
-  fast_finish: true
-
 cache:
   directories:
   - node_modules

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -19,7 +19,7 @@
 //! your service on top of Exonum blockchain you need to do the following:
 //!
 //! - Define your own information schema.
-//! - Create one or more transaction types using the [`message!`] macro and
+//! - Create one or more transaction types using the [`transactions!`] macro and
 //!   implement the [`Transaction`] trait for them.
 //! - Create a data structure implementing the [`Service`] trait.
 //! - Write API handlers for the service, if required.
@@ -27,7 +27,7 @@
 //! You may consult [the service creation tutorial][doc:create-service] for a more detailed
 //! manual on how to create services.
 //!
-//! [`message!`]: ../macro.message.html
+//! [`transactions!`]: ../macro.transactions.html
 //! [`Transaction`]: ./trait.Transaction.html
 //! [`Service`]: ./trait.Service.html
 //! [doc:create-service]: https://exonum.com/doc/get-started/create-service

--- a/exonum/src/encoding/mod.rs
+++ b/exonum/src/encoding/mod.rs
@@ -25,10 +25,10 @@
 //! - **Header:** a fixed-sized part
 //! - **Body:** dynamically sized part, known only after parsing the header
 //!
-//! To create a structure type, you can use [`message!`] and [`encoding_struct!`] macros.
+//! To create a structure type, you can use [`transactions!`] and [`encoding_struct!`] macros.
 //!
 //! [doc:serialization]: https://exonum.com/doc/architecture/serialization/
-//! [`message!`]: ../macro.message.html
+//! [`transactions!`]: ../macro.transactions.html
 //! [`encoding_struct!`]: ../macro.encoding_struct.html
 //!
 //! # Examples

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -20,7 +20,7 @@
 /// The macro also implements [`Field`], [`ExonumJson`] and [`StorageValue`] traits
 /// for the declared datatype.
 ///
-/// Unlike types created with [`message!`], the datatype is mapped to a byte buffer
+/// Unlike types created with [`transactions!`], the datatype is mapped to a byte buffer
 /// without any checks; it is assumed that the relevant checks have been performed
 /// when persisting the structure to the blockchain storage.
 ///
@@ -33,7 +33,7 @@
 /// [`Field`]: ./encoding/trait.Field.html
 /// [`ExonumJson`]: ./encoding/serialize/json/trait.ExonumJson.html
 /// [`StorageValue`]: ./storage/trait.StorageValue.html
-/// [`message!`]: macro.message.html
+/// [`transactions!`]: macro.transactions.html
 ///
 /// # Examples
 ///

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -26,7 +26,7 @@ use helpers::Round;
 
 /// A type that can be (de)serialized as a value in the blockchain storage.
 ///
-/// `StorageValue` is automatically implemented by the [`encoding_struct!`] and [`message!`]
+/// `StorageValue` is automatically implemented by the [`encoding_struct!`] and [`transactions!`]
 /// macros. In case you need to implement it manually, use little-endian encoding
 /// for integer types for compatibility with modern architectures.
 ///
@@ -74,7 +74,7 @@ use helpers::Round;
 /// ```
 ///
 /// [`encoding_struct!`]: ../macro.encoding_struct.html
-/// [`message!`]: ../macro.message.html
+/// [`transactions!`]: ../macro.transactions.html
 pub trait StorageValue: CryptoHash + Sized {
     /// Serialize a value into a vector of bytes.
     fn into_bytes(self) -> Vec<u8>;


### PR DESCRIPTION
There's no point in having `cargo-deadlinks` as a non-fatal check - everyone just ignores it.

This PR fixes some of the warnings.
Though, there're some bugs in `rustdoc`, so a few more hacks were added to suppress them for now.

```
https://docs.rs/exonum-configuration/0.6.0/exonum_configuration/struct.MaybeVote.html

Linked file at path /home/ozkriff/bitfury/exonum/target/std/string/struct.String.html does not exist!
Linked file at path /home/ozkriff/bitfury/exonum/target/std/primitive.usize.html does not exist!
Linked file at path /home/ozkriff/bitfury/exonum/target/doc/exonum_configuration/enum.Option.html does not exist!
```