### PR TITLE
Fix documentation rendering warning

### DIFF
--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -34,9 +34,9 @@ const DATABASE_PATH: &str = "DATABASE_PATH";
 // Context entry for the type of action to be performed.
 const MAINTENANCE_ACTION_PATH: &str = "MAINTENANCE_ACTION_PATH";
 
-/// Maintenance command.
-/// Supported actions:
-/// * clear-cache - clear message cache.
+/// Maintenance command. Supported actions:
+///
+/// - `clear-cache` - clear message cache.
 pub struct Maintenance;
 
 impl Maintenance {


### PR DESCRIPTION
https://travis-ci.org/exonum/exonum/jobs/380615039
```
WARNING: documentation for this crate may be rendered differently using the new Pulldown renderer.
    See https://github.com/rust-lang/rust/issues/44229 for details.
WARNING: rendering difference in `Maintenance command.`
   --> exonum/src/helpers/fabric/maintenance.rs:40:0
    /html[0]/body[0] One element is missing: expected: `ul`
```