### PR TITLE
 Implement `Display` for public sodium types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `CryptoHash`, `Field`, `StorageKey` and `StorageValue` traits are implemented for
   the `uuid::Uuid`. (#588)
 
+- `Display` trait is implemented for types from the `crypto` module. (#590)
+
 #### exonum-testkit
 
 - `create_block*` methods of the `TestKit` now return the information about

--- a/exonum/src/crypto.rs
+++ b/exonum/src/crypto.rs
@@ -37,7 +37,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use encoding::serialize::FromHex;
+use encoding::serialize::{FromHex, FromHexError, ToHex, encode_hex};
 use helpers::Round;
 
 // spell-checker:disable
@@ -273,7 +273,7 @@ macro_rules! implement_public_sodium_wrapper {
         /// Returns the hex representation of the binary data.
         /// Lower case letters are used (e.g. f9b4ca).
         pub fn to_hex(&self) -> String {
-            $crate::encoding::serialize::encode_hex(self)
+            encode_hex(self)
         }
     }
 
@@ -284,7 +284,7 @@ macro_rules! implement_public_sodium_wrapper {
     }
 
     impl FromStr for $name {
-        type Err = ::encoding::serialize::FromHexError;
+        type Err = FromHexError;
         fn from_str(s: &str) -> Result<Self, Self::Err> {
             $name::from_hex(s)
         }
@@ -336,7 +336,7 @@ macro_rules! implement_private_sodium_wrapper {
         /// Returns the hex representation of the binary data.
         /// Lower case letters are used (e.g. f9b4ca).
         pub fn to_hex(&self) -> String {
-            $crate::encoding::serialize::encode_hex(&self[..])
+            encode_hex(&self[..])
         }
     }
 
@@ -351,7 +351,7 @@ macro_rules! implement_private_sodium_wrapper {
         }
     }
 
-    impl $crate::encoding::serialize::ToHex for $name {
+    impl ToHex for $name {
         fn write_hex<W: ::std::fmt::Write>(&self, w: &mut W) -> ::std::fmt::Result {
             (self.0).0.as_ref().write_hex(w)
         }
@@ -439,15 +439,15 @@ implement_private_sodium_wrapper! {
 
 macro_rules! implement_serde {
 ($name:ident) => (
-    impl $crate::encoding::serialize::FromHex for $name {
-        type Error = $crate::encoding::serialize::FromHexError;
+    impl FromHex for $name {
+        type Error = FromHexError;
 
         fn from_hex<T: AsRef<[u8]>>(v: T) -> Result<Self, Self::Error> {
             let bytes = Vec::<u8>::from_hex(v)?;
             if let Some(self_value) = Self::from_slice(bytes.as_ref()) {
                 Ok(self_value)
             } else {
-                Err($crate::encoding::serialize::FromHexError::InvalidStringLength)
+                Err(FromHexError::InvalidStringLength)
             }
         }
     }
@@ -457,7 +457,7 @@ macro_rules! implement_serde {
         fn serialize<S>(&self, ser:S) -> Result<S::Ok, S::Error>
         where S: Serializer
         {
-            let hex_string = $crate::encoding::serialize::encode_hex(&self[..]);
+            let hex_string = encode_hex(&self[..]);
             ser.serialize_str(&hex_string)
         }
     }

--- a/exonum/src/crypto.rs
+++ b/exonum/src/crypto.rs
@@ -34,6 +34,7 @@ use uuid::Uuid;
 use std::default::Default;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 use std::fmt;
+use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use encoding::serialize::FromHex;
@@ -282,7 +283,7 @@ macro_rules! implement_public_sodium_wrapper {
         }
     }
 
-    impl ::std::str::FromStr for $name {
+    impl FromStr for $name {
         type Err = ::encoding::serialize::FromHexError;
         fn from_str(s: &str) -> Result<Self, Self::Err> {
             $name::from_hex(s)

--- a/exonum/src/crypto.rs
+++ b/exonum/src/crypto.rs
@@ -289,12 +289,6 @@ macro_rules! implement_public_sodium_wrapper {
         }
     }
 
-    impl ToString for $name {
-        fn to_string(&self) -> String {
-            self.to_hex()
-        }
-    }
-
     impl fmt::Debug for $name {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, stringify!($name))?;
@@ -303,6 +297,12 @@ macro_rules! implement_public_sodium_wrapper {
                 write!(f, "{:02X}", i)?
             }
             write!(f, ")")
+        }
+    }
+
+    impl fmt::Display for $name {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str(&self.to_hex())
         }
     }
     )


### PR DESCRIPTION
According to [documentation](https://doc.rust-lang.org/std/string/trait.ToString.html) 
> ToString shouldn't be implemented directly: Display should be implemented instead, and you get the ToString implementation for free.

Also I refactored types usage according to @vitvakatu [comment](https://github.com/exonum/exonum/pull/318#issuecomment-377505152) (not sure if I made it as it was supposed to).

There are explicit [usages](https://github.com/exonum/exonum/blob/master/testkit/tests/counter/main.rs#L567) of `Hash::to_string` with `format!`. Now it can be removed but I am not sure if we should make it.

