### PR TITLE
Fix node round race [ECR-1280]

### DIFF
--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -640,6 +640,7 @@ impl NodeHandler {
 
         info!("Jump to a new round = {}", round);
         self.state.jump_round(round);
+        self.add_round_timeout();
         self.process_new_round();
     }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -63,7 +63,7 @@ impl NodeHandler {
             let round = msg.round();
             self.state.add_queued(msg);
             trace!("Trying to reach actual round.");
-            if let Some(r) = self.state.get_actual_round(validator, round) {
+            if let Some(r) = self.state.update_validator_round(validator, round) {
                 trace!("Scheduling jump to round.");
                 let height = self.state.height();
                 self.execute_later(InternalRequest::JumpToRound(height, r));

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -568,9 +568,10 @@ impl State {
     }
 
     /// Updates known round for a validator and returns
-    /// a new actual round if at least one non byzantine validators are on a higher round.
+    /// a new actual round if at least one non byzantine validators is guaranteed to be on a higher round.
     /// Otherwise returns None.
-    pub fn get_actual_round(&mut self, id: ValidatorId, round: Round) -> Option<Round> {
+    pub fn update_validator_round(&mut self, id: ValidatorId, round: Round) -> Option<Round> {
+        // Update known round.
         {
             let known_round = self.validators_rounds.entry(id).or_insert_with(Round::zero);
             if round <= *known_round {
@@ -587,8 +588,10 @@ impl State {
             *known_round = round;
         }
 
-        // At max we can have (1/3) - 1 byzantine nodes.
-        // (1/3) is calculated via rounded up integer division.
+        // Find highest non-byzantine round.
+
+        // At max we can have (N - 1) / 3 byzantine nodes.
+        // It is calculated via rounded up integer division.
         let max_byzantine_count = (self.validators().len() + 2) / 3 - 1;
         if self.validators_rounds.len() <= max_byzantine_count {
             trace!("Count of validators, lower then max byzantine count.");
@@ -598,7 +601,7 @@ impl State {
         let mut rounds: Vec<_> = self.validators_rounds.iter().map(|(_, v)| v).collect();
         rounds.sort_unstable_by(|a, b| b.cmp(a));
 
-        if rounds[max_byzantine_count] > &self.round {
+        if *rounds[max_byzantine_count] > self.round {
             Some(*rounds[max_byzantine_count])
         } else {
             None


### PR DESCRIPTION
PR #680 didn't solved problem completely, since `add_round_timeout` wasn't called after `jump_to_round`.
This PR fixes it.

Also findings from the previous PR were fixed.