### PR TITLE
Rewrite to chrono::DateTime [ECR-821]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ jobs:
     - touch target/std/string/struct.String.html
     - touch target/doc/exonum/encoding/serialize/trait.Serialize.html
     - touch target/doc/exonum_configuration/enum.Option.html
+    - mkdir -p target/doc/exonum/encoding/serialize/reexport/serde/ts_seconds
+    - touch target/doc/exonum/encoding/serialize/reexport/serde/ts_seconds/index.html
     - cargo deadlinks --dir target/doc
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 #### exonum-time
 
 - `SystemTime` has been replaced with `chrono::DateTime<Utc>`, as it provides
-more predictable behavior on all systems.
+  more predictable behavior on all systems.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   - `tx_location_by_tx_hash` to `transactions_locations`.
   - `block_txs` to `block_transactions`.
 
+- `SystemTime` previously used as storage key or value turned out to show
+  different behavior on different platforms and, hence, has been replaced with
+  `chrono::DateTime<Utc>` that behaves the same in any environment.
+
+  Migration path:
+
+  - Replace all `SystemTime` fields with `chrono::DateTime<Utc>` ones.
+  - Use `DateTime::from` and `into()` methods to convert your existing
+  `SystemTime` instances into suitable type when constructing transactions or
+  working with database.
+
 #### exonum-testkit
 
 - Testkit api now contains two methods to work with the transaction pool:
@@ -34,18 +45,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
   - Instead of calling `mempool()`, one should use `is_tx_in_pool`
   or `add_tx` methods.
-- `SystemTime` can't serve as storage key or value anymore, it has been replaced
-  with `chrono::DateTime<Utc>`.
-- `SystemTime` previously used as storage key or value turned out to show
-  different behavior on different platforms and, hence,  has been replaced with
-  `chrono::DateTime<Utc>` that behaves the same in any environment.
-
-  Migration path:
-
-  - Replace all `SystemTime` fields with `chrono::DateTime<Utc>` ones.
-  - Use `DateTime::from` and `into()` methods to convert your existing
-  `SystemTime` instances into suitable type when constructing transactions or
-  working with database.
 
 #### exonum-configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
   - Instead of calling `mempool()`, one should use `is_tx_in_pool`
   or `add_tx` methods.
+- `SystemTime` can't serve as storage key or value anymore, it has been replaced
+  with `chrono::DateTime<Utc>`.
+
+  Migration path:
+
+  - Replace all `SystemTime` fields with `chrono::DateTime<Utc>` ones.
+  - Use `DateTime::from` and `into()` methods to convert your existing
+  `SystemTime` instances into suitable type when constructing transactions or
+  working with database.
 
 #### exonum-configuration
 
@@ -41,6 +50,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   Allows to increase the threshold amount of votes required to commit
   a new configuration proposal. By default the number of votes is calculated
   as 2/3 + 1 of total validators count. (#546)
+
+#### exonum-time
+
+- `SystemTime` has been replaced with `chrono::DateTime<Utc>`, as it provides
+more predictable behavior on all systems.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   or `add_tx` methods.
 - `SystemTime` can't serve as storage key or value anymore, it has been replaced
   with `chrono::DateTime<Utc>`.
+- `SystemTime` previously used as storage key or value turned out to show
+  different behavior on different platforms and, hence,  has been replaced with
+  `chrono::DateTime<Utc>` that behaves the same in any environment.
 
   Migration path:
 

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -46,7 +46,7 @@ tokio-retry = "0.1.0"
 tokio-timer = "0.1.2"
 failure = "0.1.1"
 os_info = "0.7.0"
-chrono = "0.4.0"
+chrono = { version = "0.4.0", features = ["serde"] }
 bodyparser = "0.8.0"
 
 exonum_rocksdb = "0.7"

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -16,6 +16,7 @@
 
 use rand::{thread_rng, Rng};
 use serde_json;
+use chrono::{DateTime, Utc};
 
 use blockchain::{Blockchain, Service, Snapshot, Schema, Transaction, ExecutionResult};
 use crypto::{gen_keypair, Hash, CryptoHash};
@@ -107,16 +108,16 @@ fn test_u64() {
 
 #[test]
 fn test_system_time() {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::UNIX_EPOCH;
     encoding_struct! {
         struct Test {
-            some_test: SystemTime,
+            some_test: DateTime<Utc>,
         }
     }
     let test_data = r##"{"some_test":{"nanos":0,"secs":"0"}}"##;
 
 
-    let test = Test::new(UNIX_EPOCH);
+    let test = Test::new(UNIX_EPOCH.into());
     let data = ::serde_json::to_string(&test).unwrap();
     assert_eq!(data, test_data);
 }

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -16,7 +16,7 @@
 
 use rand::{thread_rng, Rng};
 use serde_json;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Utc, TimeZone};
 
 use blockchain::{Blockchain, Service, Snapshot, Schema, Transaction, ExecutionResult};
 use crypto::{gen_keypair, Hash, CryptoHash};
@@ -102,23 +102,22 @@ fn test_u64() {
     }
     let test_data = r##"{"some_test":"1234"}"##;
     let test = Test::new(1234);
-    let data = ::serde_json::to_string(&test).unwrap();
+    let data = serde_json::to_string(&test).unwrap();
     assert_eq!(data, test_data);
 }
 
 #[test]
