### PR TITLE
Core private API CORS support [ECR-1261]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
+- Private API now support CORS. (#675)
+
 - The `--allow-origin` parameter has been added to the `finalize` command.
 
 - IPv6 addressing is now supported. (#615)

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -42,7 +42,8 @@ const PEER_ADDRESS: &str = "PEER_ADDRESS";
 const NODE_CONFIG_PATH: &str = "NODE_CONFIG_PATH";
 const PUBLIC_API_ADDRESS: &str = "PUBLIC_API_ADDRESS";
 const PRIVATE_API_ADDRESS: &str = "PRIVATE_API_ADDRESS";
-const ALLOW_ORIGIN: &str = "ALLOW_ORIGIN";
+const PUBLIC_ALLOW_ORIGIN: &str = "PUBLIC_ALLOW_ORIGIN";
+const PRIVATE_ALLOW_ORIGIN: &str = "PRIVATE_ALLOW_ORIGIN";
 
 /// Run command.
 pub struct Run;
@@ -503,8 +504,12 @@ impl Finalize {
         )
     }
 
-    fn allow_origin(context: &Context) -> Option<AllowOrigin> {
-        context.arg(ALLOW_ORIGIN).ok()
+    fn public_allow_origin(context: &Context) -> Option<AllowOrigin> {
+        context.arg(PUBLIC_ALLOW_ORIGIN).ok()
+    }
+
+    fn private_allow_origin(context: &Context) -> Option<AllowOrigin> {
+        context.arg(PRIVATE_ALLOW_ORIGIN).ok()
     }
 }
 
@@ -536,11 +541,19 @@ impl Command for Finalize {
                 false,
             ),
             Argument::new_named(
-                ALLOW_ORIGIN,
+                PUBLIC_ALLOW_ORIGIN,
                 false,
-                "Cross-origin resource sharing options for responses returned by API handlers.",
+                "Cross-origin resource sharing options for responses returned by public API handlers.",
                 None,
-                "allow-origin",
+                "public-allow-origin",
+                false,
+            ),
+            Argument::new_named(
+                PRIVATE_ALLOW_ORIGIN,
+                false,
+                "Cross-origin resource sharing options for responses returned by private API handlers.",
+                None,
+                "private-allow-origin",
                 false,
             ),
             Argument::new_positional("SECRET_CONFIG", true, "Path to our secret config."),
@@ -574,7 +587,8 @@ impl Command for Finalize {
 
         let public_api_address = Run::public_api_address(&context);
         let private_api_address = Run::private_api_address(&context);
-        let allow_origin = Self::allow_origin(&context);
+        let public_allow_origin = Self::public_allow_origin(&context);
+        let private_allow_origin = Self::private_allow_origin(&context);
 
         let secret_config: NodePrivateConfig =
             ConfigFile::load(secret_config_path).expect("Failed to load key config.");
@@ -619,7 +633,8 @@ impl Command for Finalize {
                 api: NodeApiConfig {
                     public_api_address,
                     private_api_address,
-                    allow_origin,
+                    public_allow_origin,
+                    private_allow_origin,
                     ..Default::default()
                 },
                 mempool: Default::default(),

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -872,8 +872,12 @@ impl Node {
         // Start private api.
         if let Some(listen_address) = self.api_options.private_api_address {
             let api_sender = self.channel();
-            let handler =
-                create_private_api_handler(blockchain.clone(), api_state.clone(), api_sender, &self.api_options);
+            let handler = create_private_api_handler(
+                blockchain.clone(),
+                api_state.clone(),
+                api_sender,
+                &self.api_options,
+            );
             let listener = Iron::new(handler).http(listen_address).unwrap();
             api_handlers.push(listener);
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -157,7 +157,7 @@ pub struct NodeApiConfig {
     ///
     /// [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     pub public_allow_origin: Option<AllowOrigin>,
-    /// Cross-origin resource sharing ([CORS][cors]) options for responses returend
+    /// Cross-origin resource sharing ([CORS][cors]) options for responses returned
     /// by private API handlers.
     ///
     /// [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -153,10 +153,15 @@ pub struct NodeApiConfig {
     /// Listen address for private api endpoints.
     pub private_api_address: Option<SocketAddr>,
     /// Cross-origin resource sharing ([CORS][cors]) options for responses returned
-    /// by API handlers.
+    /// by public API handlers.
     ///
     /// [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-    pub allow_origin: Option<AllowOrigin>,
+    pub public_allow_origin: Option<AllowOrigin>,
+    /// Cross-origin resource sharing ([CORS][cors]) options for responses returend
+    /// by private API handlers.
+    ///
+    /// [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    pub private_allow_origin: Option<AllowOrigin>,
 }
 
 impl Default for NodeApiConfig {
@@ -166,7 +171,8 @@ impl Default for NodeApiConfig {
             enable_blockchain_explorer: true,
             public_api_address: None,
             private_api_address: None,
-            allow_origin: None,
+            public_allow_origin: None,
+            private_allow_origin: None,
         }
     }
 }
@@ -975,7 +981,7 @@ pub fn create_public_api_handler(
     mount.mount("api/system", router);
 
     let mut chain = Chain::new(mount);
-    if let Some(ref allow_origin) = config.allow_origin {
+    if let Some(ref allow_origin) = config.public_allow_origin {
         chain.link_around(CorsMiddleware::from(allow_origin.clone()));
     }
     chain
@@ -999,7 +1005,7 @@ pub fn create_private_api_handler(
     mount.mount("api/system", router);
 
     let mut chain = Chain::new(mount);
-    if let Some(ref allow_origin) = config.allow_origin {
+    if let Some(ref allow_origin) = config.private_allow_origin {
         chain.link_around(CorsMiddleware::from(allow_origin.clone()));
     }
     chain

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -94,6 +94,7 @@ impl TestKitApi {
                     blockchain.clone(),
                     api_state,
                     testkit.api_sender.clone(),
+                    &testkit.api_config,
                 );
                 handler.link_after(|req: &mut Request, resp| {
                     log_request(&ApiAccess::Private, req, resp)


### PR DESCRIPTION
Added `CorsMiddleware` to `create_private_api_handler` by `create_public_api_handler`'s example. 
Now method `create_private_api_handler` takes `config: &NodeApiConfig` parameter.
Do this changes are enough to support CORS in private API and do we need to test it and how? 