### PR TITLE
example: Don't evaluate wallet in block

### DIFF
--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -326,13 +326,10 @@ pub mod api {
                 ))
             })?;
 
-            let wallet = {
-                let snapshot = self.blockchain.snapshot();
-                let schema = CurrencySchema::new(snapshot);
-                schema.wallet(&public_key)
-            };
+            let snapshot = self.blockchain.snapshot();
+            let schema = CurrencySchema::new(snapshot);
 
-            if let Some(wallet) = wallet {
+            if let Some(wallet) = schema.wallet(&public_key) {
                 self.ok_response(&serde_json::to_value(wallet).unwrap())
             } else {
                 self.not_found_response(&serde_json::to_value("Wallet not found").unwrap())


### PR DESCRIPTION
Hello,

while I was studying the example I noticed that `wallet` is evaluated in block.

I am not sure but it seems like there is no any special reason for that. So, I tried to remove the block and everything still worked fine.

Please, correct me if I am wrong here.