-fn test_system_time() {
-    use std::time::UNIX_EPOCH;
+fn test_date_time() {
     encoding_struct! {
         struct Test {
             some_test: DateTime<Utc>,
         }
     }
+
     let test_data = r##"{"some_test":{"nanos":0,"secs":"0"}}"##;
 
-
-    let test = Test::new(UNIX_EPOCH.into());
-    let data = ::serde_json::to_string(&test).unwrap();
+    let test = Test::new(Utc.timestamp(0, 0));
+    let data = serde_json::to_string(&test).unwrap();
     assert_eq!(data, test_data);
 }
 

--- a/exonum/src/encoding/fields.rs
+++ b/exonum/src/encoding/fields.rs
@@ -16,7 +16,7 @@
 
 use std::mem;
 use std::net::{SocketAddr, SocketAddrV4, Ipv4Addr};
-use std::time::{SystemTime, Duration, UNIX_EPOCH};
+use chrono::{DateTime, Utc, TimeZone};
 
 use byteorder::{ByteOrder, LittleEndian};
 
@@ -266,23 +266,21 @@ implement_pod_as_ref_field! {Signature}
 implement_pod_as_ref_field! {PublicKey}
 implement_pod_as_ref_field! {Hash}
 
-// TODO should we check `SystemTime` validity in check (ECR-157)?
-impl<'a> Field<'a> for SystemTime {
+impl<'a> Field<'a> for DateTime<Utc> {
     fn field_size() -> Offset {
-        (mem::size_of::<u64>() + mem::size_of::<u32>()) as Offset
+        (mem::size_of::<i64>() + mem::size_of::<u32>()) as Offset
     }
 
-    unsafe fn read(buffer: &'a [u8], from: Offset, to: Offset) -> SystemTime {
-        let secs = LittleEndian::read_u64(&buffer[from as usize..from as usize + 8]);
+    unsafe fn read(buffer: &'a [u8], from: Offset, to: Offset) -> Self {
+        let secs = LittleEndian::read_i64(&buffer[from as usize..from as usize + 8]);
         let nanos = LittleEndian::read_u32(&buffer[from as usize + 8..to as usize]);
-        UNIX_EPOCH + Duration::new(secs, nanos)
+        Utc.timestamp(secs, nanos)
     }
 
     fn write(&self, buffer: &mut Vec<u8>, from: Offset, to: Offset) {
-        let duration = self.duration_since(UNIX_EPOCH).unwrap();
-        let secs = duration.as_secs();
-        let nanos = duration.subsec_nanos();
-        LittleEndian::write_u64(
+        let secs = self.timestamp();
+        let nanos = self.timestamp_subsec_nanos();
+        LittleEndian::write_i64(
             &mut buffer[from as usize..to as usize - mem::size_of_val(&nanos)],
             secs,
         );

--- a/exonum/src/encoding/serialize/json.rs
+++ b/exonum/src/encoding/serialize/json.rs
@@ -24,6 +24,7 @@
 use std::net::SocketAddr;
 use std::error::Error;
 
+use serde_json;
 use serde_json::value::Value;
 use bit_vec::BitVec;
 use hex::FromHex;
@@ -211,7 +212,7 @@ impl ExonumJson for DateTime<Utc> {
             secs: self.timestamp().to_string(),
             nanos: self.timestamp_subsec_nanos(),
         };
-        Ok(::serde_json::to_value(&timestamp)?)
+        Ok(serde_json::to_value(&timestamp)?)
     }
 }
 
@@ -228,7 +229,7 @@ impl ExonumJson for SocketAddr {
     }
 
     fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
-        Ok(::serde_json::to_value(&self)?)
+        Ok(serde_json::to_value(&self)?)
     }
 }
 

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -15,9 +15,9 @@
 #![allow(unsafe_code)]
 
 use std::net::SocketAddr;
-use std::time::SystemTime;
 
 use bit_vec::BitVec;
+use chrono::Utc;
 
 use crypto::{hash, gen_keypair};
 use blockchain::{self, BlockProof, Block};
@@ -248,7 +248,7 @@ fn test_connect() {
     use std::str::FromStr;
 
     let socket_address = SocketAddr::from_str("18.34.3.4:7777").unwrap();
-    let time = SystemTime::now();
+    let time = Utc::now();
     let (public_key, secret_key) = gen_keypair();
 
     // write
@@ -315,7 +315,7 @@ fn test_precommit() {
     let propose_hash = hash(&[1, 2, 3]);
     let block_hash = hash(&[3, 2, 1]);
     let (public_key, secret_key) = gen_keypair();
-    let time = SystemTime::now();
+    let time = Utc::now();
 
     // write
     let precommit = Precommit::new(
@@ -358,7 +358,7 @@ fn test_status() {
 #[test]
 fn test_block() {
     let (pub_key, secret_key) = gen_keypair();
-    let ts = SystemTime::now();
+    let ts = Utc::now();
     let txs = [2];
     let tx_count = txs.len() as u32;
 

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -179,7 +179,7 @@ pub fn connect_message(addr: SocketAddr) -> Connect {
     Connect::new_with_signature(
         &PublicKey::zero(),
         addr,
-        time,
+        time.into(),
         &user_agent::get(),
         &Signature::zero(),
     )

--- a/exonum/src/messages/protocol.rs
+++ b/exonum/src/messages/protocol.rs
@@ -26,8 +26,9 @@
 //!     * processing - how message is processed and result of the processing
 //!     * generation - in which cases message is generated
 
+use chrono::{DateTime, Utc};
+
 use std::net::SocketAddr;
-use std::time::SystemTime;
 
 use crypto::{Hash, PublicKey};
 use blockchain;
@@ -85,7 +86,7 @@ messages! {
         /// The node's address.
         addr: SocketAddr,
         /// Time when the message was created.
-        time: SystemTime,
+        time: DateTime<Utc>,
         /// String containing information about this node including Exonum, Rust and OS versions.
         user_agent: &str,
     }
@@ -205,7 +206,7 @@ messages! {
         /// Hash of the new block.
         block_hash: &Hash,
         /// Time of the `Precommit`.
-        time: SystemTime,
+        time: DateTime<Utc>,
     }
 
     /// Information about a block.

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -913,7 +913,7 @@ impl NodeHandler {
             round,
             propose_hash,
             block_hash,
-            self.system_state.current_time(),
+            self.system_state.current_time().into(),
             self.state.consensus_secret_key(),
         );
         self.state.add_precommit(&precommit);

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -405,7 +405,7 @@ impl NodeHandler {
         let connect = Connect::new(
             &config.listener.consensus_public_key,
             external_address,
-            system_state.current_time(),
+            system_state.current_time().into(),
             &user_agent::get(),
             &config.listener.consensus_secret_key,
         );

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -288,8 +288,7 @@ impl StorageKey for DateTime<Utc> {
 mod tests {
     use super::*;
 
-    use std::time::Duration;
-    use chrono::{TimeZone, Duration as OldDuration};
+    use chrono::{TimeZone, Duration};
 
     // Number of samples for fuzz testing
     const FUZZ_SAMPLES: usize = 100_000;
@@ -450,14 +449,12 @@ mod tests {
     }
 
     #[test]
-    fn test_storage_key_for_chrono_datetime_round_trip() {
-        use chrono::Duration as OldDuration;
-
+    fn test_storage_key_for_chrono_date_time_round_trip() {
         let times = [
             Utc.timestamp(0, 0),
             Utc.timestamp(13, 23),
             Utc::now(),
-            Utc::now() + OldDuration::from_std(Duration::new(17, 15)).unwrap(),
+            Utc::now() + Duration::seconds(17) + Duration::nanoseconds(15),
             Utc.timestamp(0, 999_999_999),
             Utc.timestamp(0, 1_500_000_000), // leap second
         ];
@@ -499,7 +496,7 @@ mod tests {
         let x1 = Utc.timestamp(80, 0);
         let x2 = Utc.timestamp(10, 0);
         let y1 = Utc::now();
-        let y2 = y1 + OldDuration::from_std(Duration::new(10, 0)).unwrap();
+        let y2 = y1 + Duration::seconds(10);
         let mut fork = db.fork();
         {
             let mut index: MapIndex<_, DateTime<Utc>, DateTime<Utc>> =

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -18,7 +18,7 @@
 
 use byteorder::{ByteOrder, BigEndian};
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use chrono::{DateTime, Utc, NaiveDateTime};
 
 use crypto::{Hash, PublicKey, HASH_SIZE, PUBLIC_KEY_LENGTH};
 
@@ -261,41 +261,35 @@ impl StorageKey for str {
         String::read(buffer)
     }
 }
-
-/// The `SystemTime` (de)serialization is only possible for the values greater than
-/// 1970-01-01 00:00:00 UTC. Since the `SystemTime` type saves time in the form
-/// `(seconds: u64, nanoseconds: u32)`, the total occupied size of `SystemTime` in the storage
-/// is 12 bytes. The seconds are stored in the first 8 bytes as per the `StorageKey` implementation
-/// for u64, and nanoseconds in the remaining 4 bytes as per the `StorageKey`
-/// implementation for u32.
-impl StorageKey for SystemTime {
+/// `chrono::DateTime` uses only 12 bytes in the storage. It is represented by number of seconds
+/// since `1970-01-01 00:00:00 UTC`, which are stored in the first 8 bytes as per the `StorageKey`
+/// implementation for `i64`, and nanoseconds, which are stored in the remaining 4 bytes as per
+/// the `StorageKey` implementation for `u32`.
+impl StorageKey for DateTime<Utc> {
     fn size(&self) -> usize {
         12
     }
 
     fn write(&self, buffer: &mut [u8]) {
-        let duration = self.duration_since(UNIX_EPOCH).expect(
-            "time value is later than 1970-01-01 00:00:00 UTC.",
-        );
-        let secs = duration.as_secs();
-        let nanos = duration.subsec_nanos();
+        let secs = self.timestamp();
+        let nanos = self.timestamp_subsec_nanos();
         secs.write(&mut buffer[0..8]);
         nanos.write(&mut buffer[8..12]);
     }
 
     fn read(buffer: &[u8]) -> Self::Owned {
-        let secs = u64::read(&buffer[0..8]);
+        let secs = i64::read(&buffer[0..8]);
         let nanos = u32::read(&buffer[8..12]);
-        // `Duration` performs internal normalization of time.
-        // The value of nanoseconds can not be greater than or equal to 1,000,000,000.
-        assert!(nanos < 1_000_000_000);
-        UNIX_EPOCH + Duration::new(secs, nanos)
+        DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nanos), Utc)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::time::Duration;
+    use chrono::{TimeZone, Duration as OldDuration};
 
     // Number of samples for fuzz testing
     const FUZZ_SAMPLES: usize = 100_000;
@@ -456,48 +450,41 @@ mod tests {
     }
 
     #[test]
-    fn test_storage_key_for_system_time_round_trip() {
-        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    fn test_storage_key_for_chrono_datetime_round_trip() {
+        use chrono::Duration as OldDuration;
 
         let times = [
-            UNIX_EPOCH,
-            UNIX_EPOCH + Duration::new(13, 23),
-            SystemTime::now(),
-            SystemTime::now() + Duration::new(17, 15),
-            UNIX_EPOCH + Duration::new(0, u32::max_value()),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64, 0),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64, 999_999_999),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 1, 1_000_000_000),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 4, 4_000_000_000),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 4, u32::max_value()),
+            Utc.timestamp(0, 0),
+            Utc.timestamp(13, 23),
+            Utc::now(),
+            Utc::now() + OldDuration::from_std(Duration::new(17, 15)).unwrap(),
+            Utc.timestamp(0, 999_999_999),
+            Utc.timestamp(0, 1_500_000_000), // leap second
         ];
 
         let mut buffer = [0u8; 12];
         for time in times.iter() {
             time.write(&mut buffer);
-            assert_eq!(*time, SystemTime::read(&buffer));
+            assert_eq!(*time, DateTime::read(&buffer));
         }
     }
 
     #[test]
     fn test_storage_key_for_system_time_ordering() {
         use rand::{Rng, thread_rng};
-        use std::time::Duration;
 
         let mut rng = thread_rng();
 
         let (mut buffer1, mut buffer2) = ([0u8; 12], [0u8; 12]);
         for _ in 0..FUZZ_SAMPLES {
-            let time1 = UNIX_EPOCH +
-                Duration::new(
-                    rng.gen::<u64>() % (i32::max_value() as u64),
-                    rng.gen::<u32>() % 1_000_000_000,
-                );
-            let time2 = UNIX_EPOCH +
-                Duration::new(
-                    rng.gen::<u64>() % (i32::max_value() as u64),
-                    rng.gen::<u32>() % 1_000_000_000,
-                );
+            let time1 = Utc.timestamp(
+                rng.gen::<i64>() % (i32::max_value() as i64),
+                rng.gen::<u32>() % 1_000_000_000,
+            );
+            let time2 = Utc.timestamp(
+                rng.gen::<i64>() % (i32::max_value() as i64),
+                rng.gen::<u32>() % 1_000_000_000,
+            );
             time1.write(&mut buffer1);
             time2.write(&mut buffer2);
             assert_eq!(time1.cmp(&time2), buffer1.cmp(&buffer2));
@@ -506,17 +493,16 @@ mod tests {
 
     #[test]
     fn test_system_time_key_in_index() {
-        use std::time::{Duration, SystemTime, UNIX_EPOCH};
         use storage::{Database, MapIndex, MemoryDB};
 
         let db: Box<Database> = Box::new(MemoryDB::new());
-        let x1 = UNIX_EPOCH + Duration::new(80, 0);
-        let x2 = UNIX_EPOCH + Duration::new(10, 0);
-        let y1 = SystemTime::now();
-        let y2 = y1 + Duration::new(10, 0);
+        let x1 = Utc.timestamp(80, 0);
+        let x2 = Utc.timestamp(10, 0);
+        let y1 = Utc::now();
+        let y2 = y1 + OldDuration::from_std(Duration::new(10, 0)).unwrap();
         let mut fork = db.fork();
         {
-            let mut index: MapIndex<_, SystemTime, SystemTime> =
+            let mut index: MapIndex<_, DateTime<Utc>, DateTime<Utc>> =
                 MapIndex::new("test_index", &mut fork);
             index.put(&x1, y1);
             index.put(&x2, y2);
@@ -524,30 +510,25 @@ mod tests {
         db.merge(fork.into_patch()).unwrap();
 
         let snapshot = db.snapshot();
-        let index: MapIndex<_, SystemTime, SystemTime> = MapIndex::new("test_index", snapshot);
+        let index: MapIndex<_, DateTime<Utc>, DateTime<Utc>> =
+            MapIndex::new("test_index", snapshot);
         assert_eq!(index.get(&x1), Some(y1));
         assert_eq!(index.get(&x2), Some(y2));
 
         assert_eq!(
-            index.iter_from(&UNIX_EPOCH).collect::<Vec<_>>(),
+            index.iter_from(&Utc.timestamp(0, 0)).collect::<Vec<_>>(),
             vec![(x2, y2), (x1, y1)]
         );
         assert_eq!(
-            index
-                .iter_from(&(UNIX_EPOCH + Duration::new(20, 0)))
-                .collect::<Vec<_>>(),
+            index.iter_from(&Utc.timestamp(20, 0)).collect::<Vec<_>>(),
             vec![(x1, y1)]
         );
         assert_eq!(
-            index
-                .iter_from(&(UNIX_EPOCH + Duration::new(80, 0)))
-                .collect::<Vec<_>>(),
+            index.iter_from(&Utc.timestamp(80, 0)).collect::<Vec<_>>(),
             vec![(x1, y1)]
         );
         assert_eq!(
-            index
-                .iter_from(&(UNIX_EPOCH + Duration::new(90, 0)))
-                .collect::<Vec<_>>(),
+            index.iter_from(&Utc.timestamp(90, 0)).collect::<Vec<_>>(),
             vec![]
         );
 

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -15,10 +15,10 @@
 //! A definition of `StorageValue` trait and implementations for common types.
 
 use byteorder::{ByteOrder, LittleEndian};
+use chrono::{DateTime, Utc, NaiveDateTime};
 
 use std::mem;
 use std::borrow::Cow;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crypto::{CryptoHash, Hash, PublicKey};
 use messages::{RawMessage, MessageBuffer};
@@ -261,28 +261,34 @@ impl StorageValue for String {
     }
 }
 
-/// Uses little-endian encoding.
-impl StorageValue for SystemTime {
-    fn into_bytes(self) -> Vec<u8> {
-        let duration = self.duration_since(UNIX_EPOCH).expect(
-            "time value is later than 1970-01-01 00:00:00 UTC.",
-        );
-        let secs = duration.as_secs();
-        let nanos = duration.subsec_nanos();
+impl CryptoHash for DateTime<Utc> {
+    fn hash(&self) -> Hash {
+        let secs = self.timestamp();
+        let nanos = self.timestamp_subsec_nanos();
 
         let mut buffer = vec![0; 12];
-        LittleEndian::write_u64(&mut buffer[0..8], secs);
+        LittleEndian::write_i64(&mut buffer[0..8], secs);
+        LittleEndian::write_u32(&mut buffer[8..12], nanos);
+        buffer.hash()
+    }
+}
+
+/// Uses little-endian encoding.
+impl StorageValue for DateTime<Utc> {
+    fn into_bytes(self) -> Vec<u8> {
+        let secs = self.timestamp();
+        let nanos = self.timestamp_subsec_nanos();
+
+        let mut buffer = vec![0; 12];
+        LittleEndian::write_i64(&mut buffer[0..8], secs);
         LittleEndian::write_u32(&mut buffer[8..12], nanos);
         buffer
     }
 
     fn from_bytes(value: Cow<[u8]>) -> Self {
-        let secs = LittleEndian::read_u64(&value[0..8]);
+        let secs = LittleEndian::read_i64(&value[0..8]);
         let nanos = LittleEndian::read_u32(&value[8..12]);
-        // `Duration` performs internal normalization of time.
-        // The value of nanoseconds can not be greater than or equal to 1,000,000,000.
-        assert!(nanos < 1_000_000_000);
-        UNIX_EPOCH + Duration::new(secs, nanos)
+        DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nanos), Utc)
     }
 }
 
@@ -404,24 +410,21 @@ mod tests {
 
     #[test]
     fn test_storage_value_for_system_time_round_trip() {
-        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+        use std::time::Duration;
+        use chrono::{TimeZone, Duration as OldDuration};
 
         let times = [
-            UNIX_EPOCH,
-            UNIX_EPOCH + Duration::new(13, 23),
-            SystemTime::now(),
-            SystemTime::now() + Duration::new(17, 15),
-            UNIX_EPOCH + Duration::new(0, u32::max_value()),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64, 0),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64, 999_999_999),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 1, 1_000_000_000),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 4, 4_000_000_000),
-            UNIX_EPOCH + Duration::new(i64::max_value() as u64 - 4, u32::max_value()),
+            Utc.timestamp(0, 0),
+            Utc.timestamp(13, 23),
+            Utc::now(),
+            Utc::now() + OldDuration::from_std(Duration::new(17, 15)).unwrap(),
+            Utc.timestamp(0, 999_999_999),
+            Utc.timestamp(0, 1_500_000_000), // leap second
         ];
 
         for time in times.iter() {
             let buffer = time.into_bytes();
-            assert_eq!(*time, SystemTime::from_bytes(Cow::Borrowed(&buffer)));
+            assert_eq!(*time, DateTime::from_bytes(Cow::Borrowed(&buffer)));
         }
     }
 

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -410,14 +410,13 @@ mod tests {
 
     #[test]
     fn test_storage_value_for_system_time_round_trip() {
-        use std::time::Duration;
-        use chrono::{TimeZone, Duration as OldDuration};
+        use chrono::{TimeZone, Duration};
 
         let times = [
             Utc.timestamp(0, 0),
             Utc.timestamp(13, 23),
             Utc::now(),
-            Utc::now() + OldDuration::from_std(Duration::new(17, 15)).unwrap(),
+            Utc::now() + Duration::seconds(17) + Duration::nanoseconds(15),
             Utc.timestamp(0, 999_999_999),
             Utc.timestamp(0, 1_500_000_000), // leap second
         ];

--- a/sandbox/src/sandbox.rs
+++ b/sandbox/src/sandbox.rs
@@ -152,7 +152,7 @@ impl Sandbox {
         let connect = Connect::new(
             &self.p(VALIDATOR_0),
             self.a(VALIDATOR_0),
-            connect_message_time,
+            connect_message_time.into(),
             &user_agent::get(),
             self.s(VALIDATOR_0),
         );
@@ -162,7 +162,7 @@ impl Sandbox {
             self.recv(&Connect::new(
                 &self.p(validator),
                 self.a(validator),
-                self.time(),
+                self.time().into(),
                 &user_agent::get(),
                 self.s(validator),
             ));
@@ -602,7 +602,7 @@ impl Sandbox {
             Connect::new(
                 c.pub_key(),
                 c.addr(),
-                time,
+                time.into(),
                 c.user_agent(),
                 self.s(VALIDATOR_0),
             )
@@ -925,7 +925,7 @@ mod tests {
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_2),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));
@@ -934,7 +934,7 @@ mod tests {
             &Connect::new(
                 &s.p(VALIDATOR_0),
                 s.a(VALIDATOR_0),
-                s.time(),
+                s.time().into(),
                 &user_agent::get(),
                 s.s(VALIDATOR_0),
             ),
@@ -961,7 +961,7 @@ mod tests {
             &Connect::new(
                 &s.p(VALIDATOR_0),
                 s.a(VALIDATOR_0),
-                s.time(),
+                s.time().into(),
                 &user_agent::get(),
                 s.s(VALIDATOR_0),
             ),
@@ -976,7 +976,7 @@ mod tests {
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_2),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));
@@ -985,7 +985,7 @@ mod tests {
             &Connect::new(
                 &s.p(VALIDATOR_0),
                 s.a(VALIDATOR_0),
-                s.time(),
+                s.time().into(),
                 &user_agent::get(),
                 s.s(VALIDATOR_0),
             ),
@@ -1000,7 +1000,7 @@ mod tests {
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_2),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));
@@ -1014,14 +1014,14 @@ mod tests {
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_2),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_3),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));
@@ -1036,7 +1036,7 @@ mod tests {
         s.recv(&Connect::new(
             &public,
             s.a(VALIDATOR_2),
-            s.time(),
+            s.time().into(),
             &user_agent::get(),
             &secret,
         ));

--- a/sandbox/src/sandbox_tests_helper.rs
+++ b/sandbox/src/sandbox_tests_helper.rs
@@ -416,7 +416,7 @@ where
                 round,
                 &propose.hash(),
                 &block.hash(),
-                sandbox.time(),
+                sandbox.time().into(),
                 sandbox.s(VALIDATOR_0),
             ));
             sandbox.assert_lock(round, Some(propose.hash()));
@@ -429,7 +429,7 @@ where
                     round,
                     &propose.hash(),
                     &block.hash(),
-                    sandbox.time(),
+                    sandbox.time().into(),
                     sandbox.s(val_idx),
                 ));
 
@@ -530,7 +530,7 @@ pub fn add_one_height_with_transactions_from_other_validator(
                     round,
                     &propose.hash(),
                     &block.hash(),
-                    sandbox.time(),
+                    sandbox.time().into(),
                     sandbox.s(val_idx),
                 ));
             }

--- a/sandbox/tests/consensus.rs
+++ b/sandbox/tests/consensus.rs
@@ -203,7 +203,7 @@ fn test_disable_and_enable() {
     sandbox.process_events();
 
     // Save the current time to "rewind" sandbox to it later.
-    let time_saved = sandbox.time();
+    let time_saved = sandbox.time().into();
 
     // A fail is expected here as the node is disabled.
     sandbox.assert_state(HEIGHT_TWO, ROUND_ONE);
@@ -386,7 +386,7 @@ fn should_not_vote_after_node_restart() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     );
     sandbox.broadcast(&precommit);
@@ -459,7 +459,7 @@ fn should_save_precommit_to_consensus_cache() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     );
 
@@ -483,7 +483,7 @@ fn should_save_precommit_to_consensus_cache() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox_restarted.time(),
+        sandbox_restarted.time().into(),
         sandbox_restarted.s(VALIDATOR_1),
     ));
 
@@ -493,7 +493,7 @@ fn should_save_precommit_to_consensus_cache() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox_restarted.time(),
+        sandbox_restarted.time().into(),
         sandbox_restarted.s(VALIDATOR_2),
     ));
 
@@ -550,7 +550,7 @@ fn test_recover_consensus_messages_in_other_round() {
         ROUND_ONE,
         &first_propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     );
 
@@ -617,7 +617,7 @@ fn test_recover_consensus_messages_in_other_round() {
         ROUND_TWO,
         &second_propose.hash(),
         &second_block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     );
     sandbox.broadcast(&second_precommit);
@@ -636,7 +636,7 @@ fn test_recover_consensus_messages_in_other_round() {
         first_precommit.round(),
         first_precommit.propose_hash(),
         first_precommit.block_hash(),
-        sandbox_new.time(),
+        sandbox_new.time().into(),
         sandbox_new.s(VALIDATOR_0),
     );
     sandbox_new.broadcast(&first_precommit_new_time);
@@ -660,8 +660,8 @@ fn should_restore_peers_after_restart() {
     let (p1, s1, a1) = (sandbox.p(v1), sandbox.s(v1).clone(), sandbox.a(v1));
 
     let time = sandbox.time();
-    let connect_from_0 = Connect::new(&p0, a0, time, &user_agent::get(), &s0);
-    let connect_from_1 = Connect::new(&p1, a1, time, &user_agent::get(), &s1);
+    let connect_from_0 = Connect::new(&p0, a0, time.into(), &user_agent::get(), &s0);
+    let connect_from_1 = Connect::new(&p1, a1, time.into(), &user_agent::get(), &s1);
     let peers_request = PeersRequest::new(&p1, &p0, &s1);
 
     // check that peers are absent
@@ -1092,7 +1092,7 @@ fn respond_to_request_tx_propose_prevotes_precommits() {
         ROUND_THREE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -1101,7 +1101,7 @@ fn respond_to_request_tx_propose_prevotes_precommits() {
         ROUND_THREE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
 
@@ -1167,7 +1167,7 @@ fn respond_to_request_tx_propose_prevotes_precommits() {
         ROUND_THREE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
 
@@ -1444,7 +1444,7 @@ fn lock_to_propose_when_get_2_3_prevote_positive() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.assert_lock(LOCK_ONE, Some(propose.hash()));
@@ -1525,7 +1525,7 @@ fn lock_to_past_round_broadcast_prevote() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.assert_lock(LOCK_ONE, Some(propose.hash()));
@@ -1624,7 +1624,7 @@ fn handle_precommit_remove_request_prevotes() {
             ROUND_ONE,
             &propose.hash(),
             &block.hash(),
-            sandbox.time(),
+            sandbox.time().into(),
             sandbox.s(VALIDATOR_0),
         ));
         sandbox.assert_lock(LOCK_ONE, Some(propose.hash()));
@@ -1637,7 +1637,7 @@ fn handle_precommit_remove_request_prevotes() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     ));
     sandbox.add_time(Duration::from_millis(PREVOTES_REQUEST_TIMEOUT));
@@ -1738,7 +1738,7 @@ fn lock_to_propose_and_send_prevote() {
         ROUND_TWO,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.assert_lock(LOCK_TWO, Some(propose.hash()));
@@ -1812,7 +1812,7 @@ fn lock_remove_request_prevotes() {
             ROUND_ONE,
             &propose.hash(),
             &block.hash(),
-            sandbox.time(),
+            sandbox.time().into(),
             sandbox.s(VALIDATOR_0),
         ));
     }
@@ -1844,7 +1844,7 @@ fn handle_precommit_different_block_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -1853,7 +1853,7 @@ fn handle_precommit_different_block_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -1862,7 +1862,7 @@ fn handle_precommit_different_block_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -1909,7 +1909,7 @@ fn handle_precommit_positive_scenario_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -1918,7 +1918,7 @@ fn handle_precommit_positive_scenario_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -1927,7 +1927,7 @@ fn handle_precommit_positive_scenario_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2010,7 +2010,7 @@ fn lock_not_send_prevotes_after_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2019,7 +2019,7 @@ fn lock_not_send_prevotes_after_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
 
@@ -2084,7 +2084,7 @@ fn lock_not_send_prevotes_after_commit() {
             ROUND_ONE,
             &propose.hash(),
             &block.hash(),
-            sandbox.time(),
+            sandbox.time().into(),
             sandbox.s(VALIDATOR_0),
         ));
         sandbox.check_broadcast_status(HEIGHT_TWO, &block.hash());
@@ -2132,7 +2132,7 @@ fn do_not_commit_if_propose_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2141,7 +2141,7 @@ fn do_not_commit_if_propose_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2150,7 +2150,7 @@ fn do_not_commit_if_propose_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2216,7 +2216,7 @@ fn do_not_commit_if_tx_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2225,7 +2225,7 @@ fn do_not_commit_if_tx_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2234,7 +2234,7 @@ fn do_not_commit_if_tx_is_unknown() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2310,7 +2310,7 @@ fn commit_using_unknown_propose_with_precommits() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2319,7 +2319,7 @@ fn commit_using_unknown_propose_with_precommits() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2328,7 +2328,7 @@ fn commit_using_unknown_propose_with_precommits() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2425,7 +2425,7 @@ fn has_full_propose_wrong_state_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2434,7 +2434,7 @@ fn has_full_propose_wrong_state_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2443,7 +2443,7 @@ fn has_full_propose_wrong_state_hash() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2634,7 +2634,7 @@ fn handle_precommit_positive_scenario_commit_with_queued_precommit() {
         ROUND_ONE,
         &height_one_propose.hash(),
         &second_block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2643,7 +2643,7 @@ fn handle_precommit_positive_scenario_commit_with_queued_precommit() {
         ROUND_ONE,
         &height_one_propose.hash(),
         &second_block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2652,7 +2652,7 @@ fn handle_precommit_positive_scenario_commit_with_queued_precommit() {
         ROUND_ONE,
         &height_one_propose.hash(),
         &second_block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2760,7 +2760,7 @@ fn commit_as_leader_send_propose_round_timeout() {
         current_round,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2769,7 +2769,7 @@ fn commit_as_leader_send_propose_round_timeout() {
         current_round,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2778,7 +2778,7 @@ fn commit_as_leader_send_propose_round_timeout() {
         current_round,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -2977,7 +2977,7 @@ fn handle_round_timeout_ignore_if_height_and_round_are_not_the_same() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_1),
     );
     let precommit_2 = Precommit::new(
@@ -2986,7 +2986,7 @@ fn handle_round_timeout_ignore_if_height_and_round_are_not_the_same() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     );
     let precommit_3 = Precommit::new(
@@ -2995,7 +2995,7 @@ fn handle_round_timeout_ignore_if_height_and_round_are_not_the_same() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     );
 
@@ -3140,7 +3140,7 @@ fn handle_round_timeout_send_prevote_if_locked_to_propose() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.assert_lock(LOCK_ONE, Some(propose.hash()));

--- a/sandbox/tests/consensus.rs
+++ b/sandbox/tests/consensus.rs
@@ -203,7 +203,7 @@ fn test_disable_and_enable() {
     sandbox.process_events();
 
     // Save the current time to "rewind" sandbox to it later.
-    let time_saved = sandbox.time().into();
+    let time_saved = sandbox.time();
 
     // A fail is expected here as the node is disabled.
     sandbox.assert_state(HEIGHT_TWO, ROUND_ONE);

--- a/sandbox/tests/old.rs
+++ b/sandbox/tests/old.rs
@@ -141,7 +141,7 @@ fn test_get_lock_and_send_precommit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.assert_lock(ROUND_ONE, Some(propose.hash()));
@@ -201,7 +201,7 @@ fn test_commit() {
         ROUND_ONE,
         &propose.hash(),
         &block.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_0),
     ));
     sandbox.recv(&Precommit::new(
@@ -210,7 +210,7 @@ fn test_commit() {
         ROUND_ONE,
         &propose.hash(),
         &propose.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_2),
     ));
     sandbox.recv(&Precommit::new(
@@ -219,7 +219,7 @@ fn test_commit() {
         ROUND_ONE,
         &propose.hash(),
         &propose.hash(),
-        sandbox.time(),
+        sandbox.time().into(),
         sandbox.s(VALIDATOR_3),
     ));
     sandbox.assert_state(HEIGHT_ONE, ROUND_ONE);

--- a/services/time/Cargo.toml
+++ b/services/time/Cargo.toml
@@ -23,6 +23,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 failure = "0.1.1"
+chrono = { version = "0.4.0", features = ["serde"] }
 
 [dev-dependencies]
 exonum-testkit = { version = "0.6.0", path = "../../testkit" }

--- a/services/time/examples/simple_service.rs
+++ b/services/time/examples/simple_service.rs
@@ -21,8 +21,10 @@ extern crate exonum_time;
 extern crate exonum_testkit;
 extern crate serde_json;
 extern crate serde;
+extern crate chrono;
 
-use std::time::{UNIX_EPOCH, SystemTime, Duration};
+use chrono::{DateTime, Utc, Duration, TimeZone};
+
 use exonum::blockchain::{Service, Transaction, TransactionSet, ExecutionResult};
 use exonum::crypto::{gen_keypair, Hash, PublicKey};
 use exonum::encoding;
@@ -78,7 +80,7 @@ transactions! {
         struct TxMarker {
             from: &PublicKey,
             mark: i32,
-            time: SystemTime,
+            time: DateTime<Utc>,
         }
     }
 }
@@ -131,7 +133,7 @@ fn main() {
         .with_service(TimeService::with_provider(mock_provider.clone()))
         .create();
 
-    mock_provider.set_time(UNIX_EPOCH + Duration::new(10, 0));
+    mock_provider.set_time(Utc.timestamp(10, 0));
     testkit.create_blocks_until(Height(2));
 
     let snapshot = testkit.snapshot();
@@ -148,13 +150,13 @@ fn main() {
     let tx2 = TxMarker::new(
         &keypair2.0,
         2,
-        mock_provider.time() + Duration::new(10, 0),
+        mock_provider.time() + Duration::seconds(10),
         &keypair2.1,
     );
     let tx3 = TxMarker::new(
         &keypair3.0,
         3,
-        mock_provider.time() - Duration::new(5, 0),
+        mock_provider.time() - Duration::seconds(5),
         &keypair3.1,
     );
     testkit.create_block_with_transactions(txvec![tx1, tx2, tx3]);
@@ -168,7 +170,7 @@ fn main() {
     let tx4 = TxMarker::new(
         &keypair3.0,
         4,
-        UNIX_EPOCH + Duration::new(15, 0),
+        Utc.timestamp(15, 0),
         &keypair3.1,
     );
     testkit.create_block_with_transactions(txvec![tx4]);

--- a/services/time/examples/simple_service.rs
+++ b/services/time/examples/simple_service.rs
@@ -167,12 +167,7 @@ fn main() {
     assert_eq!(schema.marks().get(&keypair2.0), Some(2));
     assert_eq!(schema.marks().get(&keypair3.0), None);
 
-    let tx4 = TxMarker::new(
-        &keypair3.0,
-        4,
-        Utc.timestamp(15, 0),
-        &keypair3.1,
-    );
+    let tx4 = TxMarker::new(&keypair3.0, 4, Utc.timestamp(15, 0), &keypair3.1);
     testkit.create_block_with_transactions(txvec![tx4]);
 
     let snapshot = testkit.snapshot();

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -341,7 +341,8 @@ impl TimeProvider for SystemTimeProvider {
 /// # extern crate exonum;
 /// # extern crate exonum_testkit;
 /// # extern crate exonum_time;
-/// use std::time::{Duration, UNIX_EPOCH};
+/// # extern crate chrono;
+/// use chrono::{Utc, Duration, TimeZone};
 /// use exonum::helpers::Height;
 /// use exonum_testkit::TestKitBuilder;
 /// use exonum_time::{MockTimeProvider, TimeSchema, TimeService};
@@ -351,14 +352,14 @@ impl TimeProvider for SystemTimeProvider {
 /// let mut testkit = TestKitBuilder::validator()
 ///     .with_service(TimeService::with_provider(mock_provider.clone()))
 ///     .create();
-/// mock_provider.add_time(Duration::new(15, 0));
+/// mock_provider.add_time(Duration::seconds(15));
 /// testkit.create_blocks_until(Height(2));
 ///
 /// // The time reported by the mock time provider is reflected by the service.
 /// let snapshot = testkit.snapshot();
 /// let schema = TimeSchema::new(snapshot);
 /// assert_eq!(
-///     Some(UNIX_EPOCH + Duration::new(15, 0)),
+///     Some(Utc.timestamp(15, 0)),
 ///     schema.time().get().map(|time| time)
 /// );
 /// # }

--- a/services/time/tests/test_exonum_time.rs
+++ b/services/time/tests/test_exonum_time.rs
@@ -18,10 +18,12 @@ extern crate exonum_time;
 extern crate exonum_testkit;
 #[macro_use]
 extern crate pretty_assertions;
+extern crate chrono;
+
+use chrono::{DateTime, Utc, Duration, TimeZone};
 
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::time::{SystemTime, Duration, UNIX_EPOCH};
 
 use exonum::blockchain::{Schema, Transaction, TransactionErrorType};
 use exonum::helpers::{Height, ValidatorId};
@@ -34,8 +36,8 @@ use exonum_testkit::{ApiKind, TestKitApi, TestKitBuilder, TestNode};
 fn assert_storage_times_eq<T: AsRef<Snapshot>>(
     snapshot: T,
     validators: &[TestNode],
-    expected_current_time: Option<SystemTime>,
-    expected_validators_times: &[Option<SystemTime>],
+    expected_current_time: Option<DateTime<Utc>>,
+    expected_validators_times: &[Option<DateTime<Utc>>],
 ) {
     let schema = TimeSchema::new(snapshot);
 
@@ -96,7 +98,7 @@ fn test_exonum_time_service_with_3_validators() {
     //
     // Consolidated time will have the value `time0`.
 
-    let time0 = SystemTime::now();
+    let time0 = Utc::now();
     let tx0 = {
         let (pub_key, sec_key) = validators[0].service_keypair();
         TxTime::new(time0, pub_key, sec_key)
@@ -118,7 +120,7 @@ fn test_exonum_time_service_with_3_validators() {
     // In sorted order: `time1` >= `time0`.
     // Consolidated time will have the value `time1`.
 
-    let time1 = time0 + Duration::new(10, 0);
+    let time1 = time0 + Duration::seconds(10);
     let tx1 = {
         let (pub_key, sec_key) = validators[1].service_keypair();
         TxTime::new(time1, pub_key, sec_key)
@@ -164,7 +166,7 @@ fn test_exonum_time_service_with_4_validators() {
     //
     // Consolidated time doesn't change.
 
-    let time0 = SystemTime::now();
+    let time0 = Utc::now();
     let tx0 = {
         let (pub_key, sec_key) = validators[0].service_keypair();
         TxTime::new(time0, pub_key, sec_key)
@@ -186,7 +188,7 @@ fn test_exonum_time_service_with_4_validators() {
     // In sorted order: `time1` >= `time0`.
     // Consolidated time doesn't change.
 
-    let time1 = time0 + Duration::new(10, 0);
+    let time1 = time0 + Duration::seconds(10);
     let tx1 = {
         let (pub_key, sec_key) = validators[1].service_keypair();
         TxTime::new(time1, pub_key, sec_key)
@@ -208,7 +210,7 @@ fn test_exonum_time_service_with_4_validators() {
     // In sorted order: `time2` >= `time1` >= `time0`.
     // Consolidated time will have the value `time1`.
 
-    let time2 = time1 + Duration::new(10, 0);
+    let time2 = time1 + Duration::seconds(10);
     let tx2 = {
         let (pub_key, sec_key) = validators[2].service_keypair();
         TxTime::new(time2, pub_key, sec_key)
@@ -230,7 +232,7 @@ fn test_exonum_time_service_with_4_validators() {
     // In sorted order: `time3` >= `time2` >= `time1` >= `time0`.
     // Consolidated time will have the value `time2`.
 
-    let time3 = time2 + Duration::new(10, 0);
+    let time3 = time2 + Duration::seconds(10);
     let tx3 = {
         let (pub_key, sec_key) = validators[3].service_keypair();
         TxTime::new(time3, pub_key, sec_key)
@@ -257,9 +259,9 @@ fn test_exonum_time_service_with_7_validators() {
 
     assert_storage_times_eq(testkit.snapshot(), &validators, None, &validators_times);
 
-    let time = SystemTime::now();
+    let time = Utc::now();
     let times = (0..7)
-        .map(|x| time + Duration::new(x * 10, 0))
+        .map(|x| time + Duration::seconds(x * 10))
         .collect::<Vec<_>>();
     let expected_storage_times =
         vec![None, None, None, None, Some(times[2]), Some(times[3]), Some(times[4])];
@@ -305,29 +307,29 @@ fn test_mock_provider() {
         );
     };
 
-    mock_provider.add_time(Duration::new(10, 0));
-    assert_eq!(UNIX_EPOCH + Duration::new(10, 0), mock_provider.time());
+    mock_provider.add_time(Duration::seconds(10));
+    assert_eq!(Utc.timestamp(10, 0), mock_provider.time());
     testkit.create_blocks_until(Height(2));
     assert_storage_times(testkit.snapshot());
 
-    mock_provider.set_time(UNIX_EPOCH + Duration::new(50, 0));
-    assert_eq!(UNIX_EPOCH + Duration::new(50, 0), mock_provider.time());
+    mock_provider.set_time(Utc.timestamp(50, 0));
+    assert_eq!(Utc.timestamp(50, 0), mock_provider.time());
     testkit.create_blocks_until(Height(4));
     assert_storage_times(testkit.snapshot());
 
-    mock_provider.add_time(Duration::new(20, 0));
-    assert_eq!(UNIX_EPOCH + Duration::new(70, 0), mock_provider.time());
+    mock_provider.add_time(Duration::seconds(20));
+    assert_eq!(Utc.timestamp(70, 0), mock_provider.time());
     testkit.create_blocks_until(Height(6));
     assert_storage_times(testkit.snapshot());
 
-    mock_provider.set_time(UNIX_EPOCH + Duration::new(30, 0));
-    assert_eq!(UNIX_EPOCH + Duration::new(30, 0), mock_provider.time());
+    mock_provider.set_time(Utc.timestamp(30, 0));
+    assert_eq!(Utc.timestamp(30, 0), mock_provider.time());
     testkit.create_blocks_until(Height(8));
     assert_storage_times_eq(
         testkit.snapshot(),
         &validators,
-        Some(UNIX_EPOCH + Duration::new(70, 0)),
-        &[Some(UNIX_EPOCH + Duration::new(70, 0))],
+        Some(Utc.timestamp(70, 0)),
+        &[Some(Utc.timestamp(70, 0))],
     );
 }
 
@@ -367,7 +369,7 @@ fn test_selected_time_less_than_time_in_storage() {
     );
 
     if let Some(time_in_storage) = schema.time().get() {
-        let time_tx = time_in_storage - Duration::new(10, 0);
+        let time_tx = time_in_storage - Duration::seconds(10);
         let tx = {
             TxTime::new(time_tx, pub_key_1, sec_key_1)
         };
@@ -399,7 +401,7 @@ fn test_creating_transaction_is_not_validator() {
         .create();
 
     let (pub_key, sec_key) = gen_keypair();
-    let tx = TxTime::new(SystemTime::now(), &pub_key, &sec_key);
+    let tx = TxTime::new(Utc::now(), &pub_key, &sec_key);
     testkit.create_block_with_transactions(txvec![tx.clone()]);
     assert_transaction_result(testkit.snapshot(), &tx, Error::UnknownSender as u8);
 
@@ -419,7 +421,7 @@ fn test_transaction_time_less_than_validator_time_in_storage() {
     let validator = &testkit.network().validators().to_vec()[0];
     let (pub_key, sec_key) = validator.service_keypair();
 
-    let time0 = SystemTime::now();
+    let time0 = Utc::now();
     let tx0 = TxTime::new(time0, pub_key, sec_key);
 
     testkit.create_block_with_transactions(txvec![tx0.clone()]);
@@ -436,7 +438,7 @@ fn test_transaction_time_less_than_validator_time_in_storage() {
     assert_eq!(schema.time().get(), Some(time0));
     assert_eq!(schema.validators_times().get(pub_key), Some(time0));
 
-    let time1 = time0 - Duration::new(10, 0);
+    let time1 = time0 - Duration::seconds(10);
     let tx1 = TxTime::new(time1, pub_key, sec_key);
 
     testkit.create_block_with_transactions(txvec![tx1.clone()]);
@@ -453,7 +455,7 @@ fn test_transaction_time_less_than_validator_time_in_storage() {
     assert_eq!(schema.validators_times().get(pub_key), Some(time0));
 }
 
-fn get_current_time(api: &TestKitApi) -> Option<SystemTime> {
+fn get_current_time(api: &TestKitApi) -> Option<DateTime<Utc>> {
     api.get(ApiKind::Service("exonum_time"), "v1/current_time")
 }
 
@@ -465,14 +467,14 @@ fn get_all_validators_times(api: &TestKitApi) -> Vec<ValidatorTime> {
     api.get_private(ApiKind::Service("exonum_time"), "v1/validators_times/all")
 }
 
-fn assert_current_time_eq(api: &TestKitApi, expected_time: Option<SystemTime>) {
+fn assert_current_time_eq(api: &TestKitApi, expected_time: Option<DateTime<Utc>>) {
     let current_time = get_current_time(api);
     assert_eq!(expected_time, current_time);
 }
 
 fn assert_current_validators_times_eq(
     api: &TestKitApi,
-    expected_times: &HashMap<PublicKey, Option<SystemTime>>,
+    expected_times: &HashMap<PublicKey, Option<DateTime<Utc>>>,
 ) {
     let validators_times =
         HashMap::from_iter(get_current_validators_times(api).iter().map(|validator| {
@@ -484,7 +486,7 @@ fn assert_current_validators_times_eq(
 
 fn assert_all_validators_times_eq(
     api: &TestKitApi,
-    expected_validators_times: &HashMap<PublicKey, Option<SystemTime>>,
+    expected_validators_times: &HashMap<PublicKey, Option<DateTime<Utc>>>,
 ) {
     let validators_times =
         HashMap::from_iter(get_all_validators_times(api).iter().map(|validator| {
@@ -503,7 +505,7 @@ fn test_endpoint_api() {
 
     let api = testkit.api();
     let validators = testkit.network().validators().to_vec();
-    let mut current_validators_times: HashMap<PublicKey, Option<SystemTime>> =
+    let mut current_validators_times: HashMap<PublicKey, Option<DateTime<Utc>>> =
         HashMap::from_iter(validators.iter().map(|validator| {
             (*validator.service_keypair().0, None)
         }));
@@ -513,7 +515,7 @@ fn test_endpoint_api() {
     assert_current_validators_times_eq(&api, &current_validators_times);
     assert_all_validators_times_eq(&api, &all_validators_times);
 
-    let time0 = SystemTime::now();
+    let time0 = Utc::now();
     let (pub_key, sec_key) = validators[0].service_keypair();
     testkit.create_block_with_transactions(txvec![TxTime::new(time0, pub_key, sec_key)]);
     current_validators_times.insert(*pub_key, Some(time0));
@@ -523,7 +525,7 @@ fn test_endpoint_api() {
     assert_current_validators_times_eq(&api, &current_validators_times);
     assert_all_validators_times_eq(&api, &all_validators_times);
 
-    let time1 = time0 + Duration::new(10, 0);
+    let time1 = time0 + Duration::seconds(10);
     let (pub_key, sec_key) = validators[1].service_keypair();
     testkit.create_block_with_transactions(txvec![TxTime::new(time1, pub_key, sec_key)]);
     current_validators_times.insert(*pub_key, Some(time1));
@@ -533,7 +535,7 @@ fn test_endpoint_api() {
     assert_current_validators_times_eq(&api, &current_validators_times);
     assert_all_validators_times_eq(&api, &all_validators_times);
 
-    let time2 = time1 + Duration::new(10, 0);
+    let time2 = time1 + Duration::seconds(10);
     let (pub_key, sec_key) = validators[2].service_keypair();
     testkit.create_block_with_transactions(txvec![TxTime::new(time2, pub_key, sec_key)]);
     current_validators_times.insert(*pub_key, Some(time2));
@@ -572,7 +574,7 @@ fn test_endpoint_api() {
     assert_current_validators_times_eq(&api, &current_validators_times);
     assert_all_validators_times_eq(&api, &all_validators_times);
 
-    let time3 = time2 + Duration::new(10, 0);
+    let time3 = time2 + Duration::seconds(10);
     let (pub_key, sec_key) = validators[0].service_keypair();
     testkit.create_block_with_transactions(txvec![TxTime::new(time3, pub_key, sec_key)]);
     current_validators_times.insert(*pub_key, Some(time3));

--- a/testkit/src/network.rs
+++ b/testkit/src/network.rs
@@ -192,7 +192,7 @@ impl TestNode {
             propose.round(),
             &propose.hash(),
             block_hash,
-            SystemTime::now(),
+            SystemTime::now().into(),
             &self.consensus_secret_key,
         )
     }


### PR DESCRIPTION
-> What happen?
Rewriting `exonum-time` from `SystemTime` to `chrono::DateTime`. `SystemTime` can't be used in storages and messages anymore, but it's still in use in ~~dark and scary~~ some internals (no, we can't rewrite those places to `chrono`, because ~~I tried and it's complete nightmare~~ `tokio` and a lot of different things are tangled with `SystemTime` and `chrono` is not that usable in some scenarios). 

-> Drawbacks?
As a drawback, there're a lot of `into` calls in the code related to time operations, but personally I don't think it's huge problem.

-> For what? I loved `SystemTime`!
We've found some weird behavior in one of the tests under Windows. After short investigation we've released that `SystemTime` has different precision and (it's more important) different ranges on different platforms. Most likely this situation won't change, so we decided to use platform-independent solution (as we need to guarantee predictability across all platforms).