### PR TITLE
IPv6 Support [ECR-158]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### New features
+
+- IPv6 addressing is now supported. (#615)
+
 ### Bug fixes
 
 #### exonum-cryptocurrency-advanced
@@ -12,8 +16,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Frontend has been updated to reflect latest backend changes. (#602 #611)
 
 ### Internal improvements
-
-- IPv6 addressing is now supported. (#615)
 
 #### exonum-time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Internal improvements
 
+- IPv6 addressing is now supported. (#615)
+
 #### exonum-time
 
 - Split service components to separate modules. (#604)
@@ -170,8 +172,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Display` trait is implemented for types from the `crypto` module. (#590)
 
 - `transactions!` macro now allows empty body. (#593)
-
-- IPv6 addressing is now supported by exonum. (#615)
 
 #### exonum-testkit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `transactions!` macro now allows empty body. (#593)
 
+- IPv6 addressing is now supported by exonum. (#615)
+
 #### exonum-testkit
 
 - `create_block*` methods of the `TestKit` now return the information about

--- a/exonum/src/encoding/error.rs
+++ b/exonum/src/encoding/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
         /// Position in buffer where error appears.
         position: Offset,
         /// Header value.
-        value: u8
+        value: u8,
     },
     /// Segment reference is incorrect
     IncorrectSegmentReference {

--- a/exonum/src/encoding/error.rs
+++ b/exonum/src/encoding/error.rs
@@ -51,6 +51,13 @@ pub enum Error {
         /// Header value.
         value: u8,
     },
+    /// SocketAddr padding for IPv4 addresses must be 12 bytes of 0s.
+    IncorrectSocketAddrPadding {
+        /// Position in buffer where error appears.
+        position: Offset,
+        /// Padding value.
+        value: [u8; 12],
+    },
     /// Segment reference is incorrect
     IncorrectSegmentReference {
         /// position in buffer where error appears.
@@ -138,6 +145,7 @@ impl StdError for Error {
             Error::IncorrectBoolean { .. } => "Incorrect boolean value",
             Error::UnsupportedFloat { .. } => "Unsupported float value",
             Error::IncorrectSocketAddrHeader { .. } => "Incorrect SocketAddr header value",
+            Error::IncorrectSocketAddrPadding { .. } => "Incorrect SocketAddr padding",
             Error::IncorrectSegmentReference { .. } => "Incorrect segment reference",
             Error::IncorrectSegmentSize { .. } => "Incorrect segment size",
             Error::UnexpectedlyShortRawMessage { .. } => "Unexpectedly short RawMessage",

--- a/exonum/src/encoding/error.rs
+++ b/exonum/src/encoding/error.rs
@@ -44,6 +44,13 @@ pub enum Error {
         /// Value represented as `f64`.
         value: f64,
     },
+    /// SocketAddr header is neither 0 nor 1.
+    IncorrectSocketAddrHeader {
+        /// Position in buffer where error appears.
+        position: Offset,
+        /// Header value.
+        value: u8
+    },
     /// Segment reference is incorrect
     IncorrectSegmentReference {
         /// position in buffer where error appears.
@@ -130,6 +137,7 @@ impl StdError for Error {
             Error::UnexpectedlyShortPayload { .. } => "Unexpectedly short payload",
             Error::IncorrectBoolean { .. } => "Incorrect boolean value",
             Error::UnsupportedFloat { .. } => "Unsupported float value",
+            Error::IncorrectSocketAddrHeader { .. } => "Incorrect SocketAddr header value",
             Error::IncorrectSegmentReference { .. } => "Incorrect segment reference",
             Error::IncorrectSegmentSize { .. } => "Incorrect segment size",
             Error::UnexpectedlyShortRawMessage { .. } => "Unexpectedly short RawMessage",

--- a/exonum/src/encoding/fields.rs
+++ b/exonum/src/encoding/fields.rs
@@ -382,8 +382,9 @@ impl<'a> Field<'a> for SocketAddr {
             });
         }
 
-        if !(buffer[to_unchecked - SIZE_DIFF - PORT_SIZE..to_unchecked - PORT_SIZE]
-            == [0u8; SIZE_DIFF])
+        if buffer[from_unchecked] == IPV4_HEADER
+            && !(buffer[to_unchecked - SIZE_DIFF - PORT_SIZE..to_unchecked - PORT_SIZE]
+                == [0u8; SIZE_DIFF])
         {
             let mut value: [u8; SIZE_DIFF] = unsafe { mem::uninitialized() };
             value.copy_from_slice(&buffer[to_unchecked - SIZE_DIFF..to_unchecked]);

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -253,11 +253,10 @@ fn test_segments_of_status_messages() {
     assert_write_check_read(dat, 8);
 }
 
-#[test]
-fn test_connect() {
+fn test_connect(addr: &str) {
     use std::str::FromStr;
 
-    let socket_address = SocketAddr::from_str("18.34.3.4:7777").unwrap();
+    let socket_address = SocketAddr::from_str(addr).unwrap();
     let time = Utc::now();
     let (public_key, secret_key) = gen_keypair();
 
@@ -274,6 +273,16 @@ fn test_connect() {
     assert_eq!(connect.addr(), socket_address);
     assert_eq!(connect.time(), time);
     assert!(connect.verify_signature(&public_key));
+}
+
+#[test]
+fn test_connect_ipv4() {
+    test_connect("18.34.3.4:7777");
+}
+
+#[test]
+fn test_connect_ipv6() {
+    test_connect("[::1]:7777");
 }
 
 #[test]

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -336,32 +336,20 @@ impl GenerateNodeConfig {
 
     fn addr(context: &Context) -> (SocketAddr, SocketAddr) {
         let addr_str = &context.arg::<String>(PEER_ADDRESS).unwrap_or_default();
-
-        let maybe_addr = addr_str.parse::<SocketAddr>();
         let error_msg = &format!("Expected an ip address in {}", PEER_ADDRESS);
 
-        let listen_ip: (IpAddr, IpAddr) = ("0.0.0.0".parse().unwrap(), "::".parse().unwrap());
-
-        if maybe_addr.is_ok() {
-            let external_addr = maybe_addr.expect(error_msg);
-            let listen_ip = match external_addr {
-                SocketAddr::V4(_) => listen_ip.0,
-                SocketAddr::V6(_) => listen_ip.1,
-            };
-            let listen_addr = SocketAddr::new(listen_ip, external_addr.port());
-            (external_addr, listen_addr)
-        } else {
+        let external_addr = addr_str.parse::<SocketAddr>().unwrap_or_else(|_| {
             let ip = addr_str.parse::<IpAddr>().expect(error_msg);
-            let port = DEFAULT_EXONUM_LISTEN_PORT;
-            let listen_ip = match ip {
-                IpAddr::V4(_) => listen_ip.0,
-                IpAddr::V6(_) => listen_ip.1,
-            };
+            SocketAddr::new(ip, DEFAULT_EXONUM_LISTEN_PORT)
+        });
 
-            let external_addr = SocketAddr::new(ip, port);
-            let listen_addr = SocketAddr::new(listen_ip, external_addr.port());
-            (external_addr, listen_addr)
-        }
+        let listen_ip = match external_addr {
+            SocketAddr::V4(_) => "0.0.0.0".parse().unwrap(),
+            SocketAddr::V6(_) => "::".parse().unwrap(),
+        };
+        let listen_addr = SocketAddr::new(listen_ip, external_addr.port());
+
+        (external_addr, listen_addr)
     }
 }
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -21,7 +21,7 @@ use toml;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::net::{SocketAddr, IpAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::collections::{BTreeMap, HashMap};
 
 use blockchain::{GenesisConfig, config::ValidatorKeys};

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -232,13 +232,11 @@ fn test_generate_config(mode: IpMode) {
 }
 
 #[test]
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config_ipv4() {
     test_generate_config(IpMode::V4);
 }
 
 #[test]
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config_ipv6() {
     test_generate_config(IpMode::V6);
 }

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -212,7 +212,7 @@ fn test_generate_template() {
 
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config(mode: IpMode) {
-    // Important because tests run in parallel.
+    // Important because tests run in parallel, folder names should be different.
     let command = match mode {
         IpMode::V4 => "generate-config-ipv4",
         IpMode::V6 => "generate-config-ipv6",

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -104,7 +104,8 @@ fn generate_template(folder: &str) {
     ]));
 }
 
-fn generate_config(folder: &str, i: usize) {
+fn generate_config(folder: &str, i: usize, use_ipv6: bool) {
+    let ip = if use_ipv6 { "::1" } else { "127.0.0.1" };
     assert!(!default_run_with_matches(vec![
         "exonum-config-test",
         "generate-config",
@@ -112,7 +113,7 @@ fn generate_config(folder: &str, i: usize) {
         &full_tmp_name(PUB_CONFIG[i], folder),
         &full_tmp_name(SEC_CONFIG[i], folder),
         "-a",
-        "127.0.0.1",
+        ip,
     ]));
 }
 
@@ -200,14 +201,13 @@ fn test_generate_template() {
     }
 }
 
-#[test]
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
-fn test_generate_config() {
-    let command = "generate-config";
+fn test_generate_config(use_ipv6: bool) {
+    let command = if use_ipv6 { "generate-config-ipv6" } else { "generate-config-ipv4" };
 
     let result = panic::catch_unwind(|| {
         for i in 0..PUB_CONFIG.len() {
-            generate_config(command, i);
+            generate_config(command, i, use_ipv6);
         }
     });
 
@@ -216,6 +216,18 @@ fn test_generate_config() {
     if let Err(err) = result {
         panic::resume_unwind(err);
     }
+}
+
+#[test]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+fn test_generate_config_ipv4() {
+    test_generate_config(false);
+}
+
+#[test]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+fn test_generate_config_ipv6() {
+    test_generate_config(true);
 }
 
 #[test]

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -203,7 +203,11 @@ fn test_generate_template() {
 
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config(use_ipv6: bool) {
-    let command = if use_ipv6 { "generate-config-ipv6" } else { "generate-config-ipv4" };
+    let command = if use_ipv6 {
+        "generate-config-ipv6"
+    } else {
+        "generate-config-ipv4"
+    };
 
     let result = panic::catch_unwind(|| {
         for i in 0..PUB_CONFIG.len() {

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -126,7 +126,6 @@ fn generate_config(folder: &str, i: usize, mode: IpMode) {
     ]));
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
     let mut variables = vec![
         "exonum-config-test".to_owned(),
@@ -138,9 +137,9 @@ fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
 
     fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create temp folder");
 
-    for n in 0..count {
-        override_validators_count(PUB_CONFIG[n], count, folder);
-        variables.push(full_tmp_name(PUB_CONFIG[n], folder));
+    for &conf in PUB_CONFIG.iter().take(count) {
+        override_validators_count(conf, count, folder);
+        variables.push(full_tmp_name(conf, folder));
     }
     assert!(!default_run_with_matches(variables));
 }
@@ -210,7 +209,6 @@ fn test_generate_template() {
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config(mode: IpMode) {
     // Important because tests run in parallel, folder names should be different.
     let command = match mode {
@@ -242,7 +240,6 @@ fn test_generate_config_ipv6() {
 }
 
 #[test]
-#[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_full_config_run() {
     let command = "finalize";
     let result = panic::catch_unwind(|| {

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -104,8 +104,17 @@ fn generate_template(folder: &str) {
     ]));
 }
 
-fn generate_config(folder: &str, i: usize, use_ipv6: bool) {
-    let ip = if use_ipv6 { "::1" } else { "127.0.0.1" };
+#[derive(Debug, Clone, Copy)]
+enum IpMode {
+    V4,
+    V6,
+}
+
+fn generate_config(folder: &str, i: usize, mode: IpMode) {
+    let ip = match mode {
+        IpMode::V4 => "127.0.0.1",
+        IpMode::V6 => "::1",
+    };
     assert!(!default_run_with_matches(vec![
         "exonum-config-test",
         "generate-config",
@@ -202,16 +211,16 @@ fn test_generate_template() {
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
-fn test_generate_config(use_ipv6: bool) {
-    let command = if use_ipv6 {
-        "generate-config-ipv6"
-    } else {
-        "generate-config-ipv4"
+fn test_generate_config(mode: IpMode) {
+    // Important because tests run in parallel.
+    let command = match mode {
+        IpMode::V4 => "generate-config-ipv4",
+        IpMode::V6 => "generate-config-ipv6",
     };
 
     let result = panic::catch_unwind(|| {
         for i in 0..PUB_CONFIG.len() {
-            generate_config(command, i, use_ipv6);
+            generate_config(command, i, mode);
         }
     });
 
@@ -225,13 +234,13 @@ fn test_generate_config(use_ipv6: bool) {
 #[test]
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config_ipv4() {
-    test_generate_config(false);
+    test_generate_config(IpMode::V4);
 }
 
 #[test]
 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
 fn test_generate_config_ipv6() {
-    test_generate_config(true);
+    test_generate_config(IpMode::V6);
 }
 
 #[test]


### PR DESCRIPTION
To support IPv6 in exonum few things needed to be changed:
1. `SocketAddr` serialization;
2. IP address parsing in fabric;
3. IP address parsing in TOML (which happened to be needless since it's done with `serde` that already supports IPv6 in `SokcetAddr`).

While making this PR I found that we parse same data (IP addresses) differently in TOML (uses serde) and in command-line arguments (uses std), which seems odd.

## Update 2 (after collective review)
Changes introduced after the review:
1. `const` moved to the top;
2. `SIZE_DIFF` is now a standalone constant;
3. `IpMode` enum instead of `bool` in tests.

## Update
### Discussion topic
I didn't write any tests for IPv6 parsing in TOML. It is parsed by `serde` crate, so it is its responsibility to cover that and the functionality is `std::net::SocketAddr`'s responsibility, but I still have doubts about that.
