### PR TITLE
Human-readable description of tx failures

### DIFF
--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -207,7 +207,8 @@ pub enum Error {
 
 impl From<Error> for ExecutionError {
     fn from(value: Error) -> ExecutionError {
-        ExecutionError::new(value as u8)
+        let description = format!("{}", &value);
+        ExecutionError::with_description(value as u8, description)
     }
 }
 

--- a/examples/cryptocurrency/tests/api.rs
+++ b/examples/cryptocurrency/tests/api.rs
@@ -114,7 +114,7 @@ fn test_transfer_from_nonexisting_wallet() {
     testkit.create_block_with_tx_hashes(&[tx.hash()]);
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 1, "description": "" }),
+        &json!({ "type": "error", "code": 1, "description": "Sender doesn't exist" }),
     );
 
     // Check that Bob's balance doesn't change.
@@ -148,7 +148,7 @@ fn test_transfer_to_nonexisting_wallet() {
     testkit.create_block_with_tx_hashes(&[tx.hash()]);
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 2, "description": "" }),
+        &json!({ "type": "error", "code": 2, "description": "Receiver doesn't exist" }),
     );
 
     // Check that Alice's balance doesn't change.
@@ -177,7 +177,7 @@ fn test_transfer_overcharge() {
     testkit.create_block();
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 3, "description": "" }),
+        &json!({ "type": "error", "code": 3, "description": "Insufficient currency amount" }),
     );
 
     let wallet = api.get_wallet(tx_alice.pub_key());


### PR DESCRIPTION
Cryptocurrency Service now returns a human-readable description in case of a tx failure, instead of an empty string. Relevant tests are updated.
(Test unfortunately fails when two transaction with the same hash are added to the blockchain. This is expected, but an error must be generated and now it just panics)
