### PR TITLE
Replace constant waiting by message (mpsc)

### DIFF
--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -85,7 +85,7 @@ pub mod contracts {
 }
 
 pub mod service {
-    use exonum::blockchain::{Service, Transaction, TransactionSet};
+    use exonum::blockchain::{Service, Transaction, TransactionSet, ServiceContext, Schema};
     use exonum::{encoding, messages::RawTransaction};
     use exonum::crypto::{gen_keypair, Hash};
     use exonum::storage::{Database, Fork, MemoryDB, Snapshot};
@@ -99,10 +99,20 @@ pub mod service {
     use std::sync::Arc;
     use std::thread;
     use std::time;
+    use std::sync::Mutex;
+    use std::sync::mpsc::{self, Sender};
 
     pub const SERVICE_ID: u16 = 1;
 
-    pub struct BalanceService();
+    pub struct BalanceService {
+        sender: Mutex<Sender<()>>,
+    }
+
+    impl BalanceService {
+        fn new(sender: Sender<()>) -> Self {
+            Self { sender: Mutex::new(sender) }
+        }
+    }
 
     impl Service for BalanceService {
         fn service_id(&self) -> u16 {
@@ -127,6 +137,13 @@ pub mod service {
             schema.balance_mut().set(0);
             Value::Null
         }
+
+        fn handle_commit(&self, context: &ServiceContext) {
+            let core_schema = Schema::new(context.snapshot());
+            if core_schema.block_transactions(context.height()).len() > 0 {
+                self.sender.lock().unwrap().send(()).unwrap();
+            }
+        }
     }
 
     #[test]
@@ -142,7 +159,9 @@ pub mod service {
         node_cfg.genesis.consensus.propose_timeout_threshold = 0;
         node_cfg.genesis.consensus.round_timeout = 40;
 
-        let service = Box::new(BalanceService());
+        let (sender, receiver) = mpsc::channel();
+
+        let service = Box::new(BalanceService::new(sender));
         let node = Node::new(db.clone(), vec![service], node_cfg.clone());
         let api_tx = node.channel();
 
@@ -159,7 +178,7 @@ pub mod service {
         api_tx.send(tx_copy).unwrap();
 
         // Wait to be sure that transaction was processed.
-        thread::sleep(time::Duration::from_millis(200));
+        receiver.recv_timeout(time::Duration::from_secs(10)).unwrap();
 
         // Shut down the node
         api_tx

--- a/exonum/tests/balance_service.rs
+++ b/exonum/tests/balance_service.rs
@@ -85,7 +85,7 @@ pub mod contracts {
 }
 
 pub mod service {
-    use exonum::blockchain::{Service, Transaction, TransactionSet, ServiceContext, Schema};
+    use exonum::blockchain::{Schema, Service, ServiceContext, Transaction, TransactionSet};
     use exonum::{encoding, messages::RawTransaction};
     use exonum::crypto::{gen_keypair, Hash};
     use exonum::storage::{Database, Fork, MemoryDB, Snapshot};
@@ -110,7 +110,9 @@ pub mod service {
 
     impl BalanceService {
         fn new(sender: Sender<()>) -> Self {
-            Self { sender: Mutex::new(sender) }
+            Self {
+                sender: Mutex::new(sender),
+            }
         }
     }
 
@@ -140,7 +142,7 @@ pub mod service {
 
         fn handle_commit(&self, context: &ServiceContext) {
             let core_schema = Schema::new(context.snapshot());
-            if core_schema.block_transactions(context.height()).len() > 0 {
+            if !core_schema.block_transactions(context.height()).is_empty() {
                 self.sender.lock().unwrap().send(()).unwrap();
             }
         }
@@ -178,7 +180,9 @@ pub mod service {
         api_tx.send(tx_copy).unwrap();
 
         // Wait to be sure that transaction was processed.
-        receiver.recv_timeout(time::Duration::from_secs(10)).unwrap();
+        receiver
+            .recv_timeout(time::Duration::from_secs(10))
+            .unwrap();
 
         // Shut down the node
         api_tx


### PR DESCRIPTION
Constant (200ms) timeout has been replaced by (somewhat) smarter behaviour: service signals about transactions processing using `mpsc`.