### PR TITLE
Fix handling of shutdown request [ECR-1255]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Already processed transactions are rejected now in
   `NodeHandler::handle_incoming_tx` method. (#642)
 
+- Fixed bug with shutdown requests handling. (#666)
+
 #### exonum-cryptocurrency-advanced
 
 - Frontend has been updated to reflect latest backend changes. (#602 #611)

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -130,9 +130,7 @@ fn test_node_run() {
     }
 }
 
-// See ECR-907 for the details.
 #[test]
-#[ignore]
 fn test_node_shutdown_twice() {
     let (nodes, commit_rxs) = run_nodes(1, 16_400);
 


### PR DESCRIPTION
The problem was caused by creating `Iron` handlers in separate threads.
Since those handlers won't stop without request, `join` call on them had no effect.

More than that, as creation of those handlers is non-blocking, there is no need in additional threads.