### PR TITLE
Rename 'root_hash' to 'merkle_root' [ECR-767]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - POST-requests are now handled with `bodyparser` crate,
   so all the parameters must be passed in the body.
 
+- `ProofListIndex` and `ProofMapIndex` `root_hash` method has been renamed to
+  `merkle_root`.
+
 ## 0.6 - 2018-03-06
 
 ### Breaking changes

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -304,10 +304,10 @@ impl Blockchain {
                     for (key, hash) in state_hashes {
                         sum_table.put(&key, hash)
                     }
-                    sum_table.root_hash()
+                    sum_table.merkle_root()
                 };
 
-                let tx_hash = schema.block_txs(height).root_hash();
+                let tx_hash = schema.block_txs(height).merkle_root();
 
                 (tx_hash, state_hash)
             };

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -290,7 +290,7 @@ where
 
     /// Returns the `state_hash` table for core tables.
     pub fn core_state_hash(&self) -> Vec<Hash> {
-        vec![self.configs().root_hash(), self.transaction_results().root_hash()]
+        vec![self.configs().merkle_root(), self.transaction_results().merkle_root()]
     }
 
     /// Constructs a proof of inclusion of root hash of a specific service

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -297,7 +297,7 @@ where
         self.len().next_power_of_two().trailing_zeros() as u8 + 1
     }
 
-    /// Returns the root hash of the proof list or default hash value if it is empty.
+    /// Returns the Merkle root hash of the proof list or default hash value if it is empty.
     ///
     /// # Examples
     ///
@@ -310,14 +310,14 @@ where
     /// let mut fork = db.fork();
     /// let mut index = ProofListIndex::new(name, &mut fork);
     ///
-    /// let default_hash = index.root_hash();
+    /// let default_hash = index.merkle_root();
     /// assert_eq!(Hash::default(), default_hash);
     ///
     /// index.push(1);
-    /// let hash = index.root_hash();
+    /// let hash = index.merkle_root();
     /// assert_ne!(hash, default_hash);
     /// ```
