### PR TITLE
Modify method with_description in ExecutionError structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### Exonum core
 
-- `ExecutionError::with_description` method now takes `Into<String>` instead of `String` which allows to pass `&str` directly. (#592)
+- `ExecutionError::with_description` method now takes `Into<String>`
+  instead of `String` which allows to pass `&str` directly. (#592)
 
 - POST-requests are now handled with `bodyparser` crate,
   so all the parameters must be passed in the body. (#529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### Exonum core
 
-- ExecutionError::with_description method now takes Into<String> instead of 
-  String which allows to pass &amp;str directly. (#592)
+- `ExecutionError::with_description` method now takes `Into<String>` instead of `String` which allows to pass `&str` directly. (#592)
 
 - POST-requests are now handled with `bodyparser` crate,
   so all the parameters must be passed in the body. (#529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### Exonum core
 
+- ExecutionError::with_description method now takes Into<String> instead of 
+  String which allows to pass &amp;str directly. (#592)
+
 - POST-requests are now handled with `bodyparser` crate,
   so all the parameters must be passed in the body. (#529)
 

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -167,7 +167,7 @@ impl ExecutionError {
     }
 
     /// Constructs a new `ExecutionError` instance with the given error code and description.
-    pub fn with_description<T : Into<String>>(code: u8, description: T) -> Self {
+    pub fn with_description<T: Into<String>>(code: u8, description: T) -> Self {
         Self {
             code,
             description: Some(description.into()),
@@ -663,7 +663,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn transaction_error_new() {
         let values = [
@@ -741,10 +740,7 @@ mod tests {
     fn error_discards_transaction_changes() {
         let statuses = [
             Err(ExecutionError::new(0)),
-            Err(ExecutionError::with_description(
-                0,
-                "Strange error",
-            )),
+            Err(ExecutionError::with_description(0, "Strange error")),
             Err(ExecutionError::new(255)),
             Err(ExecutionError::with_description(
                 255,

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -19,6 +19,7 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt;
 use std::u8;
+use std::convert::Into;
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -166,10 +167,10 @@ impl ExecutionError {
     }
 
     /// Constructs a new `ExecutionError` instance with the given error code and description.
-    pub fn with_description(code: u8, description: String) -> Self {
+    pub fn with_description<T : Into<String>>(code: u8, description: T) -> Self {
         Self {
             code,
-            description: Some(description),
+            description: Some(description.into()),
         }
     }
 }
@@ -656,11 +657,12 @@ mod tests {
         let values = [(0, ""), (1, "test"), (100, "error"), (255, "hello")];
 
         for value in &values {
-            let error = ExecutionError::with_description(value.0, value.1.to_owned());
+            let error = ExecutionError::with_description(value.0, value.1);
             assert_eq!(value.0, error.code);
             assert_eq!(value.1, error.description.unwrap());
         }
     }
+
 
     #[test]
     fn transaction_error_new() {
@@ -685,8 +687,8 @@ mod tests {
         let execution_errors = [
             ExecutionError::new(0),
             ExecutionError::new(255),
-            ExecutionError::with_description(1, "".to_owned()),
-            ExecutionError::with_description(1, "Terrible failure".to_owned()),
+            ExecutionError::with_description(1, ""),
+            ExecutionError::with_description(1, "Terrible failure"),
         ];
 
         for execution_error in &execution_errors {
@@ -741,12 +743,12 @@ mod tests {
             Err(ExecutionError::new(0)),
             Err(ExecutionError::with_description(
                 0,
-                "Strange error".to_owned(),
+                "Strange error",
             )),
             Err(ExecutionError::new(255)),
             Err(ExecutionError::with_description(
                 255,
-                "Error description...".to_owned(),
+                "Error description...",
             )),
             Ok(()),
         ];


### PR DESCRIPTION
Changed signature of method with_description in ExecutionError structure to
`pub fn with_description<T : Into<String>>(code: u8, description: T) -> Self`
Now we can pass &str arguments to this function.