### PR TITLE
Verifying transactions in a thread pool. [ECR-225]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Now nodes will switch to `min_propose_timeout` for block proposal timeout
   faster if they receive more than `propose_timeout_threshold` transactions
   during `max_propose_timeout`. (#844)
+### Internal Improvements
+
+#### exonum
+- Transactions are now verified in a thread pool. (#673)
 
 - Custom log formatting (along with `colored` and `term` dependencies) has been
   removed in favor of `env_logger`. (#857).
@@ -297,7 +301,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Maintenance CLI command for node management has been added. Currently the only
   supported command is `clear-cache` which clears node message cache. (#676)
-- Transactions are now verified in a thread pool. (#673)
 
 - `StoredConfiguration` validation has been extended with `txs_block_limit`
   parameter check. (#690)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   removed in favor of `env_logger`. (#857).
 
 - Several dependencies have been updated. (#861)
+
 - Transactions are now verified in a thread pool. Thread pool size is set to
   optimal value by default (CPU count) or can be configured manually. (#673)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Internal Improvements
 
 #### exonum
+
 - Transactions are now verified in a thread pool. (#673)
 
 - Custom log formatting (along with `colored` and `term` dependencies) has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 #### exonum
 
 - Bug with pool size overflow has been fixed. (#853)
+- Transactions (signature) verification benchmark has been fixed. (#673)
+- Node no longer panics when transaction pool has a lot of transactions and
+  consensus is at round 0. (#673)
 
 ### Internal Improvements
 
@@ -61,16 +64,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Now nodes will switch to `min_propose_timeout` for block proposal timeout
   faster if they receive more than `propose_timeout_threshold` transactions
   during `max_propose_timeout`. (#844)
-### Internal Improvements
-
-#### exonum
-
-- Transactions are now verified in a thread pool. (#673)
 
 - Custom log formatting (along with `colored` and `term` dependencies) has been
   removed in favor of `env_logger`. (#857).
 
 - Several dependencies have been updated. (#861)
+- Transactions are now verified in a thread pool. Thread pool size is set to
+  optimal value by default (CPU count) or can be configured manually (#673)
 
 ## 0.9.1 - 2018-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Maintenance CLI command for node management has been added. Currently the only
   supported command is `clear-cache` which clears node message cache. (#676)
+- Transactions are now verified in a thread pool. (#673)
 
 - `StoredConfiguration` validation has been extended with `txs_block_limit`
   parameter check. (#690)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 #### exonum
 
 - Bug with pool size overflow has been fixed. (#853)
+
 - Transactions (signature) verification benchmark has been fixed. (#673)
+
 - Node no longer panics when transaction pool has a lot of transactions and
   consensus is at round 0. (#673)
 
@@ -70,7 +72,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Several dependencies have been updated. (#861)
 - Transactions are now verified in a thread pool. Thread pool size is set to
-  optimal value by default (CPU count) or can be configured manually (#673)
+  optimal value by default (CPU count) or can be configured manually. (#673)
 
 ## 0.9.1 - 2018-08-02
 

--- a/examples/cryptocurrency/examples/demo.rs
+++ b/examples/cryptocurrency/examples/demo.rs
@@ -53,6 +53,7 @@ fn node_config() -> NodeConfig {
         mempool: Default::default(),
         services_configs: Default::default(),
         database: Default::default(),
+        thread_pool_size: Default::default(),
     }
 }
 

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -131,6 +131,7 @@ testdata
 testkit
 testnet
 testnetctl
+threadpool
 timestamping
 timestamps
 tlsdate

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "=0.4.5", features = ["serde"] }
 uuid = { version = "=0.6.5", features = ["serde"] }
 snow = "=0.3.1"
 rust_decimal = "=0.9.1"
+tokio-threadpool = "0.1.2"
 
 exonum_rocksdb = "0.7.4"
 exonum_sodiumoxide = { version = "0.0.20", optional = true }

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -39,13 +39,13 @@ tokio-core = "=0.1.17"
 tokio-io = "=0.1.7"
 tokio-retry = "=0.2.0"
 tokio-timer = "=0.1.2"
+tokio-threadpool = "=0.1.5"
 failure = "0.1.2"
 os_info = "1.0.1"
 chrono = { version = "=0.4.5", features = ["serde"] }
 uuid = { version = "=0.6.5", features = ["serde"] }
 snow = "=0.3.1"
 rust_decimal = "=0.9.1"
-tokio-threadpool = "0.1.5"
 
 exonum_rocksdb = "0.7.4"
 exonum_sodiumoxide = { version = "0.0.20", optional = true }

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -40,6 +40,7 @@ tokio-io = "=0.1.7"
 tokio-retry = "=0.2.0"
 tokio-timer = "=0.1.2"
 tokio-threadpool = "=0.1.5"
+tokio-executor = "=0.1.3"
 failure = "0.1.2"
 os_info = "1.0.1"
 chrono = { version = "=0.4.5", features = ["serde"] }

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "=0.4.5", features = ["serde"] }
 uuid = { version = "=0.6.5", features = ["serde"] }
 snow = "=0.3.1"
 rust_decimal = "=0.9.1"
-tokio-threadpool = "0.1.2"
+tokio-threadpool = "0.1.5"
 
 exonum_rocksdb = "0.7.4"
 exonum_sodiumoxide = { version = "0.0.20", optional = true }

--- a/exonum/benches/criterion/transactions.rs
+++ b/exonum/benches/criterion/transactions.rs
@@ -30,8 +30,7 @@ use exonum::{
         Blockchain, ExecutionResult, GenesisConfig, Service, SharedNodeState, Transaction,
         TransactionSet, ValidatorKeys,
     },
-    crypto::{self, Hash, PublicKey},
-    encoding,
+    crypto::{self, Hash, PublicKey}, encoding,
     events::{
         error::other_error, Event, EventHandler, HandlerPart, InternalEvent, InternalPart,
         NetworkEvent,
@@ -203,8 +202,7 @@ impl TransactionsBenchmarkRunner {
         };
         // Emulates transactions from the network.
         let socket_addr = handler_part.handler.inner().system_state.listen_address();
-        let transactions = self
-            .transactions
+        let transactions = self.transactions
             .into_iter()
             .map(|raw| NetworkEvent::MessageReceived(socket_addr, raw))
             .collect::<Vec<_>>();

--- a/exonum/benches/criterion/transactions.rs
+++ b/exonum/benches/criterion/transactions.rs
@@ -31,7 +31,7 @@ use exonum::{
         TransactionSet, ValidatorKeys,
     },
     crypto::{self, Hash, PublicKey}, encoding,
-    events::{error::other_error, Event, EventHandler, HandlerPart, NetworkEvent},
+    events::{error::other_error, Event, EventHandler, HandlerPart, NetworkEvent, InternalEvent},
     messages::{Message, RawTransaction},
     node::{
         ApiSender, Configuration, ConnectList, DefaultSystemState, ListenerConfig, NodeApiConfig,

--- a/exonum/benches/criterion/transactions.rs
+++ b/exonum/benches/criterion/transactions.rs
@@ -108,7 +108,7 @@ impl TransactionsHandler {
 
 impl EventHandler for TransactionsHandler {
     fn handle_event(&mut self, event: Event) {
-        let is_transaction = if let Event::Network(NetworkEvent::MessageReceived(..)) = event {
+        let is_transaction = if let Event::Internal(InternalEvent::TxVerified(_)) = event {
             true
         } else {
             false

--- a/exonum/benches/criterion/transactions.rs
+++ b/exonum/benches/criterion/transactions.rs
@@ -199,6 +199,7 @@ impl TransactionsBenchmarkRunner {
         let internal_part = InternalPart {
             internal_tx: self.channel.internal_events.0,
             internal_requests_rx: self.channel.internal_requests.1,
+            thread_pool_size: None,
         };
         // Emulates transactions from the network.
         let socket_addr = handler_part.handler.inner().system_state.listen_address();
@@ -255,6 +256,7 @@ impl TransactionsBenchmarkRunner {
             mempool: Default::default(),
             services_configs: Default::default(),
             database: Default::default(),
+            thread_pool_size: Default::default(),
         }
     }
 }

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// spell-checker:ignore threadpool
-
 use futures::{self, future, sync::mpsc, Future, Sink, Stream};
 use tokio_core::reactor::{Handle, Timeout};
 use tokio_executor::SpawnError;

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -94,7 +94,7 @@ impl InternalPart {
                     InternalRequest::VerifyTx(tx) => {
                         if !txs_in_verification.insert(tx.raw().hash()) {
                             let f = future::ok::<(), ()>(());
-                            rto_box(f)
+                            to_box(f)
                         } else {
                             let f = futures::lazy(move || {
                                 pool_tx

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -14,20 +14,17 @@
 
 // spell-checker:ignore threadpool
 
-use futures::{self, sync::mpsc, Future, Sink, Stream, future};
+use futures::{self, future, sync::mpsc, Future, Sink, Stream};
 use tokio_core::reactor::{Handle, Timeout};
 use tokio_threadpool::Builder as ThreadPoolBuilder;
 
 use std::{
-    io, time::{Duration, SystemTime},
-    rc::Rc,
+    io, rc::Rc, time::{Duration, SystemTime},
 };
 
 use super::{
     error::{into_other, other_error}, to_box, InternalEvent, InternalRequest, TimeoutRequest,
 };
-use blockchain::Transaction;
-use events::error::log_error;
 
 #[derive(Debug)]
 pub struct InternalPart {

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// spell-checker:ignore threadpool
+
 use futures::{self, sync::mpsc, Future, Sink, Stream, future};
 use tokio_core::reactor::{Handle, Timeout};
 use tokio_threadpool::Builder as ThreadPoolBuilder;

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -27,6 +27,7 @@ use super::{
 };
 use blockchain::Transaction;
 use crypto::Hash;
+use events::error::log_error;
 
 #[derive(Debug)]
 pub struct InternalPart {
@@ -102,9 +103,7 @@ impl InternalPart {
                         if txs_in_verification.insert(tx.raw().hash()) {
                             let f = futures::lazy(move || {
                                 pool_tx.send(tx).map(drop).map_err(into_other)
-                            }).map_err(|_| {
-                                panic!("Can't send tx for verification to the thread pool")
-                            });
+                            }).map_err(log_error);
                             to_box(f)
                         } else {
                             let f = future::ok::<(), ()>(());

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -14,7 +14,7 @@
 
 // spell-checker:ignore threadpool
 
-use futures::{self, sync::mpsc, Future, Sink, Stream, future};
+use futures::{self, sync::mpsc, Future, Sink, Stream};
 use tokio_core::reactor::{Handle, Timeout};
 use tokio_threadpool::Builder as ThreadPoolBuilder;
 
@@ -26,7 +26,6 @@ use super::{
     error::{into_other, other_error}, to_box, InternalEvent, InternalRequest, TimeoutRequest,
 };
 use blockchain::Transaction;
-use crypto::Hash;
 use events::error::log_error;
 
 #[derive(Debug)]
@@ -41,7 +40,7 @@ impl InternalPart {
         let thread_pool = ThreadPoolBuilder::new().build();
 
         // Buffer in a channel wouldn't do anything except clutter the memory.
-        let (pool_tx, pool_rx) = mpsc::channel::<Box<Transaction>>(0);
+        let (pool_tx, pool_rx) = mpsc::channel::<Box<dyn Transaction>>(0);
         let internal_tx = self.internal_tx.clone();
         thread_pool.spawn(
             pool_rx.for_each(move |tx| {

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -42,18 +42,16 @@ impl InternalPart {
         // Buffer in a channel wouldn't do anything except clutter the memory.
         let (pool_tx, pool_rx) = mpsc::channel::<Box<dyn Transaction>>(0);
         let internal_tx = self.internal_tx.clone();
-        thread_pool.spawn(
-            pool_rx.for_each(move |tx| {
-                if tx.verify() {
-                    internal_tx
-                        .clone()
-                        .wait()
-                        .send(InternalEvent::TxVerified(tx))
-                        .expect("Cannot send TxVerified event.");
-                }
-                Ok(())
-            })
-        );
+        thread_pool.spawn(pool_rx.for_each(move |tx| {
+            if tx.verify() {
+                internal_tx
+                    .clone()
+                    .wait()
+                    .send(InternalEvent::TxVerified(tx))
+                    .expect("Cannot send TxVerified event.");
+            }
+            Ok(())
+        }));
 
         let internal_tx = self.internal_tx.clone();
         let fut = self.internal_requests_rx

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::{self, sync::mpsc, Future, Sink, Stream};
+use futures::{self, sync::mpsc, Future, Sink, Stream, future};
 use tokio_core::reactor::{Handle, Timeout};
+use tokio_threadpool::{Builder as ThreadPoolBuilder};
 
 use std::{
     io, time::{Duration, SystemTime},
@@ -22,6 +23,8 @@ use std::{
 use super::{
     error::{into_other, other_error}, to_box, InternalEvent, InternalRequest, TimeoutRequest,
 };
+use blockchain::Transaction;
+use crypto::Hash;
 
 #[derive(Debug)]
 pub struct InternalPart {
@@ -31,6 +34,23 @@ pub struct InternalPart {
 
 impl InternalPart {
     pub fn run(self, handle: Handle) -> Box<dyn Future<Item = (), Error = io::Error>> {
+        // Default number of threads = number of cores.
+        let thread_pool = ThreadPoolBuilder::new().build();
+
+        // Buffer in a channel wouldn't do anything except clutter the memory.
+        let (pool_tx, pool_rx) = mpsc::channel::<Box<Transaction>>(0);
+        let internal_tx = self.internal_tx.clone();
+        thread_pool.spawn(futures::lazy(move || {
+            pool_rx.for_each(|tx| {
+                if tx.verify() {
+                    internal_tx.send(InternalEvent::TxVerified(tx));
+                }
+                Ok(())
+            })
+        }));
+
+        let mut txs_in_verification = HashSet::<Hash>::new();
+
         let internal_tx = self.internal_tx.clone();
         let fut = self.internal_requests_rx
             .for_each(move |request| {
@@ -69,6 +89,19 @@ impl InternalPart {
                                 .map(drop)
                                 .map_err(into_other)
                         }).map_err(|_| panic!("Can't execute shutdown"));
+                        to_box(f)
+                    }
+                    InternalRequest::VerifyTx(tx) => {
+                        if !txs_in_verification.insert(tx.raw().hash()) {
+                            let f = future::ok::<(), ()>(());
+                            return to_box(f);
+                        }
+                        let f = futures::lazy(move || {
+                            pool_tx
+                                .send(tx)
+                                .map(drop)
+                                .map_err(into_other)
+                        }).map_err(|_| panic!("Can't send tx for verification to the thread pool"));
                         to_box(f)
                     }
                 };

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -47,7 +47,7 @@ impl InternalPart {
                         .clone()
                         .send(InternalEvent::TxVerified(tx))
                         .wait()
-                        .expect("Cannot send tx to the thread pool.");
+                        .expect("Cannot send TxVerified event.");
                 }
                 Ok(())
             })

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -48,8 +48,8 @@ impl InternalPart {
                 if tx.verify() {
                     internal_tx
                         .clone()
-                        .send(InternalEvent::TxVerified(tx))
                         .wait()
+                        .send(InternalEvent::TxVerified(tx))
                         .expect("Cannot send TxVerified event.");
                 }
                 Ok(())

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -29,9 +29,9 @@ use futures::{
 
 use std::{cmp::Ordering, time::SystemTime};
 
+use blockchain::Transaction;
 use helpers::{Height, Round};
 use node::{ExternalMessage, NodeTimeout};
-use blockchain::Transaction;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -60,7 +60,7 @@ pub enum InternalRequest {
     JumpToRound(Height, Round),
     Shutdown,
     /// Async request to verify a transaction in the thread pool.
-    VerifyTx(Box<Transaction>),
+    VerifyTx(Box<dyn Transaction>),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -31,6 +31,7 @@ use std::{cmp::Ordering, time::SystemTime};
 
 use helpers::{Height, Round};
 use node::{ExternalMessage, NodeTimeout};
+use blockchain::Transaction;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;
@@ -49,13 +50,17 @@ pub enum InternalEvent {
     Timeout(NodeTimeout),
     /// Shutdown the node.
     Shutdown,
+    /// Transaction has been successfully verified.
+    TxVerified(Box<dyn Transaction>),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum InternalRequest {
     Timeout(TimeoutRequest),
     JumpToRound(Height, Round),
     Shutdown,
+    /// Async request to verify a transaction in the thread pool.
+    VerifyTx(Box<Transaction>),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -32,6 +32,7 @@ use std::{cmp::Ordering, time::SystemTime};
 use blockchain::Transaction;
 use helpers::{Height, Round};
 use node::{ExternalMessage, NodeTimeout};
+use messages::RawTransaction;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;
@@ -51,7 +52,7 @@ pub enum InternalEvent {
     /// Shutdown the node.
     Shutdown,
     /// Transaction has been successfully verified.
-    TxVerified(Box<dyn Transaction>),
+    TxVerified(RawTransaction),
 }
 
 #[derive(Debug)]

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -31,8 +31,8 @@ use std::{cmp::Ordering, time::SystemTime};
 
 use blockchain::Transaction;
 use helpers::{Height, Round};
-use node::{ExternalMessage, NodeTimeout};
 use messages::RawTransaction;
+use node::{ExternalMessage, NodeTimeout};
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -630,6 +630,7 @@ impl Command for Finalize {
                 services_configs: Default::default(),
                 database: Default::default(),
                 connect_list: ConnectListConfig::from_node_config(&list),
+                thread_pool_size: Default::default(),
             }
         };
 

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -75,6 +75,7 @@ pub fn generate_testnet_config(count: u8, start_port: u16) -> Vec<NodeConfig> {
             mempool: Default::default(),
             services_configs: Default::default(),
             database: Default::default(),
+            thread_pool_size: Default::default(),
         })
         .collect::<Vec<_>>()
 }

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -67,12 +67,12 @@ extern crate serde_json;
 extern crate snow;
 extern crate tokio_codec;
 extern crate tokio_core;
+extern crate tokio_executor;
 extern crate tokio_io;
 extern crate tokio_retry;
 extern crate tokio_threadpool;
 #[cfg(any(test, feature = "long_benchmarks"))]
 extern crate tokio_timer;
-extern crate tokio_executor;
 extern crate toml;
 extern crate uuid;
 extern crate vec_map;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -69,9 +69,9 @@ extern crate tokio_codec;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_retry;
+extern crate tokio_threadpool;
 #[cfg(any(test, feature = "long_benchmarks"))]
 extern crate tokio_timer;
-extern crate tokio_threadpool;
 extern crate toml;
 extern crate uuid;
 extern crate vec_map;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -72,6 +72,7 @@ extern crate tokio_retry;
 extern crate tokio_threadpool;
 #[cfg(any(test, feature = "long_benchmarks"))]
 extern crate tokio_timer;
+extern crate tokio_executor;
 extern crate toml;
 extern crate uuid;
 extern crate vec_map;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -71,6 +71,7 @@ extern crate tokio_io;
 extern crate tokio_retry;
 #[cfg(any(test, feature = "long_benchmarks"))]
 extern crate tokio_timer;
+extern crate tokio_threadpool;
 extern crate toml;
 extern crate uuid;
 extern crate vec_map;

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -29,7 +29,7 @@ impl NodeHandler {
             Ok(Any::Consensus(msg)) => self.handle_consensus(msg),
             Ok(Any::Request(msg)) => self.handle_request(msg),
             Ok(Any::Block(msg)) => self.handle_block(&msg),
-            Ok(Any::Transaction(msg)) => self.handle_tx(msg),
+            Ok(Any::Transaction(msg)) => self.handle_tx(&msg),
             Ok(Any::TransactionsBatch(msg)) => self.handle_txs_batch(&msg),
             Err(err) => {
                 error!("Invalid message received: {:?}", err.description());

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -596,7 +596,6 @@ impl NodeHandler {
     }
 
     /// Handles raw transactions.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_txs_batch(&mut self, msg: &TransactionsResponse) {
         if msg.to() != self.state.consensus_public_key() {
             error!(

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -585,13 +585,14 @@ impl NodeHandler {
             }
         };
 
-        if !tx.verify() {
-            return;
-        }
+        self.execute_later(InternalRequest::VerifyTx(tx));
+    }
 
+    /// Handles an already verified transaction.
+    pub fn handle_verified_tx(&mut self, tx: Box<Transaction>) {
         // We don't care about result, because situation when transaction received twice
         // is normal for internal messages (transaction may be received from 2+ nodes).
-        let _ = self.handle_tx_inner(msg);
+        let _ = self.handle_tx_inner(tx.raw().clone());
     }
 
     /// Handles raw transactions.

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -589,10 +589,10 @@ impl NodeHandler {
     }
 
     /// Handles an already verified transaction.
-    pub fn handle_verified_tx(&mut self, tx: &dyn Transaction) {
+    pub fn handle_verified_tx(&mut self, tx: RawTransaction) {
         // We don't care about result, because situation when transaction received twice
         // is normal for internal messages (transaction may be received from 2+ nodes).
-        let _ = self.handle_tx_inner(tx.raw().clone());
+        let _ = self.handle_tx_inner(tx);
     }
 
     /// Handles raw transactions.

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -589,7 +589,7 @@ impl NodeHandler {
     }
 
     /// Handles an already verified transaction.
-    pub fn handle_verified_tx(&mut self, tx: &Transaction) {
+    pub fn handle_verified_tx(&mut self, tx: &dyn Transaction) {
         // We don't care about result, because situation when transaction received twice
         // is normal for internal messages (transaction may be received from 2+ nodes).
         let _ = self.handle_tx_inner(tx.raw().clone());

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -553,7 +553,7 @@ impl NodeHandler {
             .merge(fork.into_patch())
             .expect("Unable to save transaction to persistent pool.");
 
-        if self.state.is_leader() {
+        if self.state.round() != Round::zero() && self.state.is_leader() {
             self.maybe_add_propose_timeout();
         }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -575,7 +575,7 @@ impl NodeHandler {
 
     /// Handles raw transaction. Transaction is ignored if it is already known, otherwise it is
     /// added to the transactions pool.
-    pub fn handle_tx(&mut self, msg: RawTransaction) {
+    pub fn handle_tx(&mut self, msg: &RawTransaction) {
         let tx = match self.blockchain.tx_from_raw(msg.clone()) {
             Ok(tx) => tx,
             Err(e) => {
@@ -589,13 +589,14 @@ impl NodeHandler {
     }
 
     /// Handles an already verified transaction.
-    pub fn handle_verified_tx(&mut self, tx: Box<Transaction>) {
+    pub fn handle_verified_tx(&mut self, tx: &Box<Transaction>) {
         // We don't care about result, because situation when transaction received twice
         // is normal for internal messages (transaction may be received from 2+ nodes).
         let _ = self.handle_tx_inner(tx.raw().clone());
     }
 
     /// Handles raw transactions.
+    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_txs_batch(&mut self, msg: &TransactionsResponse) {
         if msg.to() != self.state.consensus_public_key() {
             error!(
@@ -620,7 +621,7 @@ impl NodeHandler {
         }
 
         for tx in msg.transactions() {
-            self.handle_tx(tx);
+            self.handle_tx(&tx);
         }
     }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -535,7 +535,7 @@ impl NodeHandler {
 
     /// Checks if the transaction is new and adds it to the pool. This may trigger an expedited
     /// `Propose` timeout on this node if transaction count in the pool goes over the threshold.
-    fn handle_tx_inner(&mut self, msg: RawTransaction) -> Result<(), String> {
+    pub fn handle_verified_tx(&mut self, msg: RawTransaction) -> Result<(), String> {
         let hash = msg.hash();
 
         let snapshot = self.blockchain.snapshot();
@@ -588,13 +588,6 @@ impl NodeHandler {
         self.execute_later(InternalRequest::VerifyTx(tx));
     }
 
-    /// Handles an already verified transaction.
-    pub fn handle_verified_tx(&mut self, tx: RawTransaction) {
-        // We don't care about result, because situation when transaction received twice
-        // is normal for internal messages (transaction may be received from 2+ nodes).
-        let _ = self.handle_tx_inner(tx);
-    }
-
     /// Handles raw transactions.
     pub fn handle_txs_batch(&mut self, msg: &TransactionsResponse) {
         if msg.to() != self.state.consensus_public_key() {
@@ -629,7 +622,7 @@ impl NodeHandler {
     #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
     pub fn handle_incoming_tx(&mut self, msg: Box<dyn Transaction>) {
         trace!("Handle incoming transaction");
-        match self.handle_tx_inner(msg.raw().clone()) {
+        match self.handle_verified_tx(msg.raw().clone()) {
             Ok(_) => self.broadcast(msg.raw()),
             Err(e) => error!("{}", e),
         }

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -553,7 +553,7 @@ impl NodeHandler {
             .merge(fork.into_patch())
             .expect("Unable to save transaction to persistent pool.");
 
-        if self.state.round() != Round::zero() && self.state.is_leader() {
+        if self.state.is_leader() && self.state.round() != Round::zero() {
             self.maybe_add_propose_timeout();
         }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -589,7 +589,7 @@ impl NodeHandler {
     }
 
     /// Handles an already verified transaction.
-    pub fn handle_verified_tx(&mut self, tx: &Box<Transaction>) {
+    pub fn handle_verified_tx(&mut self, tx: &Transaction) {
         // We don't care about result, because situation when transaction received twice
         // is normal for internal messages (transaction may be received from 2+ nodes).
         let _ = self.handle_tx_inner(tx.raw().clone());

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -35,7 +35,7 @@ impl NodeHandler {
             InternalEvent::Timeout(timeout) => self.handle_timeout(timeout),
             InternalEvent::JumpToRound(height, round) => self.handle_new_round(height, round),
             InternalEvent::Shutdown => panic!("Shutdown should be processed in the event loop"),
-            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx.as_ref()),
+            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx),
         }
     }
 

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -35,7 +35,7 @@ impl NodeHandler {
             InternalEvent::Timeout(timeout) => self.handle_timeout(timeout),
             InternalEvent::JumpToRound(height, round) => self.handle_new_round(height, round),
             InternalEvent::Shutdown => panic!("Shutdown should be processed in the event loop"),
-            InternalEvent::TxVerified(tx) => self.handle_verified_tx(&tx),
+            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx.as_ref()),
         }
     }
 

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -35,7 +35,11 @@ impl NodeHandler {
             InternalEvent::Timeout(timeout) => self.handle_timeout(timeout),
             InternalEvent::JumpToRound(height, round) => self.handle_new_round(height, round),
             InternalEvent::Shutdown => panic!("Shutdown should be processed in the event loop"),
-            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx),
+            InternalEvent::TxVerified(tx) => {
+                // We don't care about result, because situation when transaction received twice
+                // is normal for internal messages (transaction may be received from 2+ nodes).
+                let _ = self.handle_verified_tx(tx);
+            }
         }
     }
 

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -35,6 +35,7 @@ impl NodeHandler {
             InternalEvent::Timeout(timeout) => self.handle_timeout(timeout),
             InternalEvent::JumpToRound(height, round) => self.handle_new_round(height, round),
             InternalEvent::Shutdown => panic!("Shutdown should be processed in the event loop"),
+            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx),
         }
     }
 

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -35,7 +35,7 @@ impl NodeHandler {
             InternalEvent::Timeout(timeout) => self.handle_timeout(timeout),
             InternalEvent::JumpToRound(height, round) => self.handle_new_round(height, round),
             InternalEvent::Shutdown => panic!("Shutdown should be processed in the event loop"),
-            InternalEvent::TxVerified(tx) => self.handle_verified_tx(tx),
+            InternalEvent::TxVerified(tx) => self.handle_verified_tx(&tx),
         }
     }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -266,6 +266,8 @@ pub struct NodeConfig {
     pub database: DbOptions,
     /// Node's ConnectList.
     pub connect_list: ConnectListConfig,
+    /// Transaction Verification Thread Pool size.
+    pub thread_pool_size: Option<u8>,
 }
 
 /// Configuration for the `NodeHandler`.
@@ -844,6 +846,7 @@ pub struct Node {
     handler: NodeHandler,
     channel: NodeChannel,
     max_message_len: u32,
+    thread_pool_size: Option<u8>,
 }
 
 impl NodeChannel {
@@ -924,6 +927,7 @@ impl Node {
             channel,
             network_config,
             max_message_len: node_cfg.genesis.consensus.max_message_len,
+            thread_pool_size: node_cfg.thread_pool_size,
         }
     }
 
@@ -1042,6 +1046,7 @@ impl Node {
         let timeouts_part = InternalPart {
             internal_tx,
             internal_requests_rx,
+            thread_pool_size: self.thread_pool_size,
         };
         (handler_part, network_part, timeouts_part)
     }

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -112,6 +112,12 @@ impl SandboxInner {
                     InternalRequest::JumpToRound(height, round) => self.handler
                         .handle_event(InternalEvent::JumpToRound(height, round).into()),
                     InternalRequest::Shutdown => unimplemented!(),
+                    InternalRequest::VerifyTx(tx) => {
+                        if tx.verify() {
+                            self.handler
+                                .handle_event(InternalEvent::TxVerified(tx).into());
+                        }
+                    }
                 }
             }
             Ok(())

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -115,7 +115,7 @@ impl SandboxInner {
                     InternalRequest::VerifyTx(tx) => {
                         if tx.verify() {
                             self.handler
-                                .handle_event(InternalEvent::TxVerified(tx).into());
+                                .handle_event(InternalEvent::TxVerified(tx.raw().clone()).into());
                         }
                     }
                 }


### PR DESCRIPTION
### First attempt of parallelizing transaction verification
Note that this is still a prototype in an uncompilable state.

Workflow looks something like this:

1. Thread pool is created at node launch and loaded with a `for_each` future for a pool channel.
2. Transaction is received by the node.
3. `InternalRequest::VerifyTx(tx)` is send asynchronously to verify transaction.
4. Once request has been received by `InternalPart` the transaction is, again asynchronously, sent to the Thread Pool.
5. Once the Thread Pool receives the transaction and successfully verifies it, it composes and sends `InternalEvent::TxVerified` event.
6. Event is handled by `NodeHandler` - adds transaction to the transaction pool.

### New dependency
A new dependency is introduced - `tokio_threadpool`. This a subject of change during the current evolution of the `tokio` and `future` crates.

### Thoughts on its efficiency
While working on this task I found some problems with this approach that make me doubt that parallelization is going to be efficient.
#### Problem 1
Sending a request, sending to thread pool, handling `TxVerified` event - all happen asynchronously in a single thread tokio runtime. Because of this, it seems that a big portion of transaction being in the verification process is spent waiting for these async tasks to get executed by the given runtime. In an ideal world little to no time of the main thread should be spent on waiting on such things. However, I didn't find a way to make that real in the current Exonum's async architecture.
#### Problem 2
If the Thread Pool becomes full, sending a `VerifyTx` request becomes blocking. This means that the main thread will wait roughly T/N (+ synchronization time) where T is the time it takes for tx to get verified and N is number of worker threads in the Thread Pool. This means that there should be at least 2 threads in the Pool.