### PR TITLE
Default `check` implementation for `Field` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
-- Default implementation of `check` method was added to `Field` trait (#639)
+- Default implementation of `check` method was added to `Field` trait to
+  reduce boilerplate. (#639)
 
 #### exonum-time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Internal improvements
 
+#### exonum
+
+- Default implementation of `check` method was added to `Field` trait (#639)
+
 #### exonum-time
 
 - Split service components to separate modules. (#604)

--- a/exonum/src/encoding/fields.rs
+++ b/exonum/src/encoding/fields.rs
@@ -306,7 +306,15 @@ impl<'a> Field<'a> for SocketAddr {
             &mut buffer[to as usize - PORT_SIZE..to as usize],
             self.port(),
         );
-        _: &'a [u8],
+    }
+
+    fn check(
+        buffer: &'a [u8],
+        from: CheckedOffset,
+        to: CheckedOffset,
+        latest_segment: CheckedOffset,
+    ) -> Result {
+        debug_assert_eq!((to - from)?.unchecked_offset(), Self::field_size());
 
         let from_unchecked = from.unchecked_offset() as usize;
         let to_unchecked = to.unchecked_offset() as usize;
@@ -329,6 +337,7 @@ impl<'a> Field<'a> for SocketAddr {
                 value,
             });
         }
+        Ok(latest_segment)
     }
 }
 


### PR DESCRIPTION
`fields.rs` had a lot of copy-pasted code, so I decided to move it into default implementation.