### PR TITLE
CheckpointDb and handmade checkpoints [ECR-975]

### DIFF
--- a/testkit/src/checkpoint_db.rs
+++ b/testkit/src/checkpoint_db.rs
@@ -129,7 +129,7 @@ impl<T: Database> CheckpointDbInner<T> {
         self.db.merge(patch.clone())?;
         let mut rev_fork = self.db.fork();
 
-        // Reverse a patch to get a backup patch
+        // Reverse a patch to get a backup patch.
         for (name, changes) in patch {
             for (key, _) in changes {
                 match snapshot.get(&name, &key) {
@@ -143,7 +143,7 @@ impl<T: Database> CheckpointDbInner<T> {
             }
         }
 
-        // Should insert backup patches to the front of the backup (VecDeque)
+        // Should insert backup patches to the front of the backup (VecDeque).
         self.backup_stack
             .last_mut()
             .expect("`merge_with_logging` called before checkpoint has been set")
@@ -283,7 +283,7 @@ mod tests {
             );
         }
 
-        // Check that the old snapshot still corresponds to the same DB state
+        // Check that the old snapshot still corresponds to the same DB state.
         assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![3]));
@@ -297,7 +297,7 @@ mod tests {
         fork.put("foo", vec![], vec![2]);
         db.merge(fork.into_patch()).unwrap();
 
-        // Both checkpoints are on purpose
+        // Both checkpoints are on purpose.
         handler.checkpoint();
         handler.checkpoint();
         let mut fork = db.fork();
@@ -331,7 +331,7 @@ mod tests {
             assert_eq!(backup.len(), 0);
         }
 
-        // Check that DB continues working as usual after a rollback
+        // Check that DB continues working as usual after a rollback.
         handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![4]);

--- a/testkit/src/checkpoint_db.rs
+++ b/testkit/src/checkpoint_db.rs
@@ -217,42 +217,27 @@ mod tests {
         assert_eq!(patch_set, expected_set);
     }
 
+    fn stack_len<T>(db: &CheckpointDb<T>) -> usize {
+        let inner = db.inner.read().unwrap();
+        inner.backup_stack.len()
+    }
+
     #[test]
     fn test_backup_stack() {
         let db = CheckpointDb::new(MemoryDB::new());
         let handler = db.handler();
 
-        {
-            let inner = db.inner.read().unwrap();
-            let stack = &inner.backup_stack;
-            assert_eq!(stack.len(), 0);
-        }
+        assert_eq!(stack_len(&db), 0);
         handler.checkpoint();
-        {
-            let inner = db.inner.read().unwrap();
-            let stack = &inner.backup_stack;
-            assert_eq!(stack.len(), 1);
-        }
+        assert_eq!(stack_len(&db), 1);
         handler.rollback();
-        {
-            let inner = db.inner.read().unwrap();
-            let stack = &inner.backup_stack;
-            assert_eq!(stack.len(), 0);
-        }
+        assert_eq!(stack_len(&db), 0);
 
         handler.checkpoint();
         handler.checkpoint();
-        {
-            let inner = db.inner.read().unwrap();
-            let stack = &inner.backup_stack;
-            assert_eq!(stack.len(), 2);
-        }
+        assert_eq!(stack_len(&db), 2);
         handler.rollback();
-        {
-            let inner = db.inner.read().unwrap();
-            let stack = &inner.backup_stack;
-            assert_eq!(stack.len(), 1);
-        }
+        assert_eq!(stack_len(&db), 1);
     }
 
     #[test]

--- a/testkit/src/checkpoint_db.rs
+++ b/testkit/src/checkpoint_db.rs
@@ -146,7 +146,7 @@ impl<T: Database> CheckpointDbInner<T> {
         // Should insert backup patches to the front of the backup (VecDeque)
         self.backup_stack
             .last_mut()
-            .expect("`merge_with_loggin` called before checkpoint has been set")
+            .expect("`merge_with_logging` called before checkpoint has been set")
             .push_front(rev_fork.into_patch());
         Ok(())
     }
