### PR TITLE
Deserialization for explorer types

### DIFF
--- a/exonum/examples/explorer.rs
+++ b/exonum/examples/explorer.rs
@@ -115,7 +115,7 @@ fn main() {
     assert_eq!(tx.location().position_in_block(), 0);
 
     // It is possible to access transaction content
-    let content: &Transaction = tx.content();
+    let content: &Transaction = tx.content().as_ref();
     println!("{:?}", content);
     // ...and transaction status as well
     let status: Result<(), &TransactionError> = tx.status();

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -236,12 +236,12 @@ impl TransactionError {
     }
 
     /// Creates a new `TransactionError` instance with the specified error code and description.
-    fn code(code: u8, description: Option<String>) -> Self {
+    pub(crate) fn code(code: u8, description: Option<String>) -> Self {
         Self::new(TransactionErrorType::Code(code), description)
     }
 
     /// Creates a new `TransactionError` representing panic with the given description.
-    fn panic(description: Option<String>) -> Self {
+    pub(crate) fn panic(description: Option<String>) -> Self {
         Self::new(TransactionErrorType::Panic, description)
     }
 


### PR DESCRIPTION
A more complete version of #597, allowing to deserialize transaction-related explorer types, which are returned by the explorer API.