### PR TITLE
Human readable failures in cryptocurrency example

### DIFF
--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -186,10 +186,11 @@ pub mod errors {
         InsufficientCurrencyAmount = 3,
     }
 
-impl From<Error> for ExecutionError {
-    fn from(value: Error) -> ExecutionError {
-        let description = format!("{}", &value);
-        ExecutionError::with_description(value as u8, description)
+    impl From<Error> for ExecutionError {
+        fn from(value: Error) -> ExecutionError {
+            let description = format!("{}", value);
+            ExecutionError::with_description(value as u8, description)
+        }
     }
 }
 

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -186,10 +186,10 @@ pub mod errors {
         InsufficientCurrencyAmount = 3,
     }
 
-    impl From<Error> for ExecutionError {
-        fn from(value: Error) -> ExecutionError {
-            ExecutionError::new(value as u8)
-        }
+impl From<Error> for ExecutionError {
+    fn from(value: Error) -> ExecutionError {
+        let description = format!("{}", &value);
+        ExecutionError::with_description(value as u8, description)
     }
 }
 

--- a/examples/cryptocurrency/tests/api.rs
+++ b/examples/cryptocurrency/tests/api.rs
@@ -116,7 +116,7 @@ fn test_transfer_from_nonexisting_wallet() {
     testkit.create_block_with_tx_hashes(&[tx.hash()]);
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 1, "description": "" }),
+        &json!({ "type": "error", "code": 1, "description": "Sender doesn't exist" }),
     );
 
     // Check that Bob's balance doesn't change.
@@ -150,7 +150,7 @@ fn test_transfer_to_nonexisting_wallet() {
     testkit.create_block_with_tx_hashes(&[tx.hash()]);
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 2, "description": "" }),
+        &json!({ "type": "error", "code": 2, "description": "Receiver doesn't exist" }),
     );
 
     // Check that Alice's balance doesn't change.
@@ -179,7 +179,7 @@ fn test_transfer_overcharge() {
     testkit.create_block();
     api.assert_tx_status(
         &tx.hash(),
-        &json!({ "type": "error", "code": 3, "description": "" }),
+        &json!({ "type": "error", "code": 3, "description": "Insufficient currency amount" }),
     );
 
     let wallet = api.get_wallet(tx_alice.pub_key());


### PR DESCRIPTION
Replacement for https://github.com/exonum/exonum/pull/573

There is no way to test `TxCreateWallet`, as exonum will prevent from processing the same transaction twice.