### PR TITLE
Unsafe private api [ECR-1298]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Field`, `CryptoHash`, `StorageValue` and `ExonumJson` traits have been
   implemented for `chrono::Duration` structure. (#653)
 
+- Unsafe api for emergency cases has been implemented. (#668)
+
 #### exonum-timestamping
 
 - Additional service example has been added along with frontend. (#646)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Field`, `CryptoHash`, `StorageValue` and `ExonumJson` traits have been
   implemented for `chrono::Duration` structure. (#653)
 
-- Unsafe api for emergency cases has been implemented. (#668)
+- Unsafe Exonum API that allows to restore node without recompilation
+  in emergency cases (e.g. internal node errors) 
+  has been implemented. (#668)
 
 #### exonum-timestamping
 

--- a/exonum/src/api/private/mod.rs
+++ b/exonum/src/api/private/mod.rs
@@ -15,5 +15,7 @@
 //! Private part of the Exonum rest api.
 
 pub use self::system::{NodeInfo, SystemApi};
+pub use self::unsafe_api::UnsafeApi;
 
 mod system;
+mod unsafe_api;

--- a/exonum/src/api/private/unsafe_api.rs
+++ b/exonum/src/api/private/unsafe_api.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Unsafe Exonum api that provides functionality for emergency cases.
+//! Unsafe Exonum API provides functionality for emergency cases.
 
 use router::Router;
 use iron::prelude::*;
@@ -30,7 +30,7 @@ pub struct UnsafeApi {
 
 impl UnsafeApi {
     /// Creates a new `private::UnsafeApi` instance.
-    pub fn new(blockchain: Blockchain) -> UnsafeApi {
+    pub fn new(blockchain: Blockchain) -> Self {
         UnsafeApi { blockchain }
     }
 
@@ -49,8 +49,8 @@ impl UnsafeApi {
                 .merge_sync(fork.into_patch())
                 .map_err(ApiError::Storage)?;
 
-            // Desrtoy this process.
-            process::exit(1);
+            // Destroy this process.
+            process::abort();
         };
 
         router.post("/v1/shutdown", shutdown_unsafe, "unsafe_shutdown");

--- a/exonum/src/api/private/unsafe_api.rs
+++ b/exonum/src/api/private/unsafe_api.rs
@@ -31,9 +31,7 @@ pub struct UnsafeApi {
 impl UnsafeApi {
     /// Creates a new `private::UnsafeApi` instance.
     pub fn new(blockchain: Blockchain) -> UnsafeApi {
-        UnsafeApi {
-            blockchain,
-        }
+        UnsafeApi { blockchain }
     }
 
     fn handle_unsafe_shutdown(self, router: &mut Router) {

--- a/exonum/src/api/private/unsafe_api.rs
+++ b/exonum/src/api/private/unsafe_api.rs
@@ -1,0 +1,66 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unsafe Exonum api that provides functionality for emergency cases.
+
+use router::Router;
+use iron::prelude::*;
+
+use std::process;
+
+use blockchain::{Blockchain, Schema};
+use api::{Api, ApiError};
+
+/// Private unsafe API.
+#[derive(Clone, Debug)]
+pub struct UnsafeApi {
+    blockchain: Blockchain,
+}
+
+impl UnsafeApi {
+    /// Creates a new `private::UnsafeApi` instance.
+    pub fn new(blockchain: Blockchain) -> UnsafeApi {
+        UnsafeApi {
+            blockchain,
+        }
+    }
+
+    fn handle_unsafe_shutdown(self, router: &mut Router) {
+        let shutdown_unsafe = move |_: &mut Request| -> IronResult<Response> {
+            warn!("Received unsafe shutdown request");
+
+            // Clear cache.
+            let mut blockchain = self.blockchain.clone();
+            let mut fork = blockchain.fork();
+            {
+                let mut schema = Schema::new(&mut fork);
+                schema.consensus_messages_cache_mut().clear();
+            }
+            blockchain
+                .merge_sync(fork.into_patch())
+                .map_err(ApiError::Storage)?;
+
+            // Desrtoy this process.
+            process::exit(1);
+        };
+
+        router.post("/v1/shutdown", shutdown_unsafe, "unsafe_shutdown");
+    }
+}
+
+impl Api for UnsafeApi {
+    fn wire(&self, router: &mut Router) {
+        self.clone().handle_unsafe_shutdown(router);
+    }
+}

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -148,13 +148,13 @@ impl Blockchain {
     }
 
     /// Commits changes from the patch to the blockchain storage.
-    /// See [`merge`](../trait.Database.html#tymethod.merge) for details.
+    /// See [`merge`](../storage/trait.Database.html#tymethod.merge) for details.
     pub fn merge(&mut self, patch: Patch) -> Result<(), Error> {
         self.db.merge(patch)
     }
 
     /// Commits changes from the patch to the blockchain storage with fsync.
-    /// See [`merge_sync`](../trait.Database.html#tymethod.merge_sync) for details.
+    /// See [`merge_sync`](../storage/trait.Database.html#tymethod.merge_sync) for details.
     pub fn merge_sync(&mut self, patch: Patch) -> Result<(), Error> {
         self.db.merge_sync(patch)
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -153,6 +153,12 @@ impl Blockchain {
         self.db.merge(patch)
     }
 
+    /// Commits changes from the patch to the blockchain storage with fsync.
+    /// See [`Fork`](../storage/struct.Fork.html) for details.
+    pub fn merge_sync(&mut self, patch: Patch) -> Result<(), Error> {
+        self.db.merge_sync(patch)
+    }
+
     /// Returns the hash of latest committed block.
     ///
     /// # Panics

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -148,13 +148,13 @@ impl Blockchain {
     }
 
     /// Commits changes from the patch to the blockchain storage.
-    /// See [`Fork`](../storage/struct.Fork.html) for details.
+    /// See [`merge`](../trait.Database.html#tymethod.merge) for details.
     pub fn merge(&mut self, patch: Patch) -> Result<(), Error> {
         self.db.merge(patch)
     }
 
     /// Commits changes from the patch to the blockchain storage with fsync.
-    /// See [`Fork`](../storage/struct.Fork.html) for details.
+    /// See [`merge_sync`](../trait.Database.html#tymethod.merge_sync) for details.
     pub fn merge_sync(&mut self, patch: Patch) -> Result<(), Error> {
         self.db.merge_sync(patch)
     }

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -997,6 +997,10 @@ pub fn create_private_api_handler(
     mount.mount("api/services", blockchain.mount_private_api());
 
     if config.enable_unsafe_api {
+        warn!(
+            "Node has been launched with support of unsafe API. If that's not what you want, \
+             disable unsafe API in node config."
+        );
         let mut router = Router::new();
         let unsafe_api = private::UnsafeApi::new(blockchain.clone());
         unsafe_api.wire(&mut router);

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -148,7 +148,8 @@ pub struct NodeApiConfig {
     pub state_update_timeout: usize,
     /// Enable api endpoints for the `blockchain_explorer` on public api address.
     pub enable_blockchain_explorer: bool,
-    /// Enable private unsafe api
+    /// Enable private unsafe api (disabled by default).
+    #[serde(default)]
     pub enable_unsafe_api: bool,
     /// Listen address for public api endpoints.
     pub public_api_address: Option<SocketAddr>,

--- a/exonum/tests/testdata/config/config01.toml
+++ b/exonum/tests/testdata/config/config01.toml
@@ -7,6 +7,7 @@ service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3
 service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config02.toml
+++ b/exonum/tests/testdata/config/config02.toml
@@ -7,6 +7,7 @@ service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3
 service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config03.toml
+++ b/exonum/tests/testdata/config/config03.toml
@@ -7,6 +7,7 @@ service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3
 service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config04.toml
+++ b/exonum/tests/testdata/config/config04.toml
@@ -7,6 +7,7 @@ service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3
 service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config12.toml
+++ b/exonum/tests/testdata/config/config12.toml
@@ -7,6 +7,7 @@ service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3c
 service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config13.toml
+++ b/exonum/tests/testdata/config/config13.toml
@@ -7,6 +7,7 @@ service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3c
 service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config14.toml
+++ b/exonum/tests/testdata/config/config14.toml
@@ -7,6 +7,7 @@ service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3c
 service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config23.toml
+++ b/exonum/tests/testdata/config/config23.toml
@@ -7,6 +7,7 @@ service_public_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf
 service_secret_key = "6e9a000213c7e3698f50e8e9bef4773a89d39b2d940925e7b3a82280a58c68a6ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config24.toml
+++ b/exonum/tests/testdata/config/config24.toml
@@ -7,6 +7,7 @@ service_public_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf
 service_secret_key = "6e9a000213c7e3698f50e8e9bef4773a89d39b2d940925e7b3a82280a58c68a6ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/exonum/tests/testdata/config/config34.toml
+++ b/exonum/tests/testdata/config/config34.toml
@@ -7,6 +7,7 @@ service_public_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70
 service_secret_key = "422acb782a4430c7dd982f73b88c29f03440248a010119410c7f522871919110066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
 
 [api]
+enable_unsafe_api = false
 enable_blockchain_explorer = true
 state_update_timeout = 10000
 [[genesis.validator_keys]]

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -94,6 +94,7 @@ impl TestKitApi {
                     blockchain.clone(),
                     api_state,
                     testkit.api_sender.clone(),
+                    &testkit.api_config,
                 );
                 handler.link_after(|req: &mut Request, resp| {
                     log_request(&ApiAccess::Private, req, resp)

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -40,6 +40,8 @@ use super::TestKit;
 pub enum ApiKind {
     /// `api/system` endpoints of the built-in Exonum REST API.
     System,
+    /// `api/unsafe` endpoints of the built-in Exonum REST API.
+    Unsafe,
     /// `api/explorer` endpoints of the built-in Exonum REST API.
     Explorer,
     /// Endpoints corresponding to a service with the specified string identifier.
@@ -50,6 +52,7 @@ impl ApiKind {
     fn into_prefix(self) -> String {
         match self {
             ApiKind::System => "api/system".to_string(),
+            ApiKind::Unsafe => "api/unsafe".to_string(),
             ApiKind::Explorer => "api/explorer".to_string(),
             ApiKind::Service(name) => format!("api/services/{}", name),
         }

--- a/testkit/tests/system_api.rs
+++ b/testkit/tests/system_api.rs
@@ -40,3 +40,12 @@ fn test_user_agent_info() {
     let expected = user_agent::get();
     assert_eq!(info, expected);
 }
+
+#[test]
+#[should_panic(expected = "Cannot send data")]
+fn test_unsafe_api_inaccessible_by_default() {
+    let testkit = TestKitBuilder::validator().with_validators(1).create();
+    let api = testkit.api();
+    let empty_request = "".to_string();
+    let _info: String = api.post_private(ApiKind::Unsafe, "v1/shutdown", &empty_request);
+}

--- a/testkit/tests/system_api.rs
+++ b/testkit/tests/system_api.rs
@@ -44,7 +44,7 @@ fn test_user_agent_info() {
 #[test]
 #[should_panic(expected = "Cannot send data")]
 fn test_unsafe_api_inaccessible_by_default() {
-    let testkit = TestKitBuilder::validator().with_validators(1).create();
+    let testkit = TestKitBuilder::validator().create();
     let api = testkit.api();
     let empty_request = "".to_string();
     let _info: String = api.post_private(ApiKind::Unsafe, "v1/shutdown", &empty_request);


### PR DESCRIPTION
New api can be enabled with node config '.toml' file. 
It is mounted to the private api address, and after cache clearing kills the application via `process::exit` call.

---

I think it's bad that there is no test for the actual shutdown call in current implementation, but I faced several problems while trying to implement it:

- If `process::exit` is called within test, this test fails.
- Common solution for similar situations is to create mock implementation of `exit` and mark it with `#[cfg(test)]`, while actual is marked with `#[cfg(not(test))]`. But it works only when test and code are in the same crate.

If someone'll give me a hint on this problem, I'll implement the missing test.