### PR TITLE
Implement fmt::Debug for RawTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### Exonum core
 
+- `RawTransaction` now has own implementation of `fmt::Debug` trait instead
+  of `#[derive(Debug)]`. The template of `RawTransaction`’s debug message is
+  `Transaction { version: #, service_id: #, message_type: #, length: #, hash: Hash(###) }`
+
 - `ExecutionError::with_description` method now takes `Into<String>`
   instead of `String` which allows to pass `&str` directly. (#592)
 

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -40,6 +40,18 @@ mod tests;
 /// Raw transaction type.
 pub type RawTransaction = RawMessage;
 
+impl fmt::Debug for RawTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Transaction")
+            .field("version", &self.version())
+            .field("service_id", &self.service_id())
+            .field("message_type", &self.message_type())
+            .field("length", &self.len())
+            .field("hash", &self.hash())
+            .finish()
+    }
+}
+
 /// Any possible message.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Any {

--- a/exonum/src/messages/raw.rs
+++ b/exonum/src/messages/raw.rs
@@ -30,7 +30,7 @@ pub const HEADER_LENGTH: usize = 10;
 pub const PROTOCOL_MAJOR_VERSION: u8 = 0;
 
 /// Thread-safe reference-counting pointer to the `MessageBuffer`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct RawMessage(sync::Arc<MessageBuffer>);
 
 impl RawMessage {

--- a/exonum/src/messages/tests.rs
+++ b/exonum/src/messages/tests.rs
@@ -14,7 +14,7 @@
 
 use crypto::{gen_keypair, PublicKey, SecretKey, Signature};
 use messages::raw::MessageBuffer;
-use messages::{Message, RawMessage};
+use messages::{Message, RawMessage, RawTransaction};
 use encoding::serialize::FromHex;
 
 messages! {
@@ -24,6 +24,23 @@ messages! {
         public_key: &PublicKey,
         msg: &str,
     }
+}
+
+#[test]
+fn test_debug_transaction() {
+    let (p_key, s_key) = gen_keypair();
+    let tx = TxSimple::new(&p_key, "Hello, World!", &s_key);
+    let vec = tx.as_ref().as_ref().to_vec();
+    let transaction: RawTransaction = RawTransaction::from_vec(vec);
+
+    let debug = format!("{:?}", transaction);
+
+    assert!(debug.contains("Transaction"));
+    assert!(debug.contains("version:"));
+    assert!(debug.contains("service_id:"));
+    assert!(debug.contains("message_type:"));
+    assert!(debug.contains("length:"));
+    assert!(debug.contains("hash:"));
 }
 
 #[test]


### PR DESCRIPTION
`RawTransaction` now has own implementation of `fmt::Debug` trait instead
  of `#[derive(Debug)]`. The template of `RawTransaction`’s debug message is
  `Transaction { version: #, service_id: #, message_type: #, length: #, hash: Hash(###) }`