### PR TITLE
Fix cargo-deadlinks installation [ECR-1083]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
   - env: FEATURE=lints
     install:
     - cargo-audit -V || cargo install cargo-audit --force
-    - cargo-deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
+    - cargo deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
     - rustfmt -V | grep $RUSTFMT_VERS || cargo install rustfmt --vers $RUSTFMT_VERS --force
     - nvm install 8 && nvm use 8
     - npm install cspell

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ jobs:
     - touch target/std/primitive.usize.html
     - touch target/std/string/struct.String.html
     - touch target/doc/exonum/encoding/serialize/trait.Serialize.html
+    - touch target/doc/exonum/encoding/serialize/reexport/serde/index.html
     - touch target/doc/exonum_configuration/enum.Option.html
     - mkdir -p target/doc/exonum/encoding/serialize/reexport/serde/ts_seconds
     - touch target/doc/exonum/encoding/serialize/reexport/serde/ts_seconds/index.html


### PR DESCRIPTION
`cargo-deadlinks` doesn't support `-V` version, but `cargo deadlinks` does.