@@ -326,7 +326,7 @@ mod tests {
             let backup = stack.last().expect("There are not backups in the stack");
             assert_eq!(backup.len(), 1);
             let old_backup = stack.get(stack.len() - 2).expect(
-                "Exepcted 2 backups in the stack, found 1",
+                "Expected 2 backups in the stack, found 1",
             );
             assert_eq!(old_backup.len(), 0);
         }
@@ -359,7 +359,7 @@ mod tests {
             let backup = stack.last().expect("There are not backups in the stack");
             assert_eq!(backup.len(), 1);
             let old_backup = stack.get(stack.len() - 2).expect(
-                "Exepcted 2 backups in the stack, found 1",
+                "Expected 2 backups in the stack, found 1",
             );
             assert_eq!(old_backup.len(), 0);
         }
@@ -377,7 +377,7 @@ mod tests {
             let backup = stack.last().expect("There are not backups in the stack");
             assert_eq!(backup.len(), 2);
             let old_backup = stack.get(stack.len() - 2).expect(
-                "Exepcted 2 backups in the stack, found 1",
+                "Expected 2 backups in the stack, found 1",
             );
             assert_eq!(old_backup.len(), 0);
         }

--- a/testkit/src/checkpoint_db.rs
+++ b/testkit/src/checkpoint_db.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 use std::sync::{Arc, RwLock};
+use std::collections::VecDeque;
 
 use exonum::storage::{Database, Patch, Result as StorageResult, Snapshot};
 
-/// Implementation of a `Database`, which allows to rollback commits introduced by the `merge()`
-/// function.
+/// Implementation of a `Database`, which allows to rollback its state
+/// to the last made checkpoint.
 ///
 /// **Note:** Intended for testing purposes only. Probably inefficient.
 #[derive(Debug)]
@@ -73,31 +74,39 @@ pub struct CheckpointDbHandler<T> {
 }
 
 impl<T: Database> CheckpointDbHandler<T> {
-    /// Rolls back this database by undoing the latest `count` `merge()` operations.
+    /// Sets a checkpoint for a future [`rollback`](#method.rollback).
+    pub fn checkpoint(&self) {
+        self.inner
+            .write()
+            .expect("Cannot lock checkpointDb for checkpoint")
+            .checkpoint();
+    }
+
+    /// Rolls back this database to the latest checkpoint
+    /// set with [`checkpoint`](#method.checkpoint).
     ///
     /// # Panics
     ///
-    /// - Panics if more operations are attempted to be reverted than the number of operations
-    ///   in the DB journal.
-    pub fn rollback(&self, count: usize) {
+    /// - Panics if there are no available checkpoints.
+    pub fn rollback(&self) {
         self.inner
             .write()
             .expect("Cannot lock CheckpointDb for rollback")
-            .rollback(count);
+            .rollback();
     }
 }
 
 #[derive(Debug)]
 struct CheckpointDbInner<T> {
     db: T,
-    journal: Vec<Patch>,
+    backup_stack: Vec<VecDeque<Patch>>,
 }
 
 impl<T: Database> CheckpointDbInner<T> {
     fn new(db: T) -> Self {
         CheckpointDbInner {
             db,
-            journal: Vec::new(),
+            backup_stack: Vec::new(),
         }
     }
 
@@ -106,12 +115,21 @@ impl<T: Database> CheckpointDbInner<T> {
     }
 
     fn merge(&mut self, patch: Patch) -> StorageResult<()> {
+        if self.backup_stack.is_empty() {
+            self.db.merge(patch)
+        } else {
+            self.merge_with_logging(patch)
+        }
+    }
+
+    fn merge_with_logging(&mut self, patch: Patch) -> StorageResult<()> {
         // NB: make sure that **both** the db and the journal
         // are updated atomically.
         let snapshot = self.db.snapshot();
         self.db.merge(patch.clone())?;
         let mut rev_fork = self.db.fork();
 
+        // Reverse a patch to get a backup patch
         for (name, changes) in patch {
             for (key, _) in changes {
                 match snapshot.get(&name, &key) {
@@ -125,20 +143,25 @@ impl<T: Database> CheckpointDbInner<T> {
             }
         }
 
-        self.journal.push(rev_fork.into_patch());
+        // Should insert backup patches to the front of the backup (VecDeque)
+        self.backup_stack
+            .last_mut()
+            .expect("`merge_with_loggin` called before checkpoint has been set")
+            .push_front(rev_fork.into_patch());
         Ok(())
     }
 
-    fn rollback(&mut self, count: usize) {
-        assert!(
-            self.journal.len() >= count,
-            "Cannot rollback {} changes; only {} checkpoints in the journal",
-            count,
-            self.journal.len()
-        );
+    fn checkpoint(&mut self) {
+        self.backup_stack.push(VecDeque::new())
+    }
 
-        for _ in 0..count {
-            let patch = self.journal.pop().unwrap();
+    fn rollback(&mut self) {
+        assert!(
+            !self.backup_stack.is_empty(),
+            "Checkpoint has not been set yet"
+        );
+        let mut changelog = self.backup_stack.pop().unwrap();
+        for patch in changelog.drain(..) {
             self.db.merge(patch).expect("Cannot merge roll-back patch");
         }
     }
@@ -195,33 +218,83 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_db_basics() {
+    fn test_backup_stack() {
         let db = CheckpointDb::new(MemoryDB::new());
+        let handler = db.handler();
+
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 0);
+        }
+        handler.checkpoint();
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 1);
+        }
+        handler.rollback();
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 0);
+        }
+
+        handler.checkpoint();
+        handler.checkpoint();
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 2);
+        }
+        handler.rollback();
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_backup() {
+        let db = CheckpointDb::new(MemoryDB::new());
+        let handler = db.handler();
+        handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![2]);
         db.merge(fork.into_patch()).unwrap();
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 1);
-            check_patch(&journal[0], vec![("foo", vec![], Change::Delete)]);
+            let stack = &inner.backup_stack;
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 1);
+            check_patch(&backup[0], vec![("foo", vec![], Change::Delete)]);
         }
 
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
 