-    pub fn root_hash(&self) -> Hash {
+    pub fn merkle_root(&self) -> Hash {
         self.get_branch(self.root_key()).unwrap_or_default()
     }
 

--- a/exonum/src/storage/proof_list_index/proof.rs
+++ b/exonum/src/storage/proof_list_index/proof.rs
@@ -77,15 +77,15 @@ impl<V: StorageValue> ListProof<V> {
         Ok(hash)
     }
 
-    /// Verifies the correctness of the proof by the trusted root hash and the number of elements
-    /// in the tree.
+    /// Verifies the correctness of the proof by the trusted Merkle root hash and the number of
+    /// elements in the tree.
     ///
     /// If the proof is valid, a vector with indices and references to elements is returned.
     /// Otherwise, `Err` is returned.
-    pub fn validate(&self, root_hash: Hash, len: u64) -> Result<Vec<(u64, &V)>, ListProofError> {
+    pub fn validate(&self, merkle_root: Hash, len: u64) -> Result<Vec<(u64, &V)>, ListProofError> {
         let mut vec = Vec::new();
         let height = len.next_power_of_two().trailing_zeros() as u8 + 1;
-        if self.collect(ProofListKey::new(height, 0), &mut vec)? != root_hash {
+        if self.collect(ProofListKey::new(height, 0), &mut vec)? != merkle_root {
             return Err(ListProofError::UnmatchedRootHash);
         }
         Ok(vec)

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -260,7 +260,7 @@ where
         Some(res)
     }
 
-    /// Returns the root hash of the proof map or default hash value if it is empty.
+    /// Returns the Merkle root hash of the proof map or default hash value if it is empty.
     ///
     /// # Examples
     ///
@@ -273,14 +273,14 @@ where
     /// let mut fork = db.fork();
     /// let mut index = ProofMapIndex::new(name, &mut fork);
     ///
-    /// let default_hash = index.root_hash();
+    /// let default_hash = index.merkle_root();
     /// assert_eq!(Hash::default(), default_hash);
     ///
     /// index.put(&default_hash, 100);
-    /// let hash = index.root_hash();
+    /// let hash = index.merkle_root();
     /// assert_ne!(hash, default_hash);
     /// ```
-    pub fn root_hash(&self) -> Hash {
+    pub fn merkle_root(&self) -> Hash {
         match self.get_root_node() {
             Some((k, Node::Leaf(v))) => {
                 HashStream::new()
@@ -926,18 +926,18 @@ impl<V: StorageValue + fmt::Debug> ProofMapIndexEntry<V> {
         T: AsRef<Snapshot>,
         K: ProofMapKey,
     {
-        let root_hash = index.root_hash();
+        let merkle_root = index.merkle_root();
         match root_node {
             Node::Leaf(value) => ProofMapIndexEntry::Leaf {
                 key: root_prefix,
-                hash: root_hash,
+                hash: merkle_root,
                 value,
             },
             Node::Branch(branch) => {
                 let left = Box::new(Self::child_node(index, &branch, ChildKind::Left));
                 let right = Box::new(Self::child_node(index, &branch, ChildKind::Right));
                 ProofMapIndexEntry::Branch {
-                    hash: root_hash,
+                    hash: merkle_root,
                     prefix: root_prefix,
                     left,
                     right,

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -102,8 +102,8 @@ pub enum BranchProofNode<V> {
 }
 
 impl<V: StorageValue> MapProof<V> {
-    /// Returns root hash of the map proof.
-    pub fn root_hash(&self) -> Hash {
+    /// Returns Merkle root hash of the map proof.
+    pub fn merkle_root(&self) -> Hash {
         use self::MapProof::*;
         match *self {
             Empty => Hash::zero(),
@@ -119,22 +119,22 @@ impl<V: StorageValue> MapProof<V> {
                     .update(root_val_hash.as_ref())
                     .hash()
             }
-            Branch(ref branch) => branch.root_hash(),
+            Branch(ref branch) => branch.merkle_root(),
         }
     }
 }
 impl<V: StorageValue> ProofNode<V> {
-    fn root_hash(&self) -> Hash {
+    fn merkle_root(&self) -> Hash {
         use self::ProofNode::*;
         match *self {
             Leaf(ref val) => val.hash(),
-            Branch(ref branch) => branch.root_hash(),
+            Branch(ref branch) => branch.merkle_root(),
         }
     }
 }
 
 impl<V: StorageValue> BranchProofNode<V> {
-    fn root_hash(&self) -> Hash {
+    fn merkle_root(&self) -> Hash {
         use self::BranchProofNode::*;
         match *self {
             BranchKeyNotFound {
@@ -157,7 +157,7 @@ impl<V: StorageValue> BranchProofNode<V> {
                 ref right_key,
             } => {
                 HashStream::new()
-                    .update(left_node.root_hash().as_ref())
+                    .update(left_node.merkle_root().as_ref())
                     .update(right_hash.as_ref())
                     .update(left_key.as_bytes())
                     .update(right_key.as_bytes())
@@ -171,7 +171,7 @@ impl<V: StorageValue> BranchProofNode<V> {
             } => {
                 HashStream::new()
                     .update(left_hash.as_ref())
-                    .update(right_node.root_hash().as_ref())
+                    .update(right_node.merkle_root().as_ref())
                     .update(left_key.as_bytes())
                     .update(right_key.as_bytes())
                     .hash()
@@ -276,7 +276,7 @@ impl<V: fmt::Debug + StorageValue> MapProof<V> {
     /// If the proof is valid and the requested key exists, `Ok(Some(&V))` is returned.
     /// If the proof is valid and the requested key does not exists, `Ok(None)` is returned.
     /// If the proof is invalid, `Err` is returned.
-    pub fn validate<K: ProofMapKey>(&self, key: &K, root_hash: Hash) -> Result<Option<&V>, Error> {
+    pub fn validate<K: ProofMapKey>(&self, key: &K, merkle_root: Hash) -> Result<Option<&V>, Error> {
         let searched_key = ProofPath::new(key);
         use self::MapProof::*;
 
@@ -309,12 +309,12 @@ impl<V: fmt::Debug + StorageValue> MapProof<V> {
             }
             Branch(ref branch) => branch.validate(&searched_key)?,
         };
-        let proof_hash = self.root_hash();
-        if proof_hash != root_hash {
+        let proof_hash = self.merkle_root();
+        if proof_hash != merkle_root {
             return Err(Error::new(format!(
                 "The proof doesn't match the expected hash! \
                  Expected: {:?} , from proof: {:?}",
-                root_hash,
+                merkle_root,
                 proof_hash
             )));
         }

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -276,7 +276,11 @@ impl<V: fmt::Debug + StorageValue> MapProof<V> {
     /// If the proof is valid and the requested key exists, `Ok(Some(&V))` is returned.
     /// If the proof is valid and the requested key does not exists, `Ok(None)` is returned.
     /// If the proof is invalid, `Err` is returned.
-    pub fn validate<K: ProofMapKey>(&self, key: &K, merkle_root: Hash) -> Result<Option<&V>, Error> {
+    pub fn validate<K: ProofMapKey>(
+        &self,
+        key: &K,
+        merkle_root: Hash,
+    ) -> Result<Option<&V>, Error> {
         let searched_key = ProofPath::new(key);
         use self::MapProof::*;
 

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -494,10 +494,10 @@ impl Sandbox {
         schema.get_proof_to_service_table(service_id, table_idx)
     }
 
-    pub fn get_configs_root_hash(&self) -> Hash {
+    pub fn get_configs_merkle_root(&self) -> Hash {
         let snapshot = self.blockchain_ref().snapshot();
         let schema = Schema::new(&snapshot);
-        schema.configs().root_hash()
+        schema.configs().merkle_root()
     }
 
     pub fn cfg(&self) -> StoredConfiguration {

--- a/sandbox/src/sandbox_tests_helper.rs
+++ b/sandbox/src/sandbox_tests_helper.rs
@@ -110,7 +110,7 @@ impl<'a> BlockBuilder<'a> {
 
     pub fn with_txs_hashes(mut self, tx_hashes: &[Hash]) -> Self {
         // root of merkle table, containing this array of transactions
-        let merkle_root = compute_txs_root_hash(tx_hashes);
+        let merkle_root = compute_txs_merkle_root(tx_hashes);
         self.tx_hash = Some(merkle_root);
         self.tx_count = Some(tx_hashes.len() as u32);
         self
@@ -237,19 +237,18 @@ impl Default for SandboxState {
     }
 }
 
-/// just returns valid Hash object filled with zeros
+/// Returns valid Hash object filled with zeros.
 pub fn empty_hash() -> Hash {
     Hash::from_slice(&[0; HASH_SIZE]).unwrap()
 }
 
-pub fn compute_txs_root_hash(txs: &[Hash]) -> Hash {
-    // TODO use special function
+pub fn compute_txs_merkle_root(txs: &[Hash]) -> Hash {
     use exonum::storage::{MemoryDB, ProofListIndex};
 
     let mut fork = MemoryDB::new().fork();
     let mut hashes = ProofListIndex::new("name", &mut fork);
     hashes.extend(txs.iter().cloned());
-    hashes.root_hash()
+    hashes.merkle_root()
 }
 
 pub fn add_round_with_transactions(

--- a/sandbox/tests/consensus.rs
+++ b/sandbox/tests/consensus.rs
@@ -238,24 +238,24 @@ fn test_query_state_hash() {
     //we do not change the state hash in between blocks for TimestampingService for now
     for _ in 0..2 {
         let state_hash = sandbox.last_state_hash();
-        let configs_rh = sandbox.get_configs_root_hash();
+        let configs_rh = sandbox.get_configs_merkle_root();
         let configs_key = Blockchain::service_table_unique_key(CONSENSUS, 0);
         let timestamp_t1_key = Blockchain::service_table_unique_key(TIMESTAMPING_SERVICE, 0);
         let timestamp_t2_key = Blockchain::service_table_unique_key(TIMESTAMPING_SERVICE, 1);
 
         let proof_configs = sandbox.get_proof_to_service_table(CONSENSUS, 0);
-        assert_eq!(state_hash, proof_configs.root_hash());
+        assert_eq!(state_hash, proof_configs.merkle_root());
         assert_ne!(configs_rh, Hash::zero());
         let opt_configs_h = proof_configs.validate(&configs_key, state_hash).unwrap();
         assert_eq!(configs_rh, *opt_configs_h.unwrap());
 
         let proof_configs = sandbox.get_proof_to_service_table(TIMESTAMPING_SERVICE, 0);
-        assert_eq!(state_hash, proof_configs.root_hash());
+        assert_eq!(state_hash, proof_configs.merkle_root());
         let opt_configs_h = proof_configs.validate(&timestamp_t1_key, state_hash);
         assert_eq!(&[127; 32], opt_configs_h.unwrap().unwrap().as_ref());
 
         let proof_configs = sandbox.get_proof_to_service_table(TIMESTAMPING_SERVICE, 1);
-        assert_eq!(state_hash, proof_configs.root_hash());
+        assert_eq!(state_hash, proof_configs.merkle_root());
         let opt_configs_h = proof_configs.validate(&timestamp_t2_key, state_hash);
         assert_eq!(&[128; 32], opt_configs_h.unwrap().unwrap().as_ref());
 

--- a/services/configuration/src/schema.rs
+++ b/services/configuration/src/schema.rs
@@ -178,8 +178,8 @@ where
     /// Returns state hash values used by the configuration service.
     pub fn state_hash(&self) -> Vec<Hash> {
         vec![
-            self.propose_data_by_config_hash().root_hash(),
-            self.config_hash_by_ordinal().root_hash(),
+            self.propose_data_by_config_hash().merkle_root(),
+            self.config_hash_by_ordinal().merkle_root(),
         ]
     }
 }
@@ -237,13 +237,13 @@ mod tests {
 
         let db = MemoryDB::new();
         let mut fork = db.fork();
-        let root_hash = {
+        let merkle_root = {
             let mut index: ProofListIndex<_, Vote> = ProofListIndex::new("index", &mut fork);
             for _ in 0..VALIDATORS {
                 index.push(NO_VOTE.clone());
             }
             index.set(1, vote.clone());
-            index.root_hash()
+            index.merkle_root()
         };
         db.merge(fork.into_patch()).unwrap();
 
@@ -261,13 +261,13 @@ mod tests {
         }
 
         // Touch the index in order to recalculate its root hash
-        let new_root_hash = {
+        let new_merkle_root = {
             let mut fork = db.fork();
             let mut index: ProofListIndex<_, MaybeVote> = ProofListIndex::new("index", &mut fork);
             index.set(2, MaybeVote::some(vote.clone()));
             index.set(2, MaybeVote::none());
-            index.root_hash()
+            index.merkle_root()
         };
-        assert_eq!(root_hash, new_root_hash);
+        assert_eq!(merkle_root, new_merkle_root);
     }
 }

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -171,7 +171,7 @@ impl Propose {
 
             ProposeData::new(
                 self.clone(),
-                &votes_table.root_hash(),
+                &votes_table.merkle_root(),
                 num_validators as u64,
             )
         };
@@ -271,7 +271,7 @@ impl Vote {
         let propose_data = {
             let mut votes = schema.votes_by_config_hash_mut(cfg_hash);
             votes.set(validator_id as u64, MaybeVote::some(self.clone()));
-            propose_data.set_history_hash(&votes.root_hash())
+            propose_data.set_history_hash(&votes.merkle_root())
         };
 
         schema.propose_data_by_config_hash_mut().put(

--- a/services/time/examples/simple_service.rs
+++ b/services/time/examples/simple_service.rs
@@ -56,7 +56,7 @@ impl<T: AsRef<Snapshot>> MarkerSchema<T> {
 
     /// Returns hashes for stored table.
     pub fn state_hash(&self) -> Vec<Hash> {
-        vec![self.marks().root_hash()]
+        vec![self.marks().merkle_root()]
     }
 }
 

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -83,7 +83,7 @@ impl<T: AsRef<Snapshot>> TimeSchema<T> {
 
     /// Returns hashes for stored tables.
     pub fn state_hash(&self) -> Vec<Hash> {
-        vec![self.validators_times().root_hash(), self.time().hash()]
+        vec![self.validators_times().merkle_root(), self.time().hash()]
     }
 }
 


### PR DESCRIPTION
Personally, I prefer a more concise naming: `merkle_root`, but `merkle_root_hash` can be more descriptive.