### PR TITLE
Fixed calculation of max byzantine nodes amount [ECR-1280]

### DIFF
--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -586,7 +586,10 @@ impl State {
             }
             *known_round = round;
         }
-        let max_byzantine_count = self.validators().len() / 3;
+
+        // At max we can have (1/3) - 1 byzantine nodes.
+        // (1/3) is calculated via rounded up integer division.
+        let max_byzantine_count = (self.validators().len() + 2) / 3 - 1;
         if self.validators_rounds.len() <= max_byzantine_count {
             trace!("Count of validators, lower then max byzantine count.");
             return None;


### PR DESCRIPTION
Initial problem: with only 3 nodes started, if two of them gets disconnected and one restores after some time, it can't reach working node round.

The reason: incorrect max byzantine nodes amount calculation. It was calculated as (1/3) of all validators, while it should have been (1/3)-1.

After this fix, reconnected node can reach actual round without any problem.

---

I've tried to write a test for this behavior, but didn't succeed. As far as I can see, sandbox doesn't provide functionality to emulate node disconnect. Is there any way to emulate such a behavior?