+        handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![3]);
         fork.put("bar", vec![1], vec![4]);
+        fork.put("bar2", vec![5], vec![6]);
         db.merge(fork.into_patch()).unwrap();
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 2);
-            check_patch(&journal[0], vec![("foo", vec![], Change::Delete)]);
+            let stack = &inner.backup_stack;
+            let recent_backup = stack.last().expect("There are not backups in the stack");
+            let older_backup = stack.get(stack.len() - 2).expect(
+                "Expected 2 backups, found 1",
+            );
+            check_patch(&older_backup[0], vec![("foo", vec![], Change::Delete)]);
             check_patch(
-                &journal[1],
-                vec![("foo", vec![], Change::Put(vec![2])), ("bar", vec![1], Change::Delete)],
+                &recent_backup[0],
+                vec![
+                    ("bar2", vec![5], Change::Delete),
+                    ("bar", vec![1], Change::Delete),
+                    ("foo", vec![], Change::Put(vec![2])),
+                ],
             );
         }
 
@@ -232,44 +305,63 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_db_rollback() {
+    fn test_rollback() {
         let db = CheckpointDb::new(MemoryDB::new());
         let handler = db.handler();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![2]);
         db.merge(fork.into_patch()).unwrap();
 
+        // Both checkpoints are on purpose
+        handler.checkpoint();
+        handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![3]);
         fork.put("bar", vec![1], vec![4]);
         db.merge(fork.into_patch()).unwrap();
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 2);
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 2);
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 1);
+            let old_backup = stack.get(stack.len() - 2).expect(
+                "Exepcted 2 backups in the stack, found 1",
+            );
+            assert_eq!(old_backup.len(), 0);
         }
 
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![3]));
-        handler.rollback(1);
+        handler.rollback();
+
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
         assert_eq!(snapshot.get("bar", &[1]), None);
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 1);
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 1);
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 0);
         }
 
         // Check that DB continues working as usual after a rollback
