### PR TITLE
Make storage error constructor private (pub crate)

### DIFF
--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -31,7 +31,7 @@ impl Error {
     ///
     /// let error = Error::new("Oh no!");
     /// ```
-    pub fn new<T: Into<String>>(message: T) -> Error {
+    pub(crate) fn new<T: Into<String>>(message: T) -> Error {
         Error {
             message: message.into(),
         }

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -23,14 +23,6 @@ pub struct Error {
 
 impl Error {
     /// Creates a new storage error with an information message about the reason.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exonum::storage::Error;
-    ///
-    /// let error = Error::new("Oh no!");
-    /// ```
     pub(crate) fn new<T: Into<String>>(message: T) -> Error {
         Error {
             message: message.into(),


### PR DESCRIPTION
There is no need for user to construct storage errors. Additionally, we treat such errors specifically during transactions execution and this mechanic can be misused.