### PR TITLE
UniqueHash trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `events` module becomes private. (#568)
 
+- `CryptoHash` trait is no longer implemented for `Hash`. (#579) 
+
 #### exonum-testkit
 
 - Testkit api now contains two methods to work with the transaction pool:
@@ -97,6 +99,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   arbitrary number of elements at one time with the help of `get_multiproof`
   method. Correspondingly, `MapProof` allows to verify proofs for an arbitrary
   number of elements. (#380)
+
+- `storage::UniqueHash` trait that represents a unique, but not necessary
+  cryptographic hash function, is introduced. (#579)
 
 ### Internal improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `events` module becomes private. (#568)
 
-- `CryptoHash` trait is no longer implemented for `Hash`. (#579) 
+- `CryptoHash` trait is no longer implemented for `Hash`. (#579)
 
 #### exonum-testkit
 

--- a/exonum/src/storage/hash.rs
+++ b/exonum/src/storage/hash.rs
@@ -1,0 +1,36 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::{CryptoHash, Hash};
+
+/// A common trait for the ability to compute a unique hash. Unlike `CryptoHash`, the hash value
+/// returned by the `UniqueHash::hash()` method isn't always irreversible.
+pub trait UniqueHash {
+    /// Returns a hash of the value.
+    ///
+    /// Hash must be unique, but not necessary cryptographic.
+    fn hash(&self) -> Hash;
+}
+
+impl<T: CryptoHash> UniqueHash for T {
+    fn hash(&self) -> Hash {
+        CryptoHash::hash(self)
+    }
+}
+
+impl UniqueHash for Hash {
+    fn hash(&self) -> Hash {
+        *self
+    }
+}

--- a/exonum/src/storage/mod.rs
+++ b/exonum/src/storage/mod.rs
@@ -131,6 +131,7 @@ pub use self::value_set_index::ValueSetIndex;
 pub use self::proof_list_index::{ProofListIndex, ListProof};
 #[doc(no_inline)]
 pub use self::proof_map_index::{ProofMapIndex, MapProof, HashedKey};
+pub use self::hash::UniqueHash;
 
 /// A specialized `Result` type for I/O operations with storage.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -140,11 +141,10 @@ mod db;
 mod options;
 mod rocksdb;
 mod memorydb;
-
 mod keys;
 mod values;
-
 mod entry;
+mod hash;
 
 pub mod base_index;
 mod indexes_metadata;

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -20,9 +20,10 @@ use chrono::{DateTime, Utc, NaiveDateTime};
 use std::mem;
 use std::borrow::Cow;
 
-use crypto::{CryptoHash, Hash, PublicKey};
+use crypto::{Hash, PublicKey};
 use messages::{RawMessage, MessageBuffer};
 use helpers::Round;
+use super::UniqueHash;
 
 /// A type that can be (de)serialized as a value in the blockchain storage.
 ///
@@ -75,7 +76,7 @@ use helpers::Round;
 ///
 /// [`encoding_struct!`]: ../macro.encoding_struct.html
 /// [`transactions!`]: ../macro.transactions.html
-pub trait StorageValue: CryptoHash + Sized {
+pub trait StorageValue: UniqueHash + Sized {
     /// Serialize a value into a vector of bytes.
     fn into_bytes(self) -> Vec<u8>;
 
@@ -258,18 +259,6 @@ impl StorageValue for String {
 
     fn from_bytes(value: Cow<[u8]>) -> Self {
         String::from_utf8(value.into_owned()).unwrap()
-    }
-}
-
-impl CryptoHash for DateTime<Utc> {
-    fn hash(&self) -> Hash {
-        let secs = self.timestamp();
-        let nanos = self.timestamp_subsec_nanos();
-
-        let mut buffer = vec![0; 12];
-        LittleEndian::write_i64(&mut buffer[0..8], secs);
-        LittleEndian::write_u32(&mut buffer[8..12], nanos);
-        buffer.hash()
     }
 }
 


### PR DESCRIPTION
A slightly different approach to the "`CryptoHash` implementation for `Hash`" [problem](https://github.com/exonum/exonum/pull/562):
- `CryptoHash` is no longer implemented for `Hash`.
- `UniqueHash` trait is introduced.
- Storage uses `UniqueHash` instead of `CryptoHash`.