+        handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![4]);
         fork.put("foo", vec![0, 0], vec![255]);
         db.merge(fork.into_patch()).unwrap();
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 2);
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 2);
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 1);
+            let old_backup = stack.get(stack.len() - 2).expect(
+                "Exepcted 2 backups in the stack, found 1",
+            );
+            assert_eq!(old_backup.len(), 0);
         }
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![4]));
@@ -280,19 +372,27 @@ mod tests {
         db.merge(fork.into_patch()).unwrap();
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 3);
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 2);
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 2);
+            let old_backup = stack.get(stack.len() - 2).expect(
+                "Exepcted 2 backups in the stack, found 1",
+            );
+            assert_eq!(old_backup.len(), 0);
         }
         let new_snapshot = db.snapshot();
         assert_eq!(new_snapshot.get("foo", &[]), Some(vec![4]));
         assert_eq!(new_snapshot.get("foo", &[0, 0]), Some(vec![255]));
         assert_eq!(new_snapshot.get("bar", &[1]), Some(vec![254]));
+        handler.rollback();
 
-        handler.rollback(2);
         {
             let inner = db.inner.read().unwrap();
-            let journal = &inner.journal;
-            assert_eq!(journal.len(), 1);
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 1);
+            let backup = stack.last().expect("There are not backups in the stack");
+            assert_eq!(backup.len(), 0);
         }
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
@@ -302,21 +402,42 @@ mod tests {
         assert_eq!(new_snapshot.get("foo", &[]), Some(vec![4]));
         assert_eq!(new_snapshot.get("foo", &[0, 0]), Some(vec![255]));
         assert_eq!(new_snapshot.get("bar", &[1]), Some(vec![254]));
+        handler.rollback();
+
+        {
+            let inner = db.inner.read().unwrap();
+            let stack = &inner.backup_stack;
+            assert_eq!(stack.len(), 0);
+        }
     }
 
     #[test]
-    fn test_checkpoint_db_handler() {
+    fn test_handler() {
         let db = CheckpointDb::new(MemoryDB::new());
-        let db_handler = db.handler();
+        let handler = db.handler();
 
+        handler.checkpoint();
         let mut fork = db.fork();
         fork.put("foo", vec![], vec![2]);
         db.merge(fork.into_patch()).unwrap();
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), Some(vec![2]));
 
-        db_handler.rollback(1);
+        handler.rollback();
         let snapshot = db.snapshot();
         assert_eq!(snapshot.get("foo", &[]), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_extra_rollback() {
+        let db = CheckpointDb::new(MemoryDB::new());
+        let handler = db.handler();
+
+        handler.checkpoint();
+        handler.checkpoint();
+        handler.rollback();
+        handler.rollback();
+        handler.rollback();
     }
 }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -388,7 +388,12 @@ impl TestKit {
         &mut self.blockchain
     }
 
-    /// Rolls the blockchain back for a certain number of blocks.
+    /// Sets a checkpoint for a future [`rollback`](#method.rollback)
+    pub fn checkpoint(&mut self) {
+        self.db_handler.checkpoint()
+    }
+
+    /// Rolls the blockchain back to the latest [`checkpoint`](#method.checkpoint)
     ///
     /// # Examples
     ///
@@ -447,24 +452,21 @@ impl TestKit {
     /// let (pubkey, key) = exonum::crypto::gen_keypair();
     /// let tx_a = MyTransaction::new(&pubkey, "foo", &key);
     /// let tx_b = MyTransaction::new(&pubkey, "bar", &key);
+    ///
+    /// testkit.checkpoint();
     /// testkit.create_block_with_transactions(txvec![tx_a.clone(), tx_b.clone()]);
     /// assert_something_about(&testkit);
-    /// testkit.rollback(1);
+    /// testkit.rollback();
+    ///
+    /// testkit.checkpoint();
     /// testkit.create_block_with_transactions(txvec![tx_a.clone()]);
     /// testkit.create_block_with_transactions(txvec![tx_b.clone()]);
     /// assert_something_about(&testkit);
-    /// testkit.rollback(2);
+    /// testkit.rollback();
     /// # }
     /// ```
-    pub fn rollback(&mut self, blocks: usize) {
-        assert!(
-            self.height().0 >= blocks as u64,
-            "Cannot rollback past genesis block"
-        );
-        // Each block contain at least two phases:
-        // 1. add tx into pool;
-        // 2. commit tx from pool into next block.
-        self.db_handler.rollback(blocks * 2);
+    pub fn rollback(&mut self) {
+        self.db_handler.rollback()
     }
 
     /// Executes a list of transactions given the current state of the blockchain, but does not
@@ -483,9 +485,11 @@ impl TestKit {
             !schema.transactions().contains(&tx.hash()) ||
                 schema.transactions_pool().contains(&tx.hash())
         });
+
+        self.checkpoint();
         self.create_block_with_transactions(uncommitted_txs);
         let snapshot = self.snapshot();
-        self.rollback(1);
+        self.rollback();
         snapshot
     }
 

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -388,12 +388,12 @@ impl TestKit {
         &mut self.blockchain
     }
 
