### PR TITLE
Change mempool to save transactions in storage. [ECR-895]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Internal improvements
+
+#### Exonum core
+
+- Non-committed transactions are now stored persistently in the storage
+  instead of memory pool. (#549)
+
 ### Breaking changes
 
 #### Exonum core
@@ -19,8 +26,18 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   `new_in_family`. Now it uses `index_id` instead of prefixes. Moreover,
   `blockchain::gen_prefix` method has been removed. Instead, any type that
   implements `StorageKey` trait, can serve as an `index_id`. (#531)
+
+#### exonum-testkit
+
+- Testkit api now contain two methods to work with transaction pool:
+  - `is_tx_in_pool` - for checking transaction existence in pool;
+  - `add_tx` - for adding new transaction into pool.
   
-- Transaction pool are now collected in storage instead of memory. (#549)
+  Migration path:
+  
+  - Instead of calling `mempool()`, one should use `is_tx_in_pool`
+  or `add_tx` methods.
+
 
 #### exonum-configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   `new_in_family`. Now it uses `index_id` instead of prefixes. Moreover,
   `blockchain::gen_prefix` method has been removed. Instead, any type that
   implements `StorageKey` trait, can serve as an `index_id`. (#531)
+  
+- Transaction pool are now collected in storage instead of memory. (#549)
 
 #### exonum-configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Testkit api now contain two methods to work with transaction pool:
   - `is_tx_in_pool` - for checking transaction existence in pool;
   - `add_tx` - for adding new transaction into pool.
-  
+
   Migration path:
-  
+
   - Instead of calling `mempool()`, one should use `is_tx_in_pool`
   or `add_tx` methods.
-
 
 #### exonum-configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### Internal improvements
-
-#### Exonum core
-
-- Non-committed transactions are now stored persistently in the storage
-  instead of memory pool. (#549)
-
 ### Breaking changes
 
 #### Exonum core
@@ -29,9 +22,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum-testkit
 
-- Testkit api now contain two methods to work with transaction pool:
-  - `is_tx_in_pool` - for checking transaction existence in pool;
-  - `add_tx` - for adding new transaction into pool.
+- Testkit api now contains two methods to work with the transaction pool:
+  - `is_tx_in_pool` - for checking transaction existence in the pool;
+  - `add_tx` - for adding a new transaction into the pool.
 
   Migration path:
 
@@ -61,6 +54,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Added `v1/user_agent` endpoint with information about Exonum, Rust
   and OS versions. (#548)
+
+### Internal improvements
+
+#### Exonum core
+
+- Non-committed transactions are now stored persistently in the storage
+  instead of memory pool. (#549)
 
 ## 0.6 - 2018-03-06
 

--- a/exonum/benches/block.rs
+++ b/exonum/benches/block.rs
@@ -23,37 +23,62 @@ extern crate test;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
 
     use tempdir::TempDir;
     use futures::sync::mpsc;
     use test::Bencher;
+    use exonum::storage::{Database, Fork, Patch, ProofMapIndex, RocksDB, DbOptions, Snapshot};
+    use exonum::blockchain::{ExecutionResult, Blockchain, Transaction, Schema, Service};
     use exonum::storage::{Database, Fork, Patch, ProofMapIndex, RocksDB, DbOptions};
     use exonum::blockchain::{Blockchain, Transaction, ExecutionResult};
     use exonum::crypto::{gen_keypair, CryptoHash, Hash, PublicKey, SecretKey};
-    use exonum::messages::Message;
+    use exonum::messages::{Message, RawTransaction};
+    use exonum::encoding::Error as EncodingError;
     use exonum::helpers::{Height, ValidatorId};
     use exonum::node::ApiSender;
 
-    fn create_blockchain(db: Box<Database>) -> Blockchain {
+    fn create_blockchain(db: Box<Database>, services: Vec<Box<Service>>) -> Blockchain {
         let dummy_channel = mpsc::channel(1);
         let dummy_keypair = (PublicKey::zero(), SecretKey::zero());
         Blockchain::new(
             db,
-            Vec::new(),
+            services,
             dummy_keypair.0,
             dummy_keypair.1,
             ApiSender::new(dummy_channel.0),
         )
     }
 
-    fn execute_timestamping(db: Box<Database>, b: &mut Bencher) {
-        let mut blockchain = create_blockchain(db);
+    fn execute_block(blockchain: &Blockchain, height: u64, txs: &[Hash]) -> Patch {
+        blockchain
+            .create_patch(ValidatorId::zero(), Height(height), txs)
+            .1
 
+    }
+
+    fn execute_timestamping(db: Box<Database>, b: &mut Bencher) {
+
+        struct Timestamping;
+        impl Service for Timestamping {
+            fn service_id(&self) -> u16 {
+                255
+            }
+
+            fn service_name(&self) -> &'static str {
+                "timestamping"
+            }
+
+            fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+                Vec::new()
+            }
+
+            fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {
+                Ok(Box::new(Tx::from_raw(raw)?))
+            }
+        }
         transactions! {
             Transactions {
                 const SERVICE_ID = 1;
-
                 struct Tx {
                     from: &PublicKey,
                     data: &Hash,
@@ -71,52 +96,59 @@ mod tests {
             }
         }
 
-        fn prepare_txs(height: u64, count: u64) -> (Vec<Hash>, BTreeMap<Hash, Box<Transaction>>) {
-            let (pub_key, sec_key) = gen_keypair();
+        fn prepare_txs(blockchain: &mut Blockchain, height: u64, count: u64) -> Vec<Hash> {
+            let mut fork = blockchain.fork();
             let mut txs = Vec::new();
-            let mut pool = BTreeMap::new();
-            for i in (height * count)..((height + 1) * count) {
-                let tx = Tx::new(&pub_key, &i.hash(), &sec_key);
-                let tx_hash = Transaction::hash(&tx);
-                txs.push(tx_hash);
-                pool.insert(tx_hash, Box::new(tx) as Box<Transaction>);
+            {
+                let mut schema = Schema::new(&mut fork);
+                let (pub_key, sec_key) = gen_keypair();
+                for i in (height * count)..((height + 1) * count) {
+                    let tx = Tx::new(&pub_key, &i.hash(), &sec_key);
+                    let tx_hash = Transaction::hash(&tx);
+                    txs.push(tx_hash);
+                    schema.add_transaction_into_pool(tx.raw().clone());
+                }
             }
-            (txs, pool)
+            blockchain.merge(fork.into_patch()).unwrap();
+            txs
         }
-
-        fn execute_block(
-            blockchain: &Blockchain,
-            height: u64,
-            txs: &[Hash],
-            pool: &BTreeMap<Hash, Box<Transaction>>,
-        ) -> Patch {
-            blockchain
-                .create_patch(ValidatorId::zero(), Height(height), txs, pool)
-                .1
-        }
-
+        let mut blockchain = create_blockchain(db, vec![Box::new(Timestamping)]);
         for i in 0..100 {
-            let (txs, pool) = prepare_txs(i, 1000);
-            let patch = execute_block(&blockchain, i, &txs, &pool);
+            let txs = prepare_txs(&mut blockchain, i, 1000);
+            let patch = execute_block(&mut blockchain, i, &txs);
             blockchain.merge(patch).unwrap();
         }
 
-        let (txs, pool) = prepare_txs(100, 1000);
+        let txs = prepare_txs(&mut blockchain, 100, 1000);
 
-        b.iter(|| execute_block(&blockchain, 100, &txs, &pool));
+        b.iter(|| execute_block(&mut blockchain, 100, &txs));
     }
 
     fn execute_cryptocurrency(db: Box<Database>, b: &mut Bencher) {
-        let mut blockchain = create_blockchain(db);
+        struct Cryptocurrency;
+        impl Service for Cryptocurrency {
+            fn service_id(&self) -> u16 {
+                255
+            }
 
-        transactions! {
-            Transactions {
-                const SERVICE_ID = 1;
+            fn service_name(&self) -> &'static str {
+                "cryptocurrency"
+            }
 
-                struct Tx {
-                    from: &PublicKey,
-                    to: &PublicKey,
-                }
+            fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+                Vec::new()
+            }
+
+            fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {
+                Ok(Box::new(Tx::from_raw(raw)?))
+            }
+        }
+
+        messages! {
+            const SERVICE_ID = 255;
+            struct Tx {
+                from: &PublicKey,
+                to: &PublicKey,
             }
         }
 
@@ -125,8 +157,8 @@ mod tests {
                 self.verify_signature(self.from())
             }
 
-            fn execute(&self, fork: &mut Fork) -> ExecutionResult {
-                let mut index = ProofMapIndex::new("balances_txs", fork);
+            fn execute(&self, view: &mut Fork) -> ExecutionResult {
+                let mut index = ProofMapIndex::new("balances_txs", view);
                 let from_balance = index.get(self.from()).unwrap_or(0u64);
                 let to_balance = index.get(self.to()).unwrap_or(0u64);
                 index.put(self.from(), from_balance - 1);
@@ -135,52 +167,47 @@ mod tests {
             }
         }
 
+        fn prepare_txs(
+            blockchain: &mut Blockchain,
+            height: u64,
+            count: u64,
+            keys: &[(PublicKey, SecretKey)],
+        ) -> Vec<Hash> {
+            let mut fork = blockchain.fork();
+            let mut txs = Vec::new();
+            {
+                let mut schema = Schema::new(&mut fork);
+                for i in (height * count)..((height + 1) * count) {
+                    let tx = Tx::new(
+                        &keys[i as usize % 10_000].0,
+                        &keys[(i as usize + 3_456) % 10_000].0,
+                        &keys[i as usize % 10_000].1,
+                    );
+                    let tx_hash = Transaction::hash(&tx);
+                    txs.push(tx_hash);
+                    schema.add_transaction_into_pool(tx.raw().clone());
+                }
+            }
+            blockchain.merge(fork.into_patch()).unwrap();
+            txs
+        }
+
+
+        let mut blockchain = create_blockchain(db, vec![Box::new(Cryptocurrency)]);
         let mut keys = Vec::new();
 
         for _ in 0..10_000 {
             keys.push(gen_keypair());
         }
-
-        fn prepare_txs(
-            height: u64,
-            count: u64,
-            keys: &[(PublicKey, SecretKey)],
-        ) -> (Vec<Hash>, BTreeMap<Hash, Box<Transaction>>) {
-            let mut txs = Vec::new();
-            let mut pool = BTreeMap::new();
-            for i in (height * count)..((height + 1) * count) {
-                let tx = Tx::new(
-                    &keys[i as usize % 10_000].0,
-                    &keys[(i as usize + 3_456) % 10_000].0,
-                    &keys[i as usize % 10_000].1,
-                );
-                let tx_hash = Transaction::hash(&tx);
-                txs.push(tx_hash);
-                pool.insert(tx_hash, Box::new(tx) as Box<Transaction>);
-            }
-            (txs, pool)
-        }
-
-        fn execute_block(
-            blockchain: &Blockchain,
-            height: u64,
-            txs: &[Hash],
-            pool: &BTreeMap<Hash, Box<Transaction>>,
-        ) -> Patch {
-            blockchain
-                .create_patch(ValidatorId::zero(), Height(height), txs, pool)
-                .1
-        }
-
         for i in 0..100 {
-            let (txs, pool) = prepare_txs(i, 1000, &keys);
-            let patch = execute_block(&blockchain, i, &txs, &pool);
+            let txs = prepare_txs(&mut blockchain, i, 1000, &keys);
+            let patch = execute_block(&mut blockchain, i, &txs);
             blockchain.merge(patch).unwrap();
         }
 
-        let (txs, pool) = prepare_txs(100, 1000, &keys);
+        let txs = prepare_txs(&mut blockchain, 100, 1000, &keys);
 
-        b.iter(|| execute_block(&blockchain, 100, &txs, &pool));
+        b.iter(|| execute_block(&mut blockchain, 100, &txs));
     }
 
     fn create_rocksdb(tempdir: &TempDir) -> Box<Database> {

--- a/exonum/benches/block.rs
+++ b/exonum/benches/block.rs
@@ -35,7 +35,7 @@ mod tests {
     use exonum::node::ApiSender;
 
     const TIMESTAMPING_SERVICE_ID: u16 = 1;
-    const CRYPTOCURRENCY_SERVICE_ID: u16 = 1;
+    const CRYPTOCURRENCY_SERVICE_ID: u16 = 255;
 
     fn create_blockchain(db: Box<Database>, services: Vec<Box<Service>>) -> Blockchain {
         let dummy_channel = mpsc::channel(1);
@@ -76,6 +76,7 @@ mod tests {
                 Ok(Box::new(Tx::from_raw(raw)?))
             }
         }
+
         transactions! {
             TimestampingTransactions {
                 const SERVICE_ID = TIMESTAMPING_SERVICE_ID;

--- a/exonum/src/api/public/blockchain_explorer.rs
+++ b/exonum/src/api/public/blockchain_explorer.rs
@@ -146,7 +146,7 @@ impl ExplorerApi {
             let content = box_transaction.serialize_field().map_err(
                 ApiError::InternalError,
             )?;
-            Ok(TransactionInfo::InPool { content: content })
+            Ok(TransactionInfo::InPool { content })
         } else if let Some(tx_info) = self.explorer().tx_info(hash)? {
             Ok(TransactionInfo::Committed(tx_info))
         } else {

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -51,7 +51,7 @@ impl SystemApi {
         let mempool = move |_: &mut Request| -> IronResult<Response> {
             let snapshot = self.blockchain.snapshot();
             let schema = Schema::new(&snapshot);
-            let info = MemPoolInfo { size: schema.pool_len() };
+            let info = MemPoolInfo { size: schema.tx_pool_len() };
             self.ok_response(&serde_json::to_value(info).unwrap())
         };
         router.get("/v1/mempool", mempool, "mempool");

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -51,9 +51,7 @@ impl SystemApi {
         let mempool = move |_: &mut Request| -> IronResult<Response> {
             let snapshot = self.blockchain.snapshot();
             let schema = Schema::new(&snapshot);
-            let pool = schema.transactions_pool();
-            let count = pool.iter().count();
-            let info = MemPoolInfo { size: count };
+            let info = MemPoolInfo { size: schema.pool_len() };
             self.ok_response(&serde_json::to_value(info).unwrap())
         };
         router.get("/v1/mempool", mempool, "mempool");

--- a/exonum/src/api/public/system.rs
+++ b/exonum/src/api/public/system.rs
@@ -16,8 +16,7 @@ use router::Router;
 use iron::prelude::*;
 use serde_json;
 
-use node::state::TxPool;
-use blockchain::{Blockchain, SharedNodeState};
+use blockchain::{Schema, Blockchain, SharedNodeState};
 use api::Api;
 use helpers::user_agent;
 
@@ -35,20 +34,14 @@ pub struct HealthCheckInfo {
 /// Public system API.
 #[derive(Clone, Debug)]
 pub struct SystemApi {
-    pool: TxPool,
     blockchain: Blockchain,
     shared_api_state: SharedNodeState,
 }
 
 impl SystemApi {
     /// Creates a new `private::SystemApi` instance.
-    pub fn new(
-        pool: TxPool,
-        blockchain: Blockchain,
-        shared_api_state: SharedNodeState,
-    ) -> SystemApi {
+    pub fn new(blockchain: Blockchain, shared_api_state: SharedNodeState) -> SystemApi {
         SystemApi {
-            pool,
             blockchain,
             shared_api_state,
         }
@@ -56,7 +49,11 @@ impl SystemApi {
 
     fn mempool_info(self, router: &mut Router) {
         let mempool = move |_: &mut Request| -> IronResult<Response> {
-            let info = MemPoolInfo { size: self.pool.read().expect("Expected read lock").len() };
+            let snapshot = self.blockchain.snapshot();
+            let schema = Schema::new(&snapshot);
+            let pool = schema.transactions_pool();
+            let count = pool.iter().count();
+            let info = MemPoolInfo { size: count };
             self.ok_response(&serde_json::to_value(info).unwrap())
         };
         router.get("/v1/mempool", mempool, "mempool");

--- a/exonum/src/api/tests.rs
+++ b/exonum/src/api/tests.rs
@@ -37,6 +37,7 @@ fn test_json_response_for_complex_val() {
         &Hash::new([38; 32]),
     );
     struct SampleAPI;
+
     impl Api for SampleAPI {
         fn wire<'b>(&self, _: &'b mut Router) {
             return;

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -389,7 +389,7 @@ impl Blockchain {
 
         let mut schema = Schema::new(fork);
         schema.transaction_results_mut().put(&tx_hash, tx_result);
-        schema.transactions_pool_mut().remove(&tx_hash);
+        schema.commit_transaction(&tx_hash);
         schema.block_txs_mut(height).push(tx_hash);
         let location = TxLocation::new(height, index as u64);
         schema.tx_location_by_tx_hash_mut().put(&tx_hash, location);

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -267,8 +267,8 @@ impl Blockchain {
             // Save & execute transactions.
             for (index, hash) in tx_hashes.iter().enumerate() {
                 self.execute_transaction(*hash, height, index, &mut fork)
-                    // execute_transaction could fail,with invalid
-                    // Transaction that cannot be deserialized, or not found in pool.
+                    // Execution could fail if the transaction
+                    // cannot be deserialized or it isn't in the pool.
                     .expect("Transaction not found in the database.");
             }
 

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -339,11 +339,11 @@ where
         Height(self.block_hashes_by_height().len())
     }
 
-    /// Count txs in pool
+    /// Returns number of transactions in the pool
     #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-    pub fn pool_len(&self) -> usize {
+    pub fn tx_pool_len(&self) -> usize {
         let pool = self.transactions_pool();
-        // TODO: Change count to other method with O(1) complexity (ECR-977)
+        // TODO: Change count to other method with O(1) complexity. (ECR-977)
         let count = pool.iter().count();
         count
     }

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -338,6 +338,14 @@ where
     fn next_height(&self) -> Height {
         Height(self.block_hashes_by_height().len())
     }
+
+    /// Count txs in pool
+    #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
+    pub fn pool_len(&self) -> usize {
+        let pool = self.transactions_pool();
+        let count = pool.iter().count();
+        count
+    }
 }
 
 impl<'a> Schema<&'a mut Fork> {
@@ -352,7 +360,9 @@ impl<'a> Schema<&'a mut Fork> {
     /// Mutable reference to the [`transaction_results`][1] index.
     ///
     /// [1]: struct.Schema.html#method.transaction_results
-    pub fn transaction_results_mut(&mut self) -> ProofMapIndex<&mut Fork, Hash, TransactionResult> {
+    pub(crate) fn transaction_results_mut(
+        &mut self,
+    ) -> ProofMapIndex<&mut Fork, Hash, TransactionResult> {
         ProofMapIndex::new(TRANSACTION_RESULTS, self.view)
     }
 
@@ -479,7 +489,7 @@ impl<'a> Schema<&'a mut Fork> {
         // TODO: clear storages
     }
 
-    /// add transaction into persistent pool
+    /// Adds transaction into persistent pool
     #[doc(hidden)]
     pub fn add_transaction_into_pool(&mut self, tx: RawMessage) {
         self.transactions_pool_mut().insert(tx.hash());

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -25,11 +25,13 @@ use encoding::Error as MessageError;
 use helpers::{Height, ValidatorId};
 
 const IDX_NAME: &'static str = "idx_name";
+const TEST_SERVICE_ID: u16 = 255;
 
 struct TestService;
+
 impl Service for TestService {
     fn service_id(&self) -> u16 {
-        255
+        TEST_SERVICE_ID
     }
 
     fn service_name(&self) -> &'static str {
@@ -48,7 +50,7 @@ impl Service for TestService {
 
 transactions! {
     TestServiceTxs {
-        const SERVICE_ID = 255;
+        const SERVICE_ID = TEST_SERVICE_ID;
         struct Tx {
             value: u64,
         }
@@ -185,10 +187,6 @@ fn gen_tempdir_name() -> String {
     thread_rng().gen_ascii_chars().take(10).collect()
 }
 
-fn insert_tx(schema: &mut Schema<&mut Fork>, hash: Hash, tx: RawTransaction) {
-    schema.transactions_pool_mut().insert(hash);
-    schema.transactions_mut().put(&hash, tx.raw().clone());
-}
 
 fn handling_tx_panic(blockchain: &mut Blockchain) {
     let (_, sec_key) = gen_keypair();
@@ -203,14 +201,10 @@ fn handling_tx_panic(blockchain: &mut Blockchain) {
         {
             let mut schema = Schema::new(&mut fork);
 
-            insert_tx(&mut schema, tx_ok1.hash(), tx_ok1.raw().clone());
-            insert_tx(&mut schema, tx_ok2.hash(), tx_ok2.raw().clone());
-            insert_tx(&mut schema, tx_failed.hash(), tx_failed.raw().clone());
-            insert_tx(
-                &mut schema,
-                tx_storage_error.hash(),
-                tx_storage_error.raw().clone(),
-            );
+            schema.add_transaction_into_pool(tx_ok1.raw().clone());
+            schema.add_transaction_into_pool(tx_ok2.raw().clone());
+            schema.add_transaction_into_pool(tx_failed.raw().clone());
+            schema.add_transaction_into_pool(tx_storage_error.raw().clone());
         }
         fork.into_patch()
     };
@@ -260,14 +254,10 @@ fn handling_tx_panic_storage_error(blockchain: &mut Blockchain) {
         let mut fork = blockchain.fork();
         {
             let mut schema = Schema::new(&mut fork);
-            insert_tx(&mut schema, tx_ok1.hash(), tx_ok1.raw().clone());
-            insert_tx(&mut schema, tx_ok2.hash(), tx_ok2.raw().clone());
-            insert_tx(&mut schema, tx_failed.hash(), tx_failed.raw().clone());
-            insert_tx(
-                &mut schema,
-                tx_storage_error.hash(),
-                tx_storage_error.raw().clone(),
-            );
+            schema.add_transaction_into_pool(tx_ok1.raw().clone());
+            schema.add_transaction_into_pool(tx_ok2.raw().clone());
+            schema.add_transaction_into_pool(tx_failed.raw().clone());
+            schema.add_transaction_into_pool(tx_storage_error.raw().clone());
         }
         fork.into_patch()
     };

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -14,18 +14,62 @@
 
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
-
 use rand::{thread_rng, Rng};
 use serde_json;
 
-use blockchain::{Blockchain, Schema, Transaction, ExecutionResult};
-use crypto::{gen_keypair, CryptoHash, Hash};
-use storage::{Database, Fork, Error, ListIndex};
-use messages::Message;
+use blockchain::{Blockchain, Service, Snapshot, Schema, Transaction, ExecutionResult};
+use crypto::{gen_keypair, Hash, CryptoHash};
+use storage::{Error, Fork, ListIndex};
+use messages::{Message, RawTransaction};
+use encoding::Error as MessageError;
 use helpers::{Height, ValidatorId};
 
 const IDX_NAME: &'static str = "idx_name";
+
+struct TestService;
+impl Service for TestService {
+    fn service_id(&self) -> u16 {
+        255
+    }
+
+    fn service_name(&self) -> &'static str {
+        "test service"
+    }
+
+
+    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        vec![]
+    }
+
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+        Ok(Box::new(Tx::from_raw(raw)?))
+    }
+}
+
+transactions! {
+    TestServiceTxs {
+        const SERVICE_ID = 255;
+        struct Tx {
+            value: u64,
+        }
+    }
+}
+
+impl Transaction for Tx {
+    fn verify(&self) -> bool {
+        true
+    }
+
+    fn execute(&self, view: &mut Fork) -> ExecutionResult {
+        if self.value() == 42 {
+            panic!(Error::new("42"))
+        }
+        let mut index = ListIndex::new(IDX_NAME, view);
+        index.push(self.value());
+        index.push(42 / self.value());
+        Ok(())
+    }
+}
 
 #[test]
 fn test_encode_decode() {
@@ -141,32 +185,12 @@ fn gen_tempdir_name() -> String {
     thread_rng().gen_ascii_chars().take(10).collect()
 }
 
-fn handling_tx_panic(blockchain: &Blockchain, db: &mut Box<Database>) {
-    messages! {
-        const SERVICE_ID = 1;
-        struct Tx {
-            value: u64,
-        }
-    }
+fn insert_tx(schema: &mut Schema<&mut Fork>, hash: Hash, tx: RawTransaction) {
+    schema.transactions_pool_mut().insert(hash);
+    schema.transactions_mut().put(&hash, tx.raw().clone());
+}
 
-    impl Transaction for Tx {
-        fn verify(&self) -> bool {
-            true
-        }
-
-        fn execute(&self, fork: &mut Fork) -> ExecutionResult {
-            if self.value() == 42 {
-                panic!(Error::new("42"))
-            }
-
-            let mut index = ListIndex::new(IDX_NAME, fork);
-            index.push(self.value());
-            index.push(42 / self.value());
-
-            Ok(())
-        }
-    }
-
+fn handling_tx_panic(blockchain: &mut Blockchain) {
     let (_, sec_key) = gen_keypair();
 
     let tx_ok1 = Tx::new(3, &sec_key);
@@ -174,31 +198,34 @@ fn handling_tx_panic(blockchain: &Blockchain, db: &mut Box<Database>) {
     let tx_failed = Tx::new(0, &sec_key);
     let tx_storage_error = Tx::new(42, &sec_key);
 
-    let mut pool: BTreeMap<Hash, Box<Transaction>> = BTreeMap::new();
+    let patch = {
+        let mut fork = blockchain.fork();
+        {
+            let mut schema = Schema::new(&mut fork);
 
-    pool.insert(tx_ok1.hash(), Box::new(tx_ok1.clone()) as Box<Transaction>);
-    pool.insert(tx_ok2.hash(), Box::new(tx_ok2.clone()) as Box<Transaction>);
-    pool.insert(
-        tx_failed.hash(),
-        Box::new(tx_failed.clone()) as Box<Transaction>,
-    );
-    pool.insert(
-        tx_storage_error.hash(),
-        Box::new(tx_storage_error.clone()) as Box<Transaction>,
-    );
+            insert_tx(&mut schema, tx_ok1.hash(), tx_ok1.raw().clone());
+            insert_tx(&mut schema, tx_ok2.hash(), tx_ok2.raw().clone());
+            insert_tx(&mut schema, tx_failed.hash(), tx_failed.raw().clone());
+            insert_tx(
+                &mut schema,
+                tx_storage_error.hash(),
+                tx_storage_error.raw().clone(),
+            );
+        }
+        fork.into_patch()
+    };
+    blockchain.merge(patch).unwrap();
 
     let (_, patch) = blockchain.create_patch(
         ValidatorId::zero(),
         Height::zero(),
         &[tx_ok1.hash(), tx_failed.hash(), tx_ok2.hash()],
-        &pool,
     );
 
-    db.merge(patch).unwrap();
-    let snapshot = db.snapshot();
+    blockchain.merge(patch).unwrap();
+    let snapshot = blockchain.snapshot();
 
     let schema = Schema::new(&snapshot);
-
     assert_eq!(
         schema.transactions().get(&tx_ok1.hash()),
         Some(tx_ok1.raw().clone())
@@ -221,30 +248,7 @@ fn handling_tx_panic(blockchain: &Blockchain, db: &mut Box<Database>) {
     assert_eq!(index.get(3), Some(10));
 }
 
-fn handling_tx_panic_storage_error(blockchain: &Blockchain) {
-    messages! {
-        const SERVICE_ID = 1;
-        struct Tx {
-            value: u64,
-        }
-    }
-
-    impl Transaction for Tx {
-        fn verify(&self) -> bool {
-            true
-        }
-
-        fn execute(&self, view: &mut Fork) -> ExecutionResult {
-            if self.value() == 42 {
-                panic!(Error::new("42"))
-            }
-            let mut index = ListIndex::new(IDX_NAME, view);
-            index.push(self.value());
-            index.push(42 / self.value());
-            Ok(())
-        }
-    }
-
+fn handling_tx_panic_storage_error(blockchain: &mut Blockchain) {
     let (_, sec_key) = gen_keypair();
 
     let tx_ok1 = Tx::new(3, &sec_key);
@@ -252,24 +256,26 @@ fn handling_tx_panic_storage_error(blockchain: &Blockchain) {
     let tx_failed = Tx::new(0, &sec_key);
     let tx_storage_error = Tx::new(42, &sec_key);
 
-    let mut pool: BTreeMap<Hash, Box<Transaction>> = BTreeMap::new();
-
-    pool.insert(tx_ok1.hash(), Box::new(tx_ok1.clone()) as Box<Transaction>);
-    pool.insert(tx_ok2.hash(), Box::new(tx_ok2.clone()) as Box<Transaction>);
-    pool.insert(
-        tx_failed.hash(),
-        Box::new(tx_failed.clone()) as Box<Transaction>,
-    );
-    pool.insert(
-        tx_storage_error.hash(),
-        Box::new(tx_storage_error.clone()) as Box<Transaction>,
-    );
-
+    let patch = {
+        let mut fork = blockchain.fork();
+        {
+            let mut schema = Schema::new(&mut fork);
+            insert_tx(&mut schema, tx_ok1.hash(), tx_ok1.raw().clone());
+            insert_tx(&mut schema, tx_ok2.hash(), tx_ok2.raw().clone());
+            insert_tx(&mut schema, tx_failed.hash(), tx_failed.raw().clone());
+            insert_tx(
+                &mut schema,
+                tx_storage_error.hash(),
+                tx_storage_error.raw().clone(),
+            );
+        }
+        fork.into_patch()
+    };
+    blockchain.merge(patch).unwrap();
     blockchain.create_patch(
         ValidatorId::zero(),
         Height::zero(),
         &[tx_ok1.hash(), tx_storage_error.hash(), tx_ok2.hash()],
-        &pool,
     );
 }
 
@@ -372,7 +378,7 @@ mod memorydb_tests {
     use std::path::Path;
     use tempdir::TempDir;
     use storage::{Database, MemoryDB};
-    use blockchain::Blockchain;
+    use blockchain::{Blockchain, Service};
     use crypto::gen_keypair;
     use node::ApiSender;
 
@@ -385,7 +391,7 @@ mod memorydb_tests {
         let api_channel = mpsc::channel(1);
         Blockchain::new(
             MemoryDB::new(),
-            Vec::new(),
+            vec![Box::new(super::TestService) as Box<Service>],
             service_keypair.0,
             service_keypair.1,
             ApiSender::new(api_channel.0),
@@ -396,11 +402,8 @@ mod memorydb_tests {
     fn test_handling_tx_panic() {
         let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
         let path = dir.path();
-        let blockchain = create_blockchain(path);
-        let dir1 = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
-        let path1 = dir1.path();
-        let mut db = create_database(path1);
-        super::handling_tx_panic(&blockchain, &mut db);
+        let mut blockchain = create_blockchain(path);
+        super::handling_tx_panic(&mut blockchain);
     }
 
     #[test]
@@ -408,8 +411,8 @@ mod memorydb_tests {
     fn test_handling_tx_panic_storage_error() {
         let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
         let path = dir.path();
-        let blockchain = create_blockchain(path);
-        super::handling_tx_panic_storage_error(&blockchain);
+        let mut blockchain = create_blockchain(path);
+        super::handling_tx_panic_storage_error(&mut blockchain);
     }
 }
 
@@ -418,7 +421,7 @@ mod rocksdb_tests {
     use std::path::Path;
     use tempdir::TempDir;
     use storage::{Database, RocksDB, DbOptions};
-    use blockchain::Blockchain;
+    use blockchain::{Blockchain, Service};
     use crypto::gen_keypair;
     use node::ApiSender;
 
@@ -433,7 +436,7 @@ mod rocksdb_tests {
         let api_channel = mpsc::channel(1);
         Blockchain::new(
             db,
-            Vec::new(),
+            vec![Box::new(super::TestService) as Box<Service>],
             service_keypair.0,
             service_keypair.1,
             ApiSender::new(api_channel.0),
@@ -444,11 +447,8 @@ mod rocksdb_tests {
     fn test_handling_tx_panic() {
         let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
         let path = dir.path();
-        let blockchain = create_blockchain(path);
-        let dir1 = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
-        let path1 = dir1.path();
-        let mut db = create_database(path1);
-        super::handling_tx_panic(&blockchain, &mut db);
+        let mut blockchain = create_blockchain(path);
+        super::handling_tx_panic(&mut blockchain);
     }
 
     #[test]
@@ -456,7 +456,7 @@ mod rocksdb_tests {
     fn test_handling_tx_panic_storage_error() {
         let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
         let path = dir.path();
-        let blockchain = create_blockchain(path);
-        super::handling_tx_panic_storage_error(&blockchain);
+        let mut blockchain = create_blockchain(path);
+        super::handling_tx_panic_storage_error(&mut blockchain);
     }
 }

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -621,10 +621,13 @@ mod tests {
 
     use super::*;
     use crypto;
+    use encoding;
     use blockchain::{Service, Schema, Blockchain};
     use storage::{Snapshot, Database, MemoryDB, Entry};
     use node::ApiSender;
     use helpers::{ValidatorId, Height};
+
+    const TX_RESULT_SERVICE_ID: u16 = 255;
 
     lazy_static! {
         static ref EXECUTION_STATUS: Mutex<ExecutionResult> = Mutex::new(Ok(()));
@@ -825,28 +828,28 @@ mod tests {
     }
 
     struct TxResultService;
+
     impl Service for TxResultService {
         fn service_id(&self) -> u16 {
-            1
+            TX_RESULT_SERVICE_ID
         }
 
         fn service_name(&self) -> &'static str {
             "test service"
         }
 
-
         fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
             vec![]
         }
 
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, ::encoding::Error> {
+        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {
             Ok(Box::new(TxResult::from_raw(raw)?))
         }
     }
 
     transactions! {
-        TestTx {
-            const SERVICE_ID = 1;
+        TestTxs {
+            const SERVICE_ID = TX_RESULT_SERVICE_ID;
 
             struct TxResult {
                 index: u64,

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -759,11 +759,7 @@ mod tests {
                 let mut fork = blockchain.fork();
                 {
                     let mut schema = Schema::new(&mut fork);
-                    schema.transactions_mut().put(
-                        &hash,
-                        transaction.raw().clone(),
-                    );
-                    schema.transactions_pool_mut().insert(hash);
+                    schema.add_transaction_into_pool(transaction.raw().clone());
                 }
                 blockchain.merge(fork.into_patch()).unwrap();
             }

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -216,9 +216,9 @@ impl NodeHandler {
                 for raw in msg.transactions() {
                     if let Some(tx) = self.blockchain.tx_from_raw(raw) {
                         let hash = tx.hash();
-                        if schema.transactions().get(&hash).is_some() {
+                        if schema.transactions().contains(&hash) {
                             error!(
-                                "Received block with already committed transaction, block={:?}",
+                                "Received block with already known transaction, block={:?}",
                                 msg
                             );
                             return;

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -121,7 +121,7 @@ impl NodeHandler {
 
         let snapshot = self.blockchain.snapshot();
         let schema = Schema::new(&*snapshot);
-        //TODO: remove this match after errors refactor.
+        //TODO: remove this match after errors refactor. (ECR-979)
         let has_unknown_txs = match self.state.add_propose(
             msg,
             &schema.transactions(),

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -117,28 +117,24 @@ impl NodeHandler {
             return;
         }
 
+        trace!("Handle propose");
+
         let snapshot = self.blockchain.snapshot();
-        // Check that transactions are not committed yet
-        for hash in msg.transactions() {
-            if Schema::new(&snapshot).transactions().contains(hash) {
-                error!(
-                    "Received propose with already committed transaction, msg={:?}",
-                    msg
-                );
+        let schema = Schema::new(snapshot);
+        //TODO: remove this match after errors refactor.
+        let has_unknown_txs = match self.state.add_propose(
+            msg,
+            schema.transactions(),
+            schema.transactions_pool(),
+        ) {
+            Ok(state) => state.has_unknown_txs(),
+            Err(err) => {
+                warn!("{}, msg={:?}", err, msg);
                 return;
             }
-        }
-
-        if self.state.propose(&msg.hash()).is_some() {
-            return;
-        }
-
-        trace!("Handle propose");
-        // Add propose
-        let (hash, has_unknown_txs) = match self.state.add_propose(msg) {
-            Some(state) => (state.hash(), state.has_unknown_txs()),
-            None => return,
         };
+
+        let hash = msg.hash();
 
         // Remove request info
         let known_nodes = self.remove_request(&RequestData::Propose(hash));
@@ -210,34 +206,42 @@ impl NodeHandler {
         }
 
         if self.state.block(&block_hash).is_none() {
-            let snapshot = self.blockchain.snapshot();
-            let schema = Schema::new(&snapshot);
+
+
             // Verify transactions
             let mut tx_hashes = Vec::new();
-            for raw in msg.transactions() {
-                if let Some(tx) = self.blockchain.tx_from_raw(raw) {
-                    let hash = tx.hash();
-                    if schema.transactions().contains(&hash) {
-                        error!(
-                            "Received block with already committed transaction, block={:?}",
-                            msg
-                        );
-                        return;
-                    }
-                    profiler_span!("tx.verify()", {
-                        if !tx.verify() {
-                            error!("Incorrect transaction in block detected, block={:?}", msg);
+            let mut fork = self.blockchain.fork();
+            {
+                let mut schema = Schema::new(&mut fork);
+
+                for raw in msg.transactions() {
+                    if let Some(tx) = self.blockchain.tx_from_raw(raw) {
+                        let hash = tx.hash();
+                        if schema.transactions().get(&hash).is_some() {
+                            error!(
+                                "Received block with already committed transaction, block={:?}",
+                                msg
+                            );
                             return;
                         }
-                    });
-                    self.state.add_transaction(hash, tx, true);
-                    tx_hashes.push(hash);
-                } else {
-                    error!("Unknown transaction in block detected, block={:?}", msg);
-                    return;
+                        profiler_span!("tx.verify()", {
+                            if !tx.verify() {
+                                error!("Incorrect transaction in block detected, block={:?}", msg);
+                                return;
+                            }
+                        });
+                        schema.transactions_pool_mut().insert(hash);
+                        schema.transactions_mut().put(&hash, tx.raw().clone());
+                        tx_hashes.push(hash);
+                    } else {
+                        error!("Unknown transaction in block detected, block={:?}", msg);
+                        return;
+                    }
                 }
             }
-
+            self.blockchain.merge(fork.into_patch()).expect(
+                "Unable to save transaction to persistent pool.",
+            );
             let (block_hash, patch) =
                 self.create_block(block.proposer_id(), block.height(), tx_hashes.as_slice());
             // Verify block_hash
@@ -259,6 +263,7 @@ impl NodeHandler {
         }
         self.commit(block_hash, msg.precommits().iter(), None);
         self.request_next_block();
+
     }
 
     /// Executes and commits block. This function is called when node has full propose information.
@@ -487,12 +492,11 @@ impl NodeHandler {
             );
             (block_state.txs().len(), block_state.proposer_id())
         };
+        let snapshot = self.blockchain.snapshot();
+        let schema = Schema::new(&snapshot);
+        let pool = schema.transactions_pool();
+        let mempool_size = pool.iter().count();
 
-        let mempool_size = self.state
-            .transactions()
-            .read()
-            .expect("Expected read lock")
-            .len();
         metric!("node.mempool", mempool_size);
 
         let height = self.state.height();
@@ -536,7 +540,7 @@ impl NodeHandler {
         let hash = msg.hash();
         let tx = {
             let service_id = msg.service_id();
-            if let Some(tx) = self.blockchain.tx_from_raw(msg) {
+            if let Some(tx) = self.blockchain.tx_from_raw(msg.clone()) {
                 tx
             } else {
                 error!(
@@ -548,15 +552,6 @@ impl NodeHandler {
         };
 
         profiler_span!("Make sure that it is new transaction", {
-            if self.state
-                .transactions()
-                .read()
-                .expect("Expected read lock")
-                .contains_key(&hash)
-            {
-                return;
-            }
-
             let snapshot = self.blockchain.snapshot();
             if Schema::new(&snapshot).transactions().contains(&hash) {
                 return;
@@ -568,8 +563,17 @@ impl NodeHandler {
                 return;
             }
         });
+        let mut fork = self.blockchain.fork();
+        {
+            let mut schema = Schema::new(&mut fork);
+            schema.transactions_pool_mut().insert(hash);
+            schema.transactions_mut().put(&hash, msg.raw().clone());
+        }
+        self.blockchain.merge(fork.into_patch()).expect(
+            "Unable to save transaction to persistent pool.",
+        );
 
-        let full_proposes = self.state.add_transaction(hash, tx, false);
+        let full_proposes = self.state.transaction_validated(hash);
         // Go to has full propose if we get last transaction
         for (hash, round) in full_proposes {
             self.remove_request(&RequestData::Transactions(hash));
@@ -582,27 +586,20 @@ impl NodeHandler {
     pub fn handle_incoming_tx(&mut self, msg: Box<Transaction>) {
         trace!("Handle incoming transaction");
         let hash = msg.hash();
-
-        // Make sure that it is new transaction
-        if self.state
-            .transactions()
-            .read()
-            .expect("Expected read lock")
-            .contains_key(&hash)
+        let mut fork = self.blockchain.fork();
         {
-            return;
+            let mut schema = Schema::new(&mut fork);
+            schema.transactions_pool_mut().insert(hash);
+            schema.transactions_mut().put(&hash, msg.raw().clone());
         }
-
-        let snapshot = self.blockchain.snapshot();
-        if Schema::new(&snapshot).transactions().contains(&hash) {
-            return;
-        }
-
+        self.blockchain.merge(fork.into_patch()).expect(
+            "Unable to save transaction to persistent pool.",
+        );
         // Broadcast transaction to validators
         trace!("Broadcast transactions: {:?}", msg.raw());
         self.broadcast(msg.raw());
 
-        let full_proposes = self.state.add_transaction(hash, msg, false);
+        let full_proposes = self.state.transaction_validated(hash);
         // Go to has full propose if we get last transaction
         for (hash, round) in full_proposes {
             self.remove_request(&RequestData::Transactions(hash));
@@ -684,24 +681,17 @@ impl NodeHandler {
             if self.state.have_prevote(round) {
                 return;
             }
-            let pool_len = self.state
-                .transactions()
-                .read()
-                .expect("Expected read lock")
-                .len();
+            let snapshot = self.blockchain.snapshot();
+            let schema = Schema::new(&snapshot);
+            let pool = schema.transactions_pool();
+            let pool_len = pool.iter().count();
 
             info!("LEADER: pool = {}", pool_len);
 
             let round = self.state.round();
             let max_count = ::std::cmp::min(self.txs_block_limit() as usize, pool_len);
-            let txs: Vec<Hash> = self.state
-                .transactions()
-                .read()
-                .expect("Expected read lock")
-                .keys()
-                .take(max_count)
-                .cloned()
-                .collect();
+
+            let txs: Vec<Hash> = pool.iter().take(max_count).collect();
             let propose = Propose::new(
                 validator_id,
                 self.state.height(),
@@ -796,14 +786,7 @@ impl NodeHandler {
         height: Height,
         tx_hashes: &[Hash],
     ) -> (Hash, Patch) {
-        self.blockchain.create_patch(
-            proposer_id,
-            height,
-            tx_hashes,
-            &self.state.transactions().read().expect(
-                "Expected read lock",
-            ),
-        )
+        self.blockchain.create_patch(proposer_id, height, tx_hashes)
     }
 
     /// Calls `create_block` with transactions from the corresponding `Propose` and returns the

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -261,7 +261,6 @@ impl NodeHandler {
         }
         self.commit(block_hash, msg.precommits().iter(), None);
         self.request_next_block();
-
     }
 
     /// Executes and commits block. This function is called when node has full propose information.

--- a/exonum/src/node/requests.rs
+++ b/exonum/src/node/requests.rs
@@ -77,15 +77,7 @@ impl NodeHandler {
         let snapshot = self.blockchain.snapshot();
         let schema = Schema::new(&snapshot);
         for hash in msg.txs() {
-            let tx = self.state
-                .transactions()
-                .read()
-                .expect("Expected read lock")
-                .get(hash)
-                .map(|tx| tx.raw())
-                .cloned()
-                .or_else(|| schema.transactions().get(hash));
-
+            let tx = schema.transactions().get(hash);
             if let Some(tx) = tx {
                 self.send_to_peer(*msg.from(), &tx);
             }

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -739,8 +739,8 @@ impl State {
     }
 
 
-    /// Handles a transaction validated event and returns list of proposes
-    /// that don't contain unknown transactions now.
+    /// Checks whether some proposes are waiting for this transaction.
+    /// Returns a list of proposes that don't contain unknown transactions.
     ///
     /// Transaction is ignored if the following criteria are fulfilled:
     ///

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -16,18 +16,16 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::collections::hash_map::Entry;
-use std::sync::{Arc, RwLock};
 use std::net::SocketAddr;
 use std::time::{SystemTime, Duration};
 
 use serde_json::Value;
 use bit_vec::BitVec;
 
-use messages::{Message, Propose, Prevote, Precommit, ConsensusMessage, Connect};
+use messages::{RawMessage, Message, Propose, Prevote, Precommit, ConsensusMessage, Connect};
 use crypto::{CryptoHash, PublicKey, SecretKey, Hash};
-use storage::{Patch, Snapshot};
-use blockchain::{ValidatorKeys, ConsensusConfig, StoredConfiguration, Transaction,
-                 TimeoutAdjusterConfig};
+use storage::{Patch, Snapshot, MapIndex, KeySetIndex};
+use blockchain::{ValidatorKeys, ConsensusConfig, StoredConfiguration, TimeoutAdjusterConfig};
 use helpers::{Height, Round, ValidatorId, Milliseconds};
 use node::whitelist::Whitelist;
 use node::timeout_adjuster::{TimeoutAdjuster, Constant, Dynamic, MovingAverage};
@@ -43,10 +41,6 @@ pub const PREVOTES_REQUEST_TIMEOUT: Milliseconds = 100;
 /// Timeout value for the `BlockRequest` message.
 pub const BLOCK_REQUEST_TIMEOUT: Milliseconds = 100;
 
-/// Transactions pool.
-// TODO replace by persistent TxPool (ECR-171)
-pub type TxPool = Arc<RwLock<BTreeMap<Hash, Box<Transaction>>>>;
-// TODO: reduce copying of Hash (ECR-171)
 
 /// State of the `NodeHandler`.
 #[derive(Debug)]
@@ -78,8 +72,6 @@ pub struct State {
     blocks: HashMap<Hash, BlockState>,
     prevotes: HashMap<(Round, Hash), Votes<Prevote>>,
     precommits: HashMap<(Round, Hash), Votes<Precommit>>,
-
-    transactions: TxPool,
 
     queued: Vec<ConsensusMessage>,
 
@@ -399,8 +391,6 @@ impl State {
             blocks: HashMap::new(),
             prevotes: HashMap::new(),
             precommits: HashMap::new(),
-
-            transactions: Arc::new(RwLock::new(BTreeMap::new())),
 
             queued: Vec::new(),
 
@@ -723,16 +713,6 @@ impl State {
         self.locked_round = Round::zero();
         self.locked_propose = None;
         self.last_hash = *block_hash;
-        {
-            // Commit transactions if needed
-            let txs = self.block(block_hash).unwrap().txs.clone();
-            for hash in txs {
-                self.transactions
-                    .write()
-                    .expect("Expected write lock")
-                    .remove(&hash);
-            }
-        }
         // TODO: destruct/construct structure HeightState instead of call clear (ECR-171)
         self.blocks.clear();
         self.proposes.clear();
@@ -757,51 +737,23 @@ impl State {
         self.queued.push(msg);
     }
 
-    /// Returns non-committed transactions.
-    pub fn transactions(&self) -> &TxPool {
-        &self.transactions
-    }
 
-    /// Adds a transaction to the pool and returns list of proposes that don't contain unknown
-    /// transactions now.
+    /// Handles a transaction validated event and returns list of proposes
+    /// that don't contain unknown transactions now.
     ///
     /// Transaction is ignored if the following criteria are fulfilled:
     ///
     /// - transactions pool size is exceeded
     /// - transaction isn't contained in unknown transaction list of any propose
     /// - transaction isn't a part of block
-    pub fn add_transaction(
-        &mut self,
-        tx_hash: Hash,
-        msg: Box<Transaction>,
-        // if tx is in some of propose or in a block,
-        // we should add it, or we could become stuck in some state
-        mut high_priority_tx: bool,
-    ) -> Vec<(Hash, Round)> {
+    pub fn transaction_validated(&mut self, tx_hash: Hash) -> Vec<(Hash, Round)> {
         let mut full_proposes = Vec::new();
         for (propose_hash, propose_state) in &mut self.proposes {
-            high_priority_tx |= propose_state.unknown_txs.remove(&tx_hash);
+            propose_state.unknown_txs.remove(&tx_hash);
             if propose_state.unknown_txs.is_empty() {
                 full_proposes.push((*propose_hash, propose_state.message().round()));
             }
         }
-        let tx_pool_len = self.transactions.read().expect("Expected read lock").len();
-        if tx_pool_len >= self.tx_pool_capacity {
-            // but make warn about pool exceeded, even if we should add tx
-            warn!(
-                "Too many transactions in pool, txs={}, high_priority={}",
-                tx_pool_len,
-                high_priority_tx
-            );
-            if !high_priority_tx {
-                return full_proposes;
-            }
-        }
-
-        self.transactions
-            .write()
-            .expect("Expected read lock")
-            .insert(tx_hash, msg);
 
         full_proposes
     }
@@ -856,25 +808,40 @@ impl State {
     }
 
     /// Adds propose from other node. Returns `ProposeState` if it is a new propose.
-    pub fn add_propose(&mut self, msg: &Propose) -> Option<&ProposeState> {
+    pub fn add_propose(
+        &mut self,
+        msg: &Propose,
+        transactions: MapIndex<&Box<Snapshot>, Hash, RawMessage>,
+        transaction_pool: KeySetIndex<&Box<Snapshot>, Hash>,
+    ) -> Result<&ProposeState, ::failure::Error> {
         let propose_hash = msg.hash();
-        let txs = &self.transactions.read().expect("Expected read lock");
         match self.proposes.entry(propose_hash) {
-            Entry::Occupied(..) => None,
+            Entry::Occupied(..) => bail!("Propose already found."),
             Entry::Vacant(e) => {
-                let unknown_txs = msg.transactions()
-                    .iter()
-                    .filter(|tx| !txs.contains_key(tx))
-                    .cloned()
-                    .collect::<HashSet<Hash>>();
+
+                let mut unknown_txs = HashSet::new();
+                for hash in msg.transactions() {
+                    if transactions.get(hash).is_some() {
+                        if !transaction_pool.contains(hash) {
+                            bail!(
+                                "Received propose with already\
+                                                committed transaction."
+                            )
+                        }
+                    } else {
+                        unknown_txs.insert(*hash);
+                    }
+                }
+
                 for tx in &unknown_txs {
                     self.unknown_txs.entry(*tx).or_insert_with(Vec::new).push(
                         propose_hash,
                     );
                 }
-                Some(e.insert(ProposeState {
+
+                Ok(e.insert(ProposeState {
                     propose: msg.clone(),
-                    unknown_txs,
+                    unknown_txs: unknown_txs,
                     block_hash: None,
                     is_saved: false,
                 }))

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -498,7 +498,7 @@ impl Sandbox {
             let mut fork = blockchain.fork();
             {
                 let mut schema = Schema::new(&mut fork);
-                for hash in recover.into_iter() {
+                for hash in recover {
                     schema.transactions_mut().remove(&hash);
                     schema.transactions_pool_mut().remove(&hash);
                 }

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -478,8 +478,7 @@ impl Sandbox {
                     hashes.push(hash);
                     if schema.transactions().get(&hash).is_none() {
                         recover.insert(hash);
-                        schema.transactions_mut().put(&hash, raw.clone());
-                        schema.transactions_pool_mut().insert(hash);
+                        schema.add_transaction_into_pool(raw.clone());
                     }
                 }
             }

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex};
 use std::cell::{Ref, RefCell, RefMut};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
 
 use futures::{self, Async, Future, Stream};
@@ -465,28 +465,51 @@ impl Sandbox {
     where
         I: IntoIterator<Item = &'a RawTransaction>,
     {
-        let blockchain = &self.blockchain_ref();
-        let (hashes, tx_pool) = {
-            let mut pool = BTreeMap::new();
+        let height = self.current_height();
+        let mut blockchain = self.blockchain_mut();
+        let (hashes, recover, patch) = {
             let mut hashes = Vec::new();
-            for raw in txs {
-                let tx = blockchain.tx_from_raw(raw.clone()).unwrap();
-                let hash = tx.hash();
-                hashes.push(hash);
-                pool.insert(hash, tx);
+            let mut recover = BTreeSet::new();
+            let mut fork = blockchain.fork();
+            {
+                let mut schema = Schema::new(&mut fork);
+                for raw in txs {
+                    let hash = raw.hash();
+                    hashes.push(hash);
+                    if schema.transactions().get(&hash).is_none() {
+                        recover.insert(hash);
+                        schema.transactions_mut().put(&hash, raw.clone());
+                        schema.transactions_pool_mut().insert(hash);
+                    }
+                }
             }
-            (hashes, pool)
+
+            (hashes, recover, fork.into_patch())
         };
+        blockchain.merge(patch).unwrap();
 
         let fork = {
             let mut fork = blockchain.fork();
-            let (_, patch) =
-                blockchain.create_patch(ValidatorId(0), self.current_height(), &hashes, &tx_pool);
+            let (_, patch) = blockchain.create_patch(ValidatorId(0), height, &hashes);
             fork.merge(patch);
             fork
         };
+        let patch = {
+            let mut fork = blockchain.fork();
+            {
+                let mut schema = Schema::new(&mut fork);
+                for hash in recover.into_iter() {
+                    schema.transactions_mut().remove(&hash);
+                    schema.transactions_pool_mut().remove(&hash);
+                }
+            }
+            fork.into_patch()
+        };
+
+        blockchain.merge(patch).unwrap();
         *Schema::new(&fork).last_block().state_hash()
     }
+
 
     pub fn get_proof_to_service_table(&self, service_id: u16, table_idx: usize) -> MapProof<Hash> {
         let snapshot = self.blockchain_ref().snapshot();
@@ -528,11 +551,10 @@ impl Sandbox {
     }
 
     pub fn transactions_hashes(&self) -> Vec<Hash> {
-        let node_state = self.node_state();
-        let read_lock = node_state.transactions().read().expect(
-            "Expected read lock",
-        );
-        read_lock.keys().cloned().collect()
+        let schema = Schema::new(self.blockchain_ref().snapshot());
+        let idx = schema.transactions_pool();
+        let vec = idx.iter().collect();
+        vec
     }
 
     pub fn current_round(&self) -> Round {

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -498,8 +498,7 @@ impl Sandbox {
             {
                 let mut schema = Schema::new(&mut fork);
                 for hash in recover {
-                    schema.transactions_mut().remove(&hash);
-                    schema.transactions_pool_mut().remove(&hash);
+                    schema.reject_transaction(&hash).unwrap();
                 }
             }
             fork.into_patch()

--- a/sandbox/src/sandbox_tests_helper.rs
+++ b/sandbox/src/sandbox_tests_helper.rs
@@ -396,6 +396,7 @@ where
             sandbox.assert_lock(round, Some(propose.hash()));
 
             trace!("last_block: {:?}", sandbox.last_block());
+            trace!("last_block.hash(): {:?}", sandbox.last_block().hash());
 
             let state_hash = sandbox.compute_state_hash(&raw_txs);
             let block = BlockBuilder::new(sandbox)

--- a/services/configuration/src/tests/api.rs
+++ b/services/configuration/src/tests/api.rs
@@ -436,7 +436,7 @@ fn test_post_propose_tx() {
     // Check results
     let tx = new_tx_config_propose(&testkit.network().validators()[0], new_cfg.clone());
     assert_eq!(tx.hash(), info.tx_hash);
-    assert!(testkit.mempool().contains_key(&info.tx_hash));
+    assert!(testkit.is_tx_in_pool(&info.tx_hash));
 }
 
 #[test]
@@ -458,5 +458,5 @@ fn test_post_vote_tx() {
     // Check results
     let tx = new_tx_config_vote(&testkit.network().validators()[0], new_cfg.hash());
     assert_eq!(tx.hash(), info.tx_hash);
-    assert!(testkit.mempool().contains_key(&info.tx_hash));
+    assert!(testkit.is_tx_in_pool(&info.tx_hash));
 }

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -68,7 +68,6 @@ impl fmt::Debug for TestKitApi {
 impl TestKitApi {
     /// Creates a new instance of API.
     pub(crate) fn new(testkit: &TestKit) -> Self {
-        use std::sync::Arc;
 
         let blockchain = &testkit.blockchain;
         let api_state = SharedNodeState::new(10_000);
@@ -76,7 +75,6 @@ impl TestKitApi {
         TestKitApi {
             public_handler: create_public_api_handler(
                 blockchain.clone(),
-                Arc::clone(&testkit.mempool),
                 api_state.clone(),
                 &testkit.api_config,
             ),

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -136,16 +136,15 @@ extern crate log;
 use futures::Stream;
 use futures::sync::mpsc;
 
-use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::fmt;
 
 use exonum::blockchain::{Blockchain, Schema as CoreSchema, Service, StoredConfiguration,
                          Transaction};
-use exonum::crypto;
+use exonum::crypto::{self, Hash};
 use exonum::helpers::{Height, ValidatorId};
-use exonum::node::{ApiSender, ExternalMessage, State as NodeState, TxPool, NodeApiConfig};
+use exonum::node::{ApiSender, ExternalMessage, State as NodeState, NodeApiConfig};
 use exonum::storage::{MemoryDB, Patch, Snapshot};
+use exonum::messages::RawMessage;
 
 #[macro_use]
 mod macros;
@@ -293,7 +292,6 @@ pub struct TestKit {
     events_stream: Box<Stream<Item = (), Error = ()> + Send + Sync>,
     network: TestNetwork,
     api_sender: ApiSender,
-    mempool: TxPool,
     cfg_proposal: Option<ConfigurationProposalState>,
     api_config: NodeApiConfig,
 }
@@ -303,7 +301,6 @@ impl fmt::Debug for TestKit {
         f.debug_struct("TestKit")
             .field("blockchain", &self.blockchain)
             .field("network", &self.network)
-            .field("mempool", &self.mempool)
             .field("cfg_change_proposal", &self.cfg_proposal)
             .finish()
     }
@@ -336,29 +333,25 @@ impl TestKit {
         let genesis = network.genesis_config();
         blockchain.initialize(genesis.clone()).unwrap();
 
-        let mempool = Arc::new(RwLock::new(BTreeMap::new()));
         let events_stream: Box<Stream<Item = (), Error = ()> + Send + Sync> = {
-            let blockchain = blockchain.clone();
-            let mempool = Arc::clone(&mempool);
-
+            let mut blockchain = blockchain.clone();
             Box::new(api_channel.1.and_then(move |event| {
-                let snapshot = blockchain.snapshot();
-                let schema = CoreSchema::new(&snapshot);
-
-                match event {
-                    ExternalMessage::Transaction(tx) => {
-                        let hash = tx.hash();
-                        if !schema.transactions().contains(&hash) {
-                            mempool
-                                .write()
-                                .expect("Cannot write transactions to mempool")
-                                .insert(tx.hash(), tx);
+                let mut fork = blockchain.fork();
+                {
+                    let mut schema = CoreSchema::new(&mut fork);
+                    match event {
+                        ExternalMessage::Transaction(tx) => {
+                            let hash = tx.hash();
+                            if !schema.transactions().contains(&hash) {
+                                schema.add_transaction_into_pool(tx.raw().clone());
+                            }
                         }
+                        ExternalMessage::PeerAdd(_) |
+                        ExternalMessage::Enable(_) |
+                        ExternalMessage::Shutdown => { /* Ignored */ }
                     }
-                    ExternalMessage::PeerAdd(_) |
-                    ExternalMessage::Enable(_) |
-                    ExternalMessage::Shutdown => { /* Ignored */ }
                 }
+                blockchain.merge(fork.into_patch()).unwrap();
                 Ok(())
             }))
         };
@@ -369,7 +362,6 @@ impl TestKit {
             api_sender,
             events_stream,
             network,
-            mempool: Arc::clone(&mempool),
             cfg_proposal: None,
             api_config: Default::default(),
         }
@@ -406,7 +398,7 @@ impl TestKit {
     /// ```
     /// # #[macro_use] extern crate exonum;
     /// # #[macro_use] extern crate exonum_testkit;
-    /// # use exonum::blockchain::{Service, Transaction, ExecutionResult};
+    /// # use exonum::blockchain::{Service, Transaction, TransactionSet, ExecutionResult};
     /// # use exonum::messages::RawTransaction;
     /// # use exonum::encoding;
     /// # use exonum_testkit::{TestKit, TestKitBuilder};
@@ -421,16 +413,17 @@ impl TestKit {
     /// #        Vec::new()
     /// #    }
     /// #    fn service_id(&self) -> u16 {
-    /// #        0
+    /// #        1
     /// #    }
-    /// #    fn tx_from_raw(&self, _raw: RawTransaction) -> FromRawResult {
-    /// #        unimplemented!();
+    /// #    fn tx_from_raw(&self, raw: RawTransaction) -> FromRawResult {
+    /// #        let tx = MyServiceTransactions::tx_from_raw(raw)?;
+    /// #        Ok(tx.into())
     /// #    }
     /// # }
     /// #
     /// # transactions! {
-    /// #     Transactions {
-    /// #         const SERVICE_ID = 0;
+    /// #     MyServiceTransactions {
+    /// #         const SERVICE_ID = 1;
     /// #
     /// #         struct MyTransaction {
     /// #             from: &exonum::crypto::PublicKey,
@@ -464,11 +457,11 @@ impl TestKit {
     /// # }
     /// ```
     pub fn rollback(&mut self, blocks: usize) {
-        assert!(
-            (blocks as u64) <= self.height().0,
-            "Cannot rollback past genesis block"
-        );
-        self.db_handler.rollback(blocks);
+        assert!(self.height().0 >= blocks, "Cannot rollback past genesis block");
+        // each block contain at least two phases:
+        // 1. add tx into pool
+        // 2. commit tx from pool to block
+        self.db_handler.rollback(blocks * 2);
     }
 
     /// Executes a list of transactions given the current state of the blockchain, but does not
@@ -479,15 +472,17 @@ impl TestKit {
     where
         I: IntoIterator<Item = Box<Transaction>>,
     {
+        self.poll_events();
         // Filter out already committed transactions; otherwise,
         // `create_block_with_transactions()` will panic.
         let schema = CoreSchema::new(self.snapshot());
         let uncommitted_txs = transactions.into_iter().filter(|tx| {
-            !schema.transactions().contains(&tx.hash())
+            !schema.transactions().contains(&tx.hash()) ||
+                schema.transactions_pool().contains(&tx.hash())
         });
-
         self.create_block_with_transactions(uncommitted_txs);
         let snapshot = self.snapshot();
+        // rollback commit, and pool update phases.
         self.rollback(1);
         snapshot
     }
@@ -507,12 +502,10 @@ impl TestKit {
         let config_patch = self.update_configuration(new_block_height);
         let (block_hash, patch) = {
             let validator_id = self.leader().validator_id().unwrap();
-            let transactions = self.mempool();
             self.blockchain.create_patch(
                 validator_id,
                 new_block_height,
                 tx_hashes,
-                &transactions,
             )
         };
 
@@ -524,16 +517,6 @@ impl TestKit {
         } else {
             patch
         };
-
-        // Remove txs from mempool
-        {
-            let mut transactions = self.mempool.write().expect(
-                "Cannot modify transactions in mempool",
-            );
-            for hash in tx_hashes {
-                transactions.remove(hash);
-            }
-        }
 
         let propose = self.leader().create_propose(
             new_block_height,
@@ -586,7 +569,7 @@ impl TestKit {
     }
 
     /// Creates a block with the given transactions.
-    /// Transactions that are in the mempool will be ignored.
+    /// Transactions that are in the pool will be ignored.
     ///
     /// # Panics
     ///
@@ -596,31 +579,36 @@ impl TestKit {
         I: IntoIterator<Item = Box<Transaction>>,
     {
         let tx_hashes: Vec<_> = {
-            let mut mempool = self.mempool.write().expect(
-                "Cannot write transactions to mempool",
-            );
+            let blockchain = self.blockchain_mut();
+            let mut fork = blockchain.fork();
+            let hashes = {
+                let mut schema = CoreSchema::new(&mut fork);
 
-            let snapshot = self.snapshot();
-            let schema = CoreSchema::new(&snapshot);
-            txs.into_iter()
-                .filter(|tx| tx.verify())
-                .map(|tx| {
-                    let tx_id = tx.hash();
-                    assert!(
-                        !schema.transactions().contains(&tx_id),
-                        "Transaction is already committed: {:?}",
-                        tx
-                    );
-                    mempool.insert(tx_id, tx);
-                    tx_id
-                })
-                .collect()
+                txs.into_iter()
+                    .filter(|tx| tx.verify())
+                    .map(|tx| {
+                        let tx_id = tx.hash();
+                        assert!(
+                            !schema.transactions().contains(&tx_id) ||
+                                schema.transactions_pool().contains(&tx_id),
+                            "Transaction is already committed: {:?}",
+                            tx
+                        );
+                        schema.add_transaction_into_pool(tx.raw().clone());
+
+                        tx_id
+                    })
+                    .collect()
+            };
+            blockchain.merge(fork.into_patch()).unwrap();
+            hashes
         };
+
         self.create_block_with_tx_hashes(&tx_hashes);
     }
 
     /// Creates a block with the given transaction.
-    /// Transactions that are in the mempool will be ignored.
+    /// Transactions that are in the pool will be ignored.
     ///
     /// # Panics
     ///
@@ -634,27 +622,50 @@ impl TestKit {
     ///
     /// # Panics
     ///
-    /// - Panics in the case any of transaction hashes are not in the mempool.
+    /// - Panics in the case any of transaction hashes are not in the pool.
     pub fn create_block_with_tx_hashes(&mut self, tx_hashes: &[crypto::Hash]) {
         self.poll_events();
 
         {
-            let txs = self.mempool();
+            let snapshot = self.blockchain.snapshot();
+            let schema = CoreSchema::new(&snapshot);
             for hash in tx_hashes {
-                assert!(txs.contains_key(hash));
+                assert!(schema.transactions_pool().contains(hash));
             }
         }
 
         self.do_create_block(tx_hashes);
     }
 
-    /// Creates block with all transactions in the mempool.
+    /// Creates block with all transactions in the pool.
     pub fn create_block(&mut self) {
         self.poll_events();
 
-        let tx_hashes: Vec<_> = self.mempool().keys().cloned().collect();
-
+        let snapshot = self.blockchain.snapshot();
+        let schema = CoreSchema::new(&snapshot);
+        let txs = schema.transactions_pool();
+        let tx_hashes: Vec<_> = txs.iter().collect();
+        //FIXME: every block should contain two merges
+        {
+            let blockchain = self.blockchain_mut();
+            let fork = blockchain.fork();
+            blockchain.merge(fork.into_patch()).unwrap();
+        }
         self.do_create_block(&tx_hashes);
+    }
+
+    /// Adds transaction into persistent pool.
+    pub fn add_tx(&mut self, transaction: RawMessage) {
+        let mut fork = self.blockchain.fork();
+        let mut schema = CoreSchema::new(&mut fork);
+        schema.add_transaction_into_pool(transaction)
+    }
+
+    /// Checks if transaction can be found in pool
+    pub fn is_tx_in_pool(&self, tx_hash: &Hash) -> bool {
+        let snapshot = self.blockchain.snapshot();
+        let schema = CoreSchema::new(&snapshot);
+        schema.transactions_pool().contains(tx_hash)
     }
 
     /// Creates a chain of blocks until a given height.
@@ -704,13 +715,6 @@ impl TestKit {
     /// Returns sufficient number of validators for the Byzantine Fault Tolerance consensus.
     pub fn majority_count(&self) -> usize {
         NodeState::byzantine_majority_count(self.network().validators().len())
-    }
-
-    /// Returns the test node memory pool handle.
-    pub fn mempool(&self) -> RwLockReadGuard<BTreeMap<crypto::Hash, Box<Transaction>>> {
-        self.mempool.read().expect(
-            "Can't read transactions from the mempool.",
-        )
     }
 
     /// Returns the leader on the current height. At the moment first validator.

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -457,10 +457,13 @@ impl TestKit {
     /// # }
     /// ```
     pub fn rollback(&mut self, blocks: usize) {
-        assert!(self.height().0 >= blocks, "Cannot rollback past genesis block");
-        // each block contain at least two phases:
-        // 1. add tx into pool
-        // 2. commit tx from pool to block
+        assert!(
+            self.height().0 >= blocks as u64,
+            "Cannot rollback past genesis block"
+        );
+        // Each block contain at least two phases:
+        // 1. add tx into pool;
+        // 2. commit tx from pool into next block.
         self.db_handler.rollback(blocks * 2);
     }
 
@@ -482,7 +485,6 @@ impl TestKit {
         });
         self.create_block_with_transactions(uncommitted_txs);
         let snapshot = self.snapshot();
-        // rollback commit, and pool update phases.
         self.rollback(1);
         snapshot
     }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -590,9 +590,10 @@ impl TestKit {
                     .filter(|tx| tx.verify())
                     .map(|tx| {
                         let tx_id = tx.hash();
+                        let tx_not_found = !schema.transactions().contains(&tx_id);
+                        let tx_in_pool = schema.transactions_pool().contains(&tx_id);
                         assert!(
-                            !schema.transactions().contains(&tx_id) ||
-                                schema.transactions_pool().contains(&tx_id),
+                            tx_not_found || tx_in_pool,
                             "Transaction is already committed: {:?}",
                             tx
                         );
@@ -647,7 +648,7 @@ impl TestKit {
         let schema = CoreSchema::new(&snapshot);
         let txs = schema.transactions_pool();
         let tx_hashes: Vec<_> = txs.iter().collect();
-        //FIXME: every block should contain two merges
+        //TODO: every block should contain two merges (ECR-975)
         {
             let blockchain = self.blockchain_mut();
             let fork = blockchain.fork();

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //! Sample counter service.
-
 extern crate bodyparser;
 extern crate iron;
 extern crate router;
@@ -97,6 +96,7 @@ impl Transaction for TxIncrement {
     // This method purposely does not check counter overflow in order to test
     // behavior of panicking transactions.
     fn execute(&self, fork: &mut Fork) -> ExecutionResult {
+        trace!("execute tx {}", self.by());
         if self.by() == 0 {
             Err(ExecutionError::with_description(
                 0,
@@ -144,6 +144,7 @@ struct CounterApi {
 
 impl CounterApi {
     fn increment(&self, req: &mut Request) -> IronResult<Response> {
+        trace!("received increment tx");
         match req.get::<bodyparser::Struct<TxIncrement>>() {
             Ok(Some(transaction)) => {
                 let transaction: Box<Transaction> = Box::new(transaction);

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -96,7 +96,6 @@ impl Transaction for TxIncrement {
     // This method purposely does not check counter overflow in order to test
     // behavior of panicking transactions.
     fn execute(&self, fork: &mut Fork) -> ExecutionResult {
-        trace!("execute tx {}", self.by());
         if self.by() == 0 {
             Err(ExecutionError::with_description(
                 0,

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -23,6 +23,8 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate pretty_assertions;
+#[macro_use]
+extern crate log;
 
 use exonum::blockchain::Transaction;
 use exonum::crypto::{self, PublicKey, CryptoHash};
@@ -187,7 +189,6 @@ fn test_probe() {
     let snapshot = testkit.probe(other_tx.clone());
     let schema = CounterSchema::new(&snapshot);
     assert_eq!(schema.count(), Some(3));
-
     testkit.create_block();
     let snapshot = testkit.probe(other_tx.clone());
     let schema = CounterSchema::new(&snapshot);

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -14,7 +14,8 @@
 
 //! A special service which generates transactions on `handle_commit` events.
 
-use exonum::blockchain::{ServiceContext, Transaction, TransactionSet, ExecutionResult};
+use exonum::blockchain::{Service, ServiceContext, Transaction, TransactionSet, ExecutionResult};
+use exonum::messages::RawTransaction;
 use exonum::storage::{Fork, Snapshot};
 use exonum::crypto::{Hash, Signature};
 use exonum::encoding;

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -14,8 +14,7 @@
 
 //! A special service which generates transactions on `handle_commit` events.
 
-use exonum::blockchain::{Service, ServiceContext, Transaction, TransactionSet, ExecutionResult};
-use exonum::messages::RawTransaction;
+use exonum::blockchain::{ServiceContext, Transaction, TransactionSet, ExecutionResult};
 use exonum::storage::{Fork, Snapshot};
 use exonum::crypto::{Hash, Signature};
 use exonum::encoding;

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -19,7 +19,9 @@ extern crate serde;
 extern crate serde_json;
 
 use exonum::crypto::{Signature, CryptoHash};
+use exonum::blockchain::Schema;
 use exonum::helpers::Height;
+use exonum::messages::Message;
 use exonum_testkit::TestKitBuilder;
 
 mod hooks;
@@ -35,6 +37,10 @@ fn test_handle_commit() {
     for i in 1..5 {
         testkit.create_block();
         let tx = TxAfterCommit::new_with_signature(Height(i), &Signature::zero());
-        assert!(testkit.mempool().contains_key(&tx.hash()));
+        testkit.add_tx(tx.raw().clone());
+        let snapshot = testkit.blockchain_mut().snapshot();
+        let schema = Schema::new(&snapshot);
+        assert!(schema.transactions().contains(&tx.hash()));
+        assert!(schema.transactions_pool().contains(&tx.hash()));
     }
 }

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -19,9 +19,7 @@ extern crate serde;
 extern crate serde_json;
 
 use exonum::crypto::{Signature, CryptoHash};
-use exonum::blockchain::Schema;
 use exonum::helpers::Height;
-use exonum::messages::Message;
 use exonum_testkit::TestKitBuilder;
 
 mod hooks;

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -37,10 +37,6 @@ fn test_handle_commit() {
     for i in 1..5 {
         testkit.create_block();
         let tx = TxAfterCommit::new_with_signature(Height(i), &Signature::zero());
-        testkit.add_tx(tx.raw().clone());
-        let snapshot = testkit.blockchain_mut().snapshot();
-        let schema = Schema::new(&snapshot);
-        assert!(schema.transactions().contains(&tx.hash()));
-        assert!(schema.transactions_pool().contains(&tx.hash()));
+        assert!(testkit.is_tx_in_pool(&tx.hash()));
     }
 }


### PR DESCRIPTION
Save transactions in persistent pool instead of in memory `Map`. This allows node to recover safe after restart.
