### PR TITLE
Fix test_network_reconnect on windows. [ECR-446]

### DIFF
--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -311,6 +311,7 @@ fn test_network_reconnect() {
     t1.send_to(second, msg.clone());
     assert_eq!(t2.wait_for_message(), msg);
 
+    t1.disconnect_with(second);
     drop(t2);
     assert_eq!(t1.wait_for_disconnect(), second);
 


### PR DESCRIPTION
**Problem:**

`test_network_reconnect` fails on Windows.

When we drop TestHandler, the outgoing `TcpStream` in `ConnectionsPool::connect_to_peer()` is not dropped and therefore we never receive `NetworkEvent::PeerDisconnected`. Problem with 
`mio::sys::windows::Selector`, issue is described here: https://github.com/carllerche/mio/issues/776

```
drop(t2);
assert_eq!(t1.wait_for_disconnect(), second);
```

Possible solutions:
* disconnect first handler from second and then drop.
* disable test on windows.
* patch mio crate.

I decided to disconnect from the second handler.