-    /// Sets a checkpoint for a future [`rollback`](#method.rollback)
+    /// Sets a checkpoint for a future [`rollback`](#method.rollback).
     pub fn checkpoint(&mut self) {
         self.db_handler.checkpoint()
     }
 
-    /// Rolls the blockchain back to the latest [`checkpoint`](#method.checkpoint)
+    /// Rolls the blockchain back to the latest [`checkpoint`](#method.checkpoint).
     ///
     /// # Examples
     ///

--- a/testkit/tests/change_configuration.rs
+++ b/testkit/tests/change_configuration.rs
@@ -66,23 +66,13 @@ fn test_configuration_and_rollbacks() {
     let old_config = testkit.actual_configuration();
     let new_config = proposal.stored_configuration().clone();
 
+    testkit.checkpoint();
+
     testkit.commit_configuration_change(proposal);
-
-    testkit.create_blocks_until(Height(10));
-    assert_eq!(testkit.actual_configuration(), new_config);
-    testkit.rollback(2);
-    assert_eq!(testkit.actual_configuration(), old_config);
     testkit.create_blocks_until(Height(10));
     assert_eq!(testkit.actual_configuration(), new_config);
 
-    testkit.rollback(4);
-    assert_eq!(testkit.height(), Height(6));
-    testkit.rollback(1);
-    assert_eq!(testkit.height(), Height(5));
-    // Check regression: if the config is merged to blockchain as a separate patch,
-    // the rollbacks may work incorrectly.
-    testkit.rollback(1);
-    assert_eq!(testkit.height(), Height(4));
+    testkit.rollback();
 
     // As rollback is behind the time a proposal entered the blockchain,
     // the proposal is effectively forgotten.

--- a/testkit/tests/inflating_currency/main.rs
+++ b/testkit/tests/inflating_currency/main.rs
@@ -106,41 +106,48 @@ fn test_transfer_scenarios() {
         &key_alice,
     );
     // Put transactions from A to B in separate blocks, allowing them both to succeed.
+    testkit.checkpoint();
     testkit.create_block_with_transactions(txvec![tx_a_to_b.clone()]); // A: 4 + 1, B: 14 + 1
     testkit.create_block_with_transactions(txvec![]); // A: 4 + 2, B: 14 + 2
     testkit.create_block_with_transactions(txvec![next_tx_a_to_b.clone()]); // A: 0 + 1, B: 20 + 3
     assert_eq!(get_balance(&api, tx_alice.pub_key()), 1); // 0 + 1
     assert_eq!(get_balance(&api, tx_bob.pub_key()), 23); // 20 + 3
-    testkit.rollback(3);
+    testkit.rollback();
 
     // If there is no block separating transactions, Alice's balance is insufficient
     // to complete the second transaction.
+    testkit.checkpoint();
     testkit.create_block_with_transactions(txvec![tx_a_to_b.clone()]); // A: 4 + 1, B: 14 + 1
     testkit.create_block_with_transactions(txvec![next_tx_a_to_b.clone()]); // fails
     assert_eq!(get_balance(&api, tx_alice.pub_key()), 6); // 4 + 2
     assert_eq!(get_balance(&api, tx_bob.pub_key()), 16); // 14 + 2
-    testkit.rollback(2);
+    testkit.rollback();
 
+    testkit.checkpoint();
     testkit.create_block_with_transactions(txvec![next_tx_a_to_b.clone()]); // A: 3 + 1, B: 15 + 1
     testkit.create_block_with_transactions(txvec![tx_a_to_b.clone()]); // fails
     assert_eq!(get_balance(&api, tx_alice.pub_key()), 5); // 3 + 2
     assert_eq!(get_balance(&api, tx_bob.pub_key()), 17); // 15 + 2
-    testkit.rollback(2);
+    testkit.rollback();
 
     // If the transactions are put in the same block, only the first transaction should succeed
+    testkit.checkpoint();
     testkit.create_block_with_transactions(txvec![tx_a_to_b.clone(), next_tx_a_to_b.clone()]);
     assert_eq!(get_balance(&api, tx_alice.pub_key()), 5); // 4 + 1
     assert_eq!(get_balance(&api, tx_bob.pub_key()), 15); // 14 + 1
-    testkit.rollback(1);
+    testkit.rollback();
 
     // Same here
+    testkit.checkpoint();
     testkit.create_block_with_transactions(txvec![next_tx_a_to_b.clone(), tx_a_to_b.clone()]);
     assert_eq!(get_balance(&api, tx_alice.pub_key()), 4); // 3 + 1
     assert_eq!(get_balance(&api, tx_bob.pub_key()), 16); // 15 + 1
-    testkit.rollback(1);
+    testkit.rollback();
 }
 
