### PR TITLE
Introduce '--validators-count' parameter to config template. [ECR-905]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   a new configuration proposal. By default the number of votes is calculated
   as 2/3 + 1 of total validators count. (#546)
 
+- `validators-count` command-line parameter is added. Now, when generating
+  config template using `generate-template` command you must specify number of validators.
+
 #### exonum-time
 
 - `SystemTime` has been replaced with `chrono::DateTime<Utc>`, as it provides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   as 2/3 + 1 of total validators count. (#546)
 
 - `validators-count` command-line parameter is added. Now, when generating
-  config template using `generate-template` command you must specify number of validators.
+  config template using `generate-template` command you must specify number of
+  validators. (#586)
 
 #### exonum-time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   a new configuration proposal. By default the number of votes is calculated
   as 2/3 + 1 of total validators count. (#546)
 
-- `validators-count` command-line parameter is added. Now, when generating
-  config template using `generate-template` command you must specify number of
-  validators. (#586)
+- `validators-count` command-line parameter has been added. Now, when
+  generating config template using `generate-template` command, you must
+  specify the number of validators. (#586)
 
 #### exonum-time
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -282,12 +282,14 @@ impl Command for GenerateCommonConfig {
     fn args(&self) -> Vec<Argument> {
         vec![
             Argument::new_positional("COMMON_CONFIG", true, "Path to common config."),
-            Argument::new_named("VALIDATORS_COUNT",
-                                true,
-                                "Number of validators",
-                                    None,
-                                "validators-count",
-                                false),
+            Argument::new_named(
+                "VALIDATORS_COUNT",
+                true,
+                "Number of validators",
+                None,
+                "validators-count",
+                false
+            ),
         ]
     }
 
@@ -575,13 +577,12 @@ impl Command for Finalize {
 
         let (common, list, our) = Self::reduce_configs(public_configs, &secret_config);
 
-        let validators_count = common.general_config
+        let validators_count = common
+            .general_config
             .get("validators_count")
             .expect("validators_count is not found in common config.")
             .as_integer()
             .unwrap() as usize;
-
-        println!("validators count {}, list.len {}", validators_count, list.len());
 
         if validators_count != list.len() {
             panic!("Number of validators configs does not match number of validator keys.");

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -580,12 +580,14 @@ impl Command for Finalize {
         let validators_count = common
             .general_config
             .get("validators_count")
-            .expect("validators_count is not found in common config.")
+            .expect("validators_count not found in common config.")
             .as_integer()
             .unwrap() as usize;
 
         if validators_count != list.len() {
-            panic!("Number of validators configs does not match number of validator keys.");
+            panic!(
+                "The number of validators configs does not match the number of validators keys."
+            );
         }
 
         context.set(keys::AUDITOR_MODE, our.is_none());

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -183,6 +183,7 @@ pub struct Context {
 impl Context {
     fn new_from_args(args: &[Argument], matches: &clap::ArgMatches) -> Context {
         let mut context = Context::default();
+
         for arg in args {
             // processing multiple value arguments make code ugly =(
             match arg.argument_type {

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -183,7 +183,6 @@ pub struct Context {
 impl Context {
     fn new_from_args(args: &[Argument], matches: &clap::ArgMatches) -> Context {
         let mut context = Context::default();
-
         for arg in args {
             // processing multiple value arguments make code ugly =(
             match arg.argument_type {

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -65,7 +65,7 @@ pub struct CommonConfigTemplate {
     /// Services configuration.
     #[serde(default)]
     pub services_config: AbstractConfig,
-    /// General configuration
+    /// General configuration.
     pub general_config: AbstractConfig,
 }
 

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -65,6 +65,8 @@ pub struct CommonConfigTemplate {
     /// Services configuration.
     #[serde(default)]
     pub services_config: AbstractConfig,
+    /// General configuration
+    pub general_config: AbstractConfig,
 }
 
 /// `NodePrivateConfig` collects all public and secret keys.

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -111,7 +111,7 @@ fn generate_config(folder: &str, i: usize) {
     ]));
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop, unused_must_use))]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
 
     let mut variables = vec![
@@ -122,7 +122,7 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
         "-p".to_owned(),
     ];
 
-    fs::create_dir_all(full_tmp_name("", folder));
+    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create temp folder");
 
     for n in 0..count {
         override_validators_count(PUB_CONFIG[n], count, folder);
@@ -131,12 +131,13 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
     assert!(!default_run_with_matches(variables));
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(unused_must_use))]
 fn override_validators_count(config: &str, n: usize, folder: &str) {
     let res = {
         let mut contents = String::new();
-        let mut f = File::open(full_testdata_name(config)).unwrap();
-        f.read_to_string(&mut contents);
+        let mut file = File::open(full_testdata_name(config)).unwrap();
+        file.read_to_string(&mut contents).expect(
+            "Read from config file failed",
+        );
 
         let mut value = contents.as_str().parse::<Value>().unwrap();
         {
@@ -156,7 +157,8 @@ fn override_validators_count(config: &str, n: usize, folder: &str) {
 
     File::create(full_tmp_name(config, folder))
         .unwrap()
-        .write_all(res.as_bytes());
+        .write_all(res.as_bytes())
+        .expect("Create temp config file is failed");
 }
 
 fn run_node(config: &str, folder: &str) {

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -111,7 +111,7 @@ fn generate_config(folder: &str, i: usize) {
     ]));
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop, unused_must_use))]
 fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
 
     let mut variables = vec![
@@ -131,10 +131,11 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
     assert!(!default_run_with_matches(variables));
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(unused_must_use))]
 fn override_validators_count(config: &str, n: usize, folder: &str) {
     let res = {
         let mut contents = String::new();
-        let mut f = File::open(full_testdata_name(&config)).unwrap();
+        let mut f = File::open(full_testdata_name(config)).unwrap();
         f.read_to_string(&mut contents);
 
         let mut value = contents.as_str().parse::<Value>().unwrap();
@@ -153,7 +154,9 @@ fn override_validators_count(config: &str, n: usize, folder: &str) {
         toml::to_string(&value).unwrap()
     };
 
-    let res = File::create(full_tmp_name(&config, folder)).unwrap().write_all(res.as_bytes());
+    File::create(full_tmp_name(config, folder))
+        .unwrap()
+        .write_all(res.as_bytes());
 }
 
 fn run_node(config: &str, folder: &str) {
@@ -235,7 +238,7 @@ fn test_generate_full_config_run() {
         }
     });
 
-//    fs::remove_dir_all(full_tmp_folder(command)).unwrap();
+    fs::remove_dir_all(full_tmp_folder(command)).unwrap();
 
     if let Err(err) = result {
         panic::resume_unwind(err);

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -122,7 +122,7 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
         "-p".to_owned(),
     ];
 
-    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create tmp folder");
+    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create temp folder");
 
     for n in 0..count {
         override_validators_count(PUB_CONFIG[n], count, folder);

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -122,7 +122,7 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
         "-p".to_owned(),
     ];
 
-    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create temp folder");
+    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create tmp folder");
 
     for n in 0..count {
         override_validators_count(PUB_CONFIG[n], count, folder);

--- a/exonum/tests/testdata/config/config0_pub.toml
+++ b/exonum/tests/testdata/config/config0_pub.toml
@@ -6,8 +6,11 @@ status_timeout = 5000
 txs_block_limit = 1000
 
 [common.consensus_config.timeout_adjuster]
-type = "Constant"
 timeout = 500
+type = "Constant"
+
+[common.general_config]
+validators_count = 1
 
 [common.services_config]
 

--- a/exonum/tests/testdata/config/config1_pub.toml
+++ b/exonum/tests/testdata/config/config1_pub.toml
@@ -6,8 +6,11 @@ status_timeout = 5000
 txs_block_limit = 1000
 
 [common.consensus_config.timeout_adjuster]
-type = "Constant"
 timeout = 500
+type = "Constant"
+
+[common.general_config]
+validators_count = 1
 
 [common.services_config]
 

--- a/exonum/tests/testdata/config/config2_pub.toml
+++ b/exonum/tests/testdata/config/config2_pub.toml
@@ -6,8 +6,11 @@ status_timeout = 5000
 txs_block_limit = 1000
 
 [common.consensus_config.timeout_adjuster]
-type = "Constant"
 timeout = 500
+type = "Constant"
+
+[common.general_config]
+validators_count = 1
 
 [common.services_config]
 

--- a/exonum/tests/testdata/config/config3_pub.toml
+++ b/exonum/tests/testdata/config/config3_pub.toml
@@ -6,8 +6,11 @@ status_timeout = 5000
 txs_block_limit = 1000
 
 [common.consensus_config.timeout_adjuster]
-type = "Constant"
 timeout = 500
+type = "Constant"
+
+[common.general_config]
+validators_count = 1
 
 [common.services_config]
 

--- a/exonum/tests/testdata/config/template.toml
+++ b/exonum/tests/testdata/config/template.toml
@@ -10,3 +10,6 @@ type = "Constant"
 timeout = 500
 
 [services_config]
+
+[general_config]
+validators_count = 1


### PR DESCRIPTION
Introduce `--validators-count` parameter to config template.

**Use case**: 
```
cryptocurrency generate-template common.toml --validators-count 4
...
cryptocurrency finalize ... --public-configs pub_1.toml pub_2.toml pub_3.toml pub_4.toml
```

If count of provided `pub_*.toml` files differ from `validators-count` panic will be raised.

```
error: Number of validators configs does not match number of validator keys.
```

**For discussion:**
* Method `override_validators_count()` is  probably is not optimal.