### PR TITLE
Reject processed transactions [ECR-1251]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Bug fixes
 
+#### exonum
+
+- Already processed transations are rejected now in `NodeHandler::handle_incoming_tx`.
+
 #### exonum-cryptocurrency-advanced
 
 - Frontend has been updated to reflect latest backend changes. (#602 #611)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
-- Already processed transactions are rejected now in `NodeHandler::handle_incoming_tx`.
+- Already processed transactions are rejected now in 
+  `NodeHandler::handle_incoming_tx` method. (#642)
 
 #### exonum-cryptocurrency-advanced
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
-- Already processed transations are rejected now in `NodeHandler::handle_incoming_tx`.
+- Already processed transactions are rejected now in `NodeHandler::handle_incoming_tx`.
 
 #### exonum-cryptocurrency-advanced
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
-- Already processed transactions are rejected now in 
+- Already processed transactions are rejected now in
   `NodeHandler::handle_incoming_tx` method. (#642)
 
 #### exonum-cryptocurrency-advanced

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -617,6 +617,16 @@ impl NodeHandler {
         let mut fork = self.blockchain.fork();
         {
             let mut schema = Schema::new(&mut fork);
+            if schema.transactions().contains(&hash)
+                && !schema.transactions_pool().contains(&hash)
+            {
+                error!(
+                    "Received already committed transaction, hash={:?}",
+                    hash
+                );
+                return;
+            }
+
             schema.add_transaction_into_pool(msg.raw().clone());
         }
         self.blockchain

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -532,14 +532,14 @@ impl NodeHandler {
         }
     }
 
-    /// Checks if transaction is new and adds it into pool.
+    /// Checks if the transaction is new and adds it to the pool.
     fn handle_tx_inner(&mut self, msg: RawTransaction) -> Result<(), String> {
         let hash = msg.hash();
 
         profiler_span!("Make sure that it is new transaction", {
             let snapshot = self.blockchain.snapshot();
             if Schema::new(&snapshot).transactions().contains(&hash) {
-                let err = format!("Received already committed transaction, hash {:?}", hash);
+                let err = format!("Received already processed transaction, hash {:?}", hash);
                 return Err(err);
             }
         });
@@ -581,9 +581,10 @@ impl NodeHandler {
             }
         });
 
+        // We don't care about result, because situation when transaction received twice
+        // is normal for internal messages (transaction may be received from 2+ nodes).
         match self.handle_tx_inner(msg) {
-            Ok(_) => return,
-            Err(e) => error!("{}", e),
+            _ => return,
         }
     }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -617,13 +617,9 @@ impl NodeHandler {
         let mut fork = self.blockchain.fork();
         {
             let mut schema = Schema::new(&mut fork);
-            if schema.transactions().contains(&hash)
-                && !schema.transactions_pool().contains(&hash)
+            if schema.transactions().contains(&hash) && !schema.transactions_pool().contains(&hash)
             {
-                error!(
-                    "Received already committed transaction, hash={:?}",
-                    hash
-                );
+                error!("Received already committed transaction, hash={:?}", hash);
                 return;
             }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -539,7 +539,7 @@ impl NodeHandler {
         profiler_span!("Make sure that it is new transaction", {
             let snapshot = self.blockchain.snapshot();
             if Schema::new(&snapshot).transactions().contains(&hash) {
-                let err = format!("Received already commited transaction, hash {:?}", hash);
+                let err = format!("Received already committed transaction, hash {:?}", hash);
                 return Err(err);
             }
         });

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -532,35 +532,18 @@ impl NodeHandler {
         }
     }
 
-    /// Handles raw transaction. Transaction is ignored if it is already known, otherwise it is
-    /// added to the transactions pool.
-    #[cfg_attr(feature = "flame_profile", flame)]
-    pub fn handle_tx(&mut self, msg: RawTransaction) {
-        //trace!("Handle transaction");
+    /// Checks if transaction is new and adds it into pool.
+    fn handle_tx_inner(&mut self, msg: RawTransaction) -> Result<(), String> {
         let hash = msg.hash();
-        let tx = {
-            let service_id = msg.service_id();
-            match self.blockchain.tx_from_raw(msg.clone()) {
-                Ok(tx) => tx,
-                Err(e) => {
-                    error!("{}, service_id={}", e.description(), service_id);
-                    return;
-                }
-            }
-        };
 
         profiler_span!("Make sure that it is new transaction", {
             let snapshot = self.blockchain.snapshot();
             if Schema::new(&snapshot).transactions().contains(&hash) {
-                return;
+                let err = format!("Received already commited transaction, hash {:?}", hash);
+                return Err(err);
             }
         });
 
-        profiler_span!("tx.verify()", {
-            if !tx.verify() {
-                return;
-            }
-        });
         let mut fork = self.blockchain.fork();
         {
             let mut schema = Schema::new(&mut fork);
@@ -575,6 +558,35 @@ impl NodeHandler {
         for (hash, round) in full_proposes {
             self.remove_request(&RequestData::Transactions(hash));
             self.has_full_propose(hash, round);
+        }
+        Ok(())
+    }
+
+    /// Handles raw transaction. Transaction is ignored if it is already known, otherwise it is
+    /// added to the transactions pool.
+    #[cfg_attr(feature = "flame_profile", flame)]
+    pub fn handle_tx(&mut self, msg: RawTransaction) {
+        //trace!("Handle transaction");
+        let tx = {
+            match self.blockchain.tx_from_raw(msg.clone()) {
+                Ok(tx) => tx,
+                Err(e) => {
+                    let service_id = msg.service_id();
+                    error!("{}, service_id={}", e.description(), service_id);
+                    return;
+                }
+            }
+        };
+
+        profiler_span!("tx.verify()", {
+            if !tx.verify() {
+                return;
+            }
+        });
+
+        match self.handle_tx_inner(msg) {
+            Ok(_) => return,
+            Err(e) => error!("{}", e),
         }
     }
 
@@ -613,30 +625,9 @@ impl NodeHandler {
     #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
     pub fn handle_incoming_tx(&mut self, msg: Box<Transaction>) {
         trace!("Handle incoming transaction");
-        let hash = msg.hash();
-        let mut fork = self.blockchain.fork();
-        {
-            let mut schema = Schema::new(&mut fork);
-            if schema.transactions().contains(&hash) && !schema.transactions_pool().contains(&hash)
-            {
-                error!("Received already committed transaction, hash={:?}", hash);
-                return;
-            }
-
-            schema.add_transaction_into_pool(msg.raw().clone());
-        }
-        self.blockchain
-            .merge(fork.into_patch())
-            .expect("Unable to save transaction to persistent pool.");
-        // Broadcast transaction to validators
-        trace!("Broadcast transactions: {:?}", msg.raw());
-        self.broadcast(msg.raw());
-
-        let full_proposes = self.state.check_incomplete_proposes(hash);
-        // Go to has full propose if we get last transaction
-        for (hash, round) in full_proposes {
-            self.remove_request(&RequestData::Transactions(hash));
-            self.has_full_propose(hash, round);
+        match self.handle_tx_inner(msg.raw().clone()) {
+            Ok(_) => self.broadcast(msg.raw()),
+            Err(e) => error!("{}", e),
         }
     }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -566,15 +566,12 @@ impl NodeHandler {
     /// added to the transactions pool.
     #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_tx(&mut self, msg: RawTransaction) {
-        //trace!("Handle transaction");
-        let tx = {
-            match self.blockchain.tx_from_raw(msg.clone()) {
-                Ok(tx) => tx,
-                Err(e) => {
-                    let service_id = msg.service_id();
-                    error!("{}, service_id={}", e.description(), service_id);
-                    return;
-                }
+        let tx = match self.blockchain.tx_from_raw(msg.clone()) {
+            Ok(tx) => tx,
+            Err(e) => {
+                let service_id = msg.service_id();
+                error!("{}, service_id={}", e.description(), service_id);
+                return;
             }
         };
 

--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -19,8 +19,6 @@ extern crate futures;
 extern crate iron;
 extern crate router;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_json;
 
 pub mod schema {

--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -1,0 +1,260 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate bodyparser;
+#[macro_use]
+extern crate exonum;
+extern crate futures;
+extern crate iron;
+extern crate router;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+pub mod schema {
+    use exonum::storage::{Entry, Fork, Snapshot};
+
+    pub struct BalanceSchema<T> {
+        view: T,
+    }
+
+    impl<T: AsRef<Snapshot>> BalanceSchema<T> {
+        pub fn new(view: T) -> Self {
+            Self { view }
+        }
+
+        pub fn balance(&self) -> Entry<&Snapshot, u64> {
+            Entry::new("balance", self.view.as_ref())
+        }
+    }
+
+    impl<'a> BalanceSchema<&'a mut Fork> {
+        pub fn balance_mut(&mut self) -> Entry<&mut Fork, u64> {
+            Entry::new("balance", self.view)
+        }
+    }
+}
+
+pub mod transactions {
+    use service::SERVICE_ID;
+
+    transactions! {
+        pub BalanceTransactions {
+            const SERVICE_ID = SERVICE_ID;
+
+            struct TxAddBalance {
+                amount: u64,
+                seed: u64
+            }
+        }
+    }
+}
+
+pub mod contracts {
+    use exonum::blockchain::{ExecutionResult, Transaction};
+    use exonum::storage::Fork;
+
+    use transactions::TxAddBalance;
+    use schema::BalanceSchema;
+
+    impl Transaction for TxAddBalance {
+        fn verify(&self) -> bool {
+            true
+        }
+
+        fn execute(&self, view: &mut Fork) -> ExecutionResult {
+            let mut schema = BalanceSchema::new(view);
+            let new_balance = schema.balance().get().unwrap() + self.amount();
+            schema.balance_mut().set(new_balance);
+
+            Ok(())
+        }
+    }
+}
+
+pub mod api {
+    use exonum::blockchain::{Blockchain, Transaction};
+    use exonum::node::{ApiSender, TransactionSend};
+    use exonum::crypto::Hash;
+    use exonum::api::{Api, ApiError};
+    use iron::prelude::*;
+    use router::Router;
+
+    use bodyparser;
+    use serde_json;
+    use transactions::BalanceTransactions;
+    use schema::BalanceSchema;
+
+    #[derive(Clone)]
+    pub struct BalanceApi {
+        channel: ApiSender,
+        blockchain: Blockchain,
+    }
+
+    impl BalanceApi {
+        pub fn new(channel: ApiSender, blockchain: Blockchain) -> Self {
+            Self {
+                channel,
+                blockchain,
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct TransactionResponse {
+        pub tx_hash: Hash,
+    }
+
+    impl BalanceApi {
+        /// Endpoint for getting a single wallet.
+        fn get_count(&self, _: &mut Request) -> IronResult<Response> {
+            let snapshot = self.blockchain.snapshot();
+            let schema = BalanceSchema::new(snapshot);
+
+            let balance = schema.balance().get();
+            self.ok_response(&serde_json::to_value(balance).unwrap())
+        }
+
+        /// Common processing for transaction-accepting endpoints.
+        fn post_transaction(&self, req: &mut Request) -> IronResult<Response> {
+            match req.get::<bodyparser::Struct<BalanceTransactions>>() {
+                Ok(Some(transaction)) => {
+                    let transaction: Box<Transaction> = transaction.into();
+                    let tx_hash = transaction.hash();
+                    self.channel.send(transaction).map_err(ApiError::from)?;
+                    let json = TransactionResponse { tx_hash };
+                    self.ok_response(&serde_json::to_value(&json).unwrap())
+                }
+                Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
+                Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
+            }
+        }
+    }
+
+    impl Api for BalanceApi {
+        fn wire(&self, router: &mut Router) {
+            let self_ = self.clone();
+            let post_transaction = move |req: &mut Request| self_.post_transaction(req);
+            let self_ = self.clone();
+            let get_count = move |req: &mut Request| self_.get_count(req);
+
+            router.post("/v1/transaction", post_transaction, "post_transaction");
+            router.get("/v1/count", get_count, "get_count");
+        }
+    }
+}
+
+pub mod service {
+    use exonum::blockchain::{ApiContext, Service, TimeoutAdjusterConfig, Transaction,
+                             TransactionSet};
+    use exonum::{encoding, api::Api, messages::RawTransaction};
+    use exonum::crypto::{gen_keypair, Hash};
+    use exonum::storage::{Database, Fork, MemoryDB, Snapshot};
+    use exonum::node::{ExternalMessage, Node, TransactionSend};
+    use exonum::helpers;
+    use iron::Handler;
+    use router::Router;
+    use serde_json::Value;
+
+    use transactions::{BalanceTransactions, TxAddBalance};
+    use api::BalanceApi;
+    use schema::BalanceSchema;
+
+    use std::sync::Arc;
+    use std::thread;
+    use std::time;
+
+    /// Service ID for the `Service` trait.
+    pub const SERVICE_ID: u16 = 1;
+
+    pub struct BalanceService();
+
+    impl Service for BalanceService {
+        fn service_id(&self) -> u16 {
+            SERVICE_ID
+        }
+
+        fn service_name(&self) -> &str {
+            "balance"
+        }
+
+        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            vec![]
+        }
+
+        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {
+            let tx = BalanceTransactions::tx_from_raw(raw)?;
+            Ok(tx.into())
+        }
+
+        fn public_api_handler(&self, ctx: &ApiContext) -> Option<Box<Handler>> {
+            let mut router = Router::new();
+            let api = BalanceApi::new(ctx.node_channel().clone(), ctx.blockchain().clone());
+            api.wire(&mut router);
+            Some(Box::new(router))
+        }
+
+        fn initialize(&self, fork: &mut Fork) -> Value {
+            let mut schema = BalanceSchema::new(fork);
+            schema.balance_mut().set(0);
+            Value::Null
+        }
+    }
+
+    #[test]
+    fn test_node_run() {
+        let (_, private_key) = gen_keypair();
+
+        let db = Arc::from(Box::new(MemoryDB::new()) as Box<Database>) as Arc<Database>;
+        let mut node_cfg = helpers::generate_testnet_config(1, 16_500)[0].clone();
+
+        // Override timeouts to little values, so we won't have to wait for consensus too long
+        node_cfg.genesis.consensus.timeout_adjuster =
+            TimeoutAdjusterConfig::Constant { timeout: 10 };
+        node_cfg.genesis.consensus.round_timeout = 20;
+
+        let service = Box::new(BalanceService());
+        let node = Node::new(db.clone(), vec![service], node_cfg.clone());
+        let api_tx = node.channel();
+
+        let node_thread = thread::spawn(move || {
+            node.run().unwrap();
+        });
+
+        let tx_orig = Box::new(TxAddBalance::new(10, 0, &private_key));
+        let tx_copy = Box::new(TxAddBalance::new(10, 0, &private_key));
+
+        // Send two identical transactions
+        api_tx.send(tx_orig).unwrap();
+
+        api_tx.send(tx_copy).unwrap();
+
+        // Wait to be sure that transaction was processed
+        thread::sleep(time::Duration::from_millis(100));
+
+        // Shut down the node
+        api_tx
+            .send_external_message(ExternalMessage::Shutdown)
+            .unwrap();
+
+        node_thread.join().unwrap();
+
+        // Check that only one transaction was accepted
+        let schema = BalanceSchema::new(db.snapshot());
+        let balance = schema.balance().get().unwrap();
+
+        assert_eq!(balance, 10);
+    }
+}

--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! This is a basic balance service. The only available operation is a wallet balance update.
+//! Regression test for transactions processing is built on a base of this service.
 extern crate bodyparser;
 #[macro_use]
 extern crate exonum;
@@ -98,7 +100,6 @@ pub mod service {
     use std::thread;
     use std::time;
 
-    /// Service ID for the `Service` trait.
     pub const SERVICE_ID: u16 = 1;
 
     pub struct BalanceService();
@@ -135,7 +136,7 @@ pub mod service {
         let db = Arc::from(Box::new(MemoryDB::new()) as Box<Database>) as Arc<Database>;
         let mut node_cfg = helpers::generate_testnet_config(1, 16_500)[0].clone();
 
-        // Override timeouts to little values, so we won't have to wait for consensus too long
+        // Override timeouts to little values, so we won't have to wait for consensus too long.
         node_cfg.genesis.consensus.timeout_adjuster =
             TimeoutAdjusterConfig::Constant { timeout: 10 };
         node_cfg.genesis.consensus.round_timeout = 20;
@@ -149,14 +150,14 @@ pub mod service {
         });
 
         let tx_orig = Box::new(TxAddBalance::new(10, 0, &private_key));
-        let tx_copy = Box::new(TxAddBalance::new(10, 0, &private_key));
+        let tx_copy = tx_orig.clone();
 
-        // Send two identical transactions
+        // Send two identical transactions.
         api_tx.send(tx_orig).unwrap();
 
         api_tx.send(tx_copy).unwrap();
 
-        // Wait to be sure that transaction was processed
+        // Wait to be sure that transaction was processed.
         thread::sleep(time::Duration::from_millis(100));
 
         // Shut down the node
@@ -166,7 +167,7 @@ pub mod service {
 
         node_thread.join().unwrap();
 
-        // Check that only one transaction was accepted
+        // Check that only one transaction was accepted.
         let schema = BalanceSchema::new(db.snapshot());
         let balance = schema.balance().get().unwrap();
 

--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -84,92 +84,16 @@ pub mod contracts {
     }
 }
 
-pub mod api {
-    use exonum::blockchain::{Blockchain, Transaction};
-    use exonum::node::{ApiSender, TransactionSend};
-    use exonum::crypto::Hash;
-    use exonum::api::{Api, ApiError};
-    use iron::prelude::*;
-    use router::Router;
-
-    use bodyparser;
-    use serde_json;
-    use transactions::BalanceTransactions;
-    use schema::BalanceSchema;
-
-    #[derive(Clone)]
-    pub struct BalanceApi {
-        channel: ApiSender,
-        blockchain: Blockchain,
-    }
-
-    impl BalanceApi {
-        pub fn new(channel: ApiSender, blockchain: Blockchain) -> Self {
-            Self {
-                channel,
-                blockchain,
-            }
-        }
-    }
-
-    #[derive(Serialize, Deserialize)]
-    pub struct TransactionResponse {
-        pub tx_hash: Hash,
-    }
-
-    impl BalanceApi {
-        /// Endpoint for getting a single wallet.
-        fn get_count(&self, _: &mut Request) -> IronResult<Response> {
-            let snapshot = self.blockchain.snapshot();
-            let schema = BalanceSchema::new(snapshot);
-
-            let balance = schema.balance().get();
-            self.ok_response(&serde_json::to_value(balance).unwrap())
-        }
-
-        /// Common processing for transaction-accepting endpoints.
-        fn post_transaction(&self, req: &mut Request) -> IronResult<Response> {
-            match req.get::<bodyparser::Struct<BalanceTransactions>>() {
-                Ok(Some(transaction)) => {
-                    let transaction: Box<Transaction> = transaction.into();
-                    let tx_hash = transaction.hash();
-                    self.channel.send(transaction).map_err(ApiError::from)?;
-                    let json = TransactionResponse { tx_hash };
-                    self.ok_response(&serde_json::to_value(&json).unwrap())
-                }
-                Ok(None) => Err(ApiError::BadRequest("Empty request body".into()))?,
-                Err(e) => Err(ApiError::BadRequest(e.to_string()))?,
-            }
-        }
-    }
-
-    impl Api for BalanceApi {
-        fn wire(&self, router: &mut Router) {
-            let self_ = self.clone();
-            let post_transaction = move |req: &mut Request| self_.post_transaction(req);
-            let self_ = self.clone();
-            let get_count = move |req: &mut Request| self_.get_count(req);
-
-            router.post("/v1/transaction", post_transaction, "post_transaction");
-            router.get("/v1/count", get_count, "get_count");
-        }
-    }
-}
-
 pub mod service {
-    use exonum::blockchain::{ApiContext, Service, TimeoutAdjusterConfig, Transaction,
-                             TransactionSet};
-    use exonum::{encoding, api::Api, messages::RawTransaction};
+    use exonum::blockchain::{Service, TimeoutAdjusterConfig, Transaction, TransactionSet};
+    use exonum::{encoding, messages::RawTransaction};
     use exonum::crypto::{gen_keypair, Hash};
     use exonum::storage::{Database, Fork, MemoryDB, Snapshot};
     use exonum::node::{ExternalMessage, Node, TransactionSend};
     use exonum::helpers;
-    use iron::Handler;
-    use router::Router;
     use serde_json::Value;
 
     use transactions::{BalanceTransactions, TxAddBalance};
-    use api::BalanceApi;
     use schema::BalanceSchema;
 
     use std::sync::Arc;
@@ -199,13 +123,6 @@ pub mod service {
             Ok(tx.into())
         }
 
-        fn public_api_handler(&self, ctx: &ApiContext) -> Option<Box<Handler>> {
-            let mut router = Router::new();
-            let api = BalanceApi::new(ctx.node_channel().clone(), ctx.blockchain().clone());
-            api.wire(&mut router);
-            Some(Box::new(router))
-        }
-
         fn initialize(&self, fork: &mut Fork) -> Value {
             let mut schema = BalanceSchema::new(fork);
             schema.balance_mut().set(0);
@@ -214,7 +131,7 @@ pub mod service {
     }
 
     #[test]
-    fn test_node_run() {
+    fn test_duplicated_transaction() {
         let (_, private_key) = gen_keypair();
 
         let db = Arc::from(Box::new(MemoryDB::new()) as Box<Database>) as Arc<Database>;


### PR DESCRIPTION
With only one node used, it was possible to execute the same transaction multiple times.
To prevent this, additional check was added into NodeHandler::handle_tx.

However, client gets response with tx_hash even for rejected transaction (and this behavior persists even when 2+ nodes are used).
I see no simple way to change it since NodeHandler::handle_tx doesn't return Result and thus not able to tell that transaction was rejected.