-fn fuzz_transfers_and_maybe_rollbacks(use_rollbacks: bool) {
+/// Test randomly generated transfers among users without blockchain rollbacks.
+#[test]
+fn test_fuzz_transfers() {
     const USERS: usize = 10;
 
     let mut rng = rand::thread_rng();
@@ -168,16 +175,6 @@ fn fuzz_transfers_and_maybe_rollbacks(use_rollbacks: bool) {
         let total_balance: u64 = pubkeys.iter().map(|key| get_balance(&api, key)).sum();
         assert_eq!(total_balance, (USERS as u64) * testkit.height().0);
 
-        if use_rollbacks {
-            let rollback_blocks = rng.choose(&[0usize, 0, 0, 1, 2, 3]);
-            match rollback_blocks {
-                Some(&blocks) if testkit.height() > Height(blocks as u64) => {
-                    testkit.rollback(blocks)
-                }
-                _ => {}
-            }
-        }
-
         let tx_count = rng.next_u32() & 15;
         let height = testkit.height().0;
         let txs = (0..tx_count)
@@ -193,18 +190,4 @@ fn fuzz_transfers_and_maybe_rollbacks(use_rollbacks: bool) {
             .map(Box::<Transaction>::from);
         testkit.create_block_with_transactions(txs);
     }
-}
-
-/// Test randomly generated transfers among users without blockchain rollbacks.
-#[test]
-fn test_fuzz_transfers() {
-    fuzz_transfers_and_maybe_rollbacks(false);
-}
-
-/// Test randomly generated transfers among users with blockchain rollbacks.
-/// This mostly tests `TestKit::rollback()` method rather than the service,
-/// because in practice rollbacks are impossible.
-#[test]
-fn test_fuzz_transfers_and_rollbacks() {
-    fuzz_transfers_and_maybe_rollbacks(true);
 }


### PR DESCRIPTION
Note: this is remake of https://github.com/exonum/exonum/pull/569 which was closed due to local technical difficulties.

This PR changes the interface of CheckpointDb from merge based rollbacks to  rollbacks to handmade checkpoints. Multiple checkpoints can be set and are handled on a stack-based basis (Rollback always rolls back to **the last** checkpoint).

## Before:
```rust
handler.rollback(3);
```
## Now:
```rust
handler.checkpoint();
// Mutate the database
handler.rollback();
```
or 
```rust
handler.checkpoint();
handler.checkpoint();
// Mutate the database
handler.rollback();
handler.rollback();
```

## Vision
Merge-based rollbacks was a very inconvenient way to use CheckpointDb and Testkit. It only makes sense to implement actual checkpoints to CheckpointDb.
## Issues for discussion
* There is no place in the existing codebase where multiple checkpoints are needed (besides tests for CheckpointDb itself)
* Stack-based rollbacks may not be the very convenient 
