### PR TITLE
Change pub(crate) to pub in crypto-currency example [ECR-1076]

### DIFF
--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -119,7 +119,8 @@ pub mod transactions {
     use service::SERVICE_ID;
 
     transactions! {
-        pub(crate) CurrencyTransactions {
+        /// Transaction group.
+        pub CurrencyTransactions {
             const SERVICE_ID = SERVICE_ID;
 
             /// Transaction type for creating a new wallet.


### PR DESCRIPTION
A tiny change that needed to be done after https://github.com/exonum/exonum/pull/575 merge.