### PR TITLE
WIP: Fix handling of duplicated messages in propose [ECR-1247]

### DIFF
--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -816,10 +816,7 @@ impl State {
                 for hash in msg.transactions() {
                     if transactions.get(hash).is_some() {
                         if !transaction_pool.contains(hash) {
-                            bail!(
-                                "Received propose with already\
-                                 committed transaction"
-                            )
+                            warn!("Received propose with already committed transaction");
                         }
                     } else {
                         unknown_txs.insert(*hash);


### PR DESCRIPTION
Currently if already known transaction is gotten in `State::add_propose`, call to `bail!` occurs.
It leads to discarding all others unknown transactions and thus nodes can't sync.
Result is infinite round timeout.

Changing `bail!` to `warn!` and simple ignoring of gotten transaction does fix the situation.

- [x] Fix error in `State::add_propose`.
- [ ] Write tests.
