### PR TITLE
Make `transactions!` macro support empty body. [ECR-1133]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `Display` trait is implemented for types from the `crypto` module. (#590)
 
-- `transactions!` macro now allows empty body.
+- `transactions!` macro now allows empty body. (#593)
 
 #### exonum-testkit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `Display` trait is implemented for types from the `crypto` module. (#590)
 
+- `transactions!` macro now allows empty body.
+
 #### exonum-testkit
 
 - `create_block*` methods of the `TestKit` now return the information about

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -426,6 +426,8 @@ pub trait TransactionSet
 /// ```
 #[macro_export]
 macro_rules! transactions {
+    // Empty variant.
+    {} => {};
     // Variant with the private enum.
     {
         $(#[$tx_set_attr:meta])*
@@ -639,6 +641,9 @@ mod tests {
     lazy_static! {
         static ref EXECUTION_STATUS: Mutex<ExecutionResult> = Mutex::new(Ok(()));
     }
+
+    // Testing macro with empty body.
+    transactions!{}
 
     #[test]
     fn execution_error_new() {


### PR DESCRIPTION
The following `transactions!` usage is now possible:
```rust
transactions!{}
```
