### PR TITLE
Marked test_node_shutdown_twice as ignored

### DIFF
--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -130,7 +130,9 @@ fn test_node_run() {
     }
 }
 
+// See ECR-907 for the details.
 #[test]
+#[ignore]
 fn test_node_shutdown_twice() {
     let (nodes, commit_rxs) = run_nodes(1, 16_400);
 


### PR DESCRIPTION
Today while testing unsafe api I've got test `test_node_shutdown_twice` failed several times.
So I guess the problem was not only in shutdown mechanism, but also in the test itself.
Seems like it has race condition indeed (sometimes it passes, sometimes not). 

My suggestion is to ignore this test for now and resolve it as a part of [ECR-1161].
