### PR TITLE
rename `execute` to `execute_before_commit` and `handle_commit` to `after_commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- `handle_commit` method in `Service` trait  has been renamed to `after_commit`. (#715)
+- `handle_commit` method in `Service` trait  has been renamed to 
+  `after_commit`. (#715)
 
 #### exonum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Field`, `CryptoHash`, `StorageValue` and `ExonumJson` traits have been
   implemented for `chrono::Duration` structure. (#653)
 
-- `execute` method has been added in `Service` trait. (#667)
+- `execute_before_commit` method has been added in `Service` trait. (#667) (#709)
 
 - `Field`, `CryptoHash`, `StorageKey`, `StorageValue` and `ExonumJson` traits
   have been implemented for `rust_decimal::Decimal`. (#671)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Field`, `CryptoHash`, `StorageValue` and `ExonumJson` traits have been
   implemented for `chrono::Duration` structure. (#653)
 
-- `execute_before_commit` method has been added in `Service` trait. (#667) (#715)
+- `before_commit` method has been added in `Service` trait. (#667) (#715)
+
+- `handle_commit` method in `Service` trait has been has been renamed to `on_commit`. (#715)
 
 - `Field`, `CryptoHash`, `StorageKey`, `StorageValue` and `ExonumJson` traits
   have been implemented for `rust_decimal::Decimal`. (#671)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- `handle_commit` method in `Service` trait  has been renamed to 
+- `handle_commit` method in `Service` trait  has been renamed to
   `after_commit`. (#715)
 
 #### exonum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Field`, `CryptoHash`, `StorageValue` and `ExonumJson` traits have been
   implemented for `chrono::Duration` structure. (#653)
 
-- `execute_before_commit` method has been added in `Service` trait. (#667) (#709)
+- `execute_before_commit` method has been added in `Service` trait. (#667) (#715)
 
 - `Field`, `CryptoHash`, `StorageKey`, `StorageValue` and `ExonumJson` traits
   have been implemented for `rust_decimal::Decimal`. (#671)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
+- `handle_commit` method in `Service` trait has been has been renamed to `on_commit`. (#715)
+
 #### exonum
 
 - `TimeoutAdjusterConfig` has been removed along with different timeout
@@ -47,8 +49,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   implemented for `chrono::Duration` structure. (#653)
 
 - `before_commit` method has been added in `Service` trait. (#667) (#715)
-
-- `handle_commit` method in `Service` trait has been has been renamed to `on_commit`. (#715)
 
 - `Field`, `CryptoHash`, `StorageKey`, `StorageValue` and `ExonumJson` traits
   have been implemented for `rust_decimal::Decimal`. (#671)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- `handle_commit` method in `Service` trait has been has been renamed to `on_commit`. (#715)
+- `handle_commit` method in `Service` trait has been has been renamed to `after_commit`. (#715)
 
 #### exonum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
-- `handle_commit` method in `Service` trait has been has been renamed to `after_commit`. (#715)
+- `handle_commit` method in `Service` trait  has been renamed to `after_commit`. (#715)
 
 #### exonum
 

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -411,7 +411,7 @@ impl Blockchain {
     }
 
     /// Commits to the blockchain a new block with the indicated changes (patch),
-    /// hash and Precommit messages. After that invokes `on_commit`
+    /// hash and Precommit messages. After that invokes `after_commit`
     /// for each service in the increasing order of their identifiers.
     #[cfg_attr(feature = "flame_profile", flame)]
     pub fn commit<'a, I>(
@@ -450,9 +450,9 @@ impl Blockchain {
             self.api_sender.clone(),
             self.fork(),
         );
-        // Invokes `on_commit` for each service in order of their identifiers
+        // Invokes `after_commit` for each service in order of their identifiers
         for service in self.service_map.values() {
-            service.on_commit(&context);
+            service.after_commit(&context);
         }
         Ok(())
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -411,7 +411,7 @@ impl Blockchain {
     }
 
     /// Commits to the blockchain a new block with the indicated changes (patch),
-    /// hash and Precommit messages. After that invokes `handle_commit`
+    /// hash and Precommit messages. After that invokes `on_commit`
     /// for each service in the increasing order of their identifiers.
     #[cfg_attr(feature = "flame_profile", flame)]
     pub fn commit<'a, I>(
@@ -450,9 +450,9 @@ impl Blockchain {
             self.api_sender.clone(),
             self.fork(),
         );
-        // Invokes `handle_commit` for each service in order of their identifiers
+        // Invokes `on_commit` for each service in order of their identifiers
         for service in self.service_map.values() {
-            service.handle_commit(&context);
+            service.on_commit(&context);
         }
         Ok(())
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -278,7 +278,7 @@ impl Blockchain {
             for service in self.service_map.values() {
                 // Skip execution for genesis block.
                 if height > Height(0) {
-                    service_before_commit(service.as_ref(), &mut fork);
+                    before_commit(service.as_ref(), &mut fork);
                 }
             }
 
@@ -552,11 +552,9 @@ impl Blockchain {
     }
 }
 
-fn service_before_commit(service: &Service, fork: &mut Fork) {
+fn before_commit(service: &Service, fork: &mut Fork) {
     fork.checkpoint();
-    match panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        service.before_commit(fork)
-    })) {
+    match panic::catch_unwind(panic::AssertUnwindSafe(|| service.before_commit(fork))) {
         Ok(..) => fork.commit(),
         Err(err) => {
             if err.is::<Error>() {

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -278,7 +278,7 @@ impl Blockchain {
             for service in self.service_map.values() {
                 // Skip execution for genesis block.
                 if height > Height(0) {
-                    service_execute_before_commit(service.as_ref(), &mut fork);
+                    service_before_commit(service.as_ref(), &mut fork);
                 }
             }
 
@@ -552,10 +552,10 @@ impl Blockchain {
     }
 }
 
-fn service_execute_before_commit(service: &Service, fork: &mut Fork) {
+fn service_before_commit(service: &Service, fork: &mut Fork) {
     fork.checkpoint();
     match panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        service.execute_before_commit(fork)
+        service.before_commit(fork)
     })) {
         Ok(..) => fork.commit(),
         Err(err) => {
@@ -565,7 +565,7 @@ fn service_execute_before_commit(service: &Service, fork: &mut Fork) {
             }
             fork.rollback();
             error!(
-                "{} service execute_before_commit failed with error: {:?}",
+                "{} service before_commit failed with error: {:?}",
                 service.service_name(),
                 err
             );

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -184,7 +184,7 @@ pub trait Service: Send + Sync + 'static {
     /// `execute` for the service with the smallest ID is invoked first up to the largest one.
     /// Effectively, this means that services should not rely on a particular ordering of
     /// Service::execute invocations.
-    fn execute(&self, fork: &mut Fork) {}
+    fn execute_before_commit(&self, fork: &mut Fork) {}
 
     /// Handles block commit. This handler is invoked for each service after commit of the block.
     /// For example, a service can create one or more transactions if a specific condition

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -180,8 +180,9 @@ pub trait Service: Send + Sync + 'static {
     /// A service execution. This method is invoked for each service after execution
     /// of all transactions in the block but before `handle_commit` handler.
     ///
-    /// The order of invoking `execute` method for every service depends on the service ID.
-    /// `execute` for the service with the smallest ID is invoked first up to the largest one.
+    /// The order of invoking `execute_before_commit` method for every service depends on the
+    /// service ID. `execute_before_commit` for the service with the smallest ID is invoked
+    /// first up to the largest one.
     /// Effectively, this means that services should not rely on a particular ordering of
     /// Service::execute invocations.
     fn execute_before_commit(&self, fork: &mut Fork) {}

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -178,7 +178,7 @@ pub trait Service: Send + Sync + 'static {
     }
 
     /// A service execution. This method is invoked for each service after execution
-    /// of all transactions in the block but before `on_commit` handler.
+    /// of all transactions in the block but before `after_commit` handler.
     ///
     /// The order of invoking `before_commit` method for every service depends on the
     /// service ID. `before_commit` for the service with the smallest ID is invoked
@@ -192,7 +192,7 @@ pub trait Service: Send + Sync + 'static {
     /// has occurred.
     ///
     /// *Try not to perform long operations in this handler*.
-    fn on_commit(&self, context: &ServiceContext) {}
+    fn after_commit(&self, context: &ServiceContext) {}
 
     /// Returns an API handler for public requests. The handler is mounted on
     /// the `/api/services/{service_name}` path at [the public listen address][pub-addr]
@@ -214,7 +214,7 @@ pub trait Service: Send + Sync + 'static {
 }
 
 /// The current node state on which the blockchain is running, or in other words
-/// execution context. This structure is passed to the `on_commit` method
+/// execution context. This structure is passed to the `after_commit` method
 /// of the `Service` trait and is used for the interaction between service
 /// business logic and the current node state.
 #[derive(Debug)]

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -180,12 +180,12 @@ pub trait Service: Send + Sync + 'static {
     /// A service execution. This method is invoked for each service after execution
     /// of all transactions in the block but before `handle_commit` handler.
     ///
-    /// The order of invoking `execute_before_commit` method for every service depends on the
-    /// service ID. `execute_before_commit` for the service with the smallest ID is invoked
+    /// The order of invoking `before_commit` method for every service depends on the
+    /// service ID. `before_commit` for the service with the smallest ID is invoked
     /// first up to the largest one.
     /// Effectively, this means that services should not rely on a particular ordering of
     /// Service::execute invocations.
-    fn execute_before_commit(&self, fork: &mut Fork) {}
+    fn before_commit(&self, fork: &mut Fork) {}
 
     /// Handles block commit. This handler is invoked for each service after commit of the block.
     /// For example, a service can create one or more transactions if a specific condition

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -178,7 +178,7 @@ pub trait Service: Send + Sync + 'static {
     }
 
     /// A service execution. This method is invoked for each service after execution
-    /// of all transactions in the block but before `handle_commit` handler.
+    /// of all transactions in the block but before `on_commit` handler.
     ///
     /// The order of invoking `before_commit` method for every service depends on the
     /// service ID. `before_commit` for the service with the smallest ID is invoked
@@ -192,7 +192,7 @@ pub trait Service: Send + Sync + 'static {
     /// has occurred.
     ///
     /// *Try not to perform long operations in this handler*.
-    fn handle_commit(&self, context: &ServiceContext) {}
+    fn on_commit(&self, context: &ServiceContext) {}
 
     /// Returns an API handler for public requests. The handler is mounted on
     /// the `/api/services/{service_name}` path at [the public listen address][pub-addr]
@@ -214,7 +214,7 @@ pub trait Service: Send + Sync + 'static {
 }
 
 /// The current node state on which the blockchain is running, or in other words
-/// execution context. This structure is passed to the `handle_commit` method
+/// execution context. This structure is passed to the `on_commit` method
 /// of the `Service` trait and is used for the interaction between service
 /// business logic and the current node state.
 #[derive(Debug)]

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -380,7 +380,7 @@ impl Service for ServiceGood {
         unimplemented!()
     }
 
-    fn execute(&self, fork: &mut Fork) {
+    fn execute_before_commit(&self, fork: &mut Fork) {
         let mut index = ListIndex::new(IDX_NAME, fork);
         index.push(1);
     }
@@ -405,7 +405,7 @@ impl Service for ServicePanic {
         unimplemented!()
     }
 
-    fn execute(&self, _fork: &mut Fork) {
+    fn execute_before_commit(&self, _fork: &mut Fork) {
         panic!("42");
     }
 }
@@ -429,7 +429,7 @@ impl Service for ServicePanicStorageError {
         unimplemented!()
     }
 
-    fn execute(&self, _fork: &mut Fork) {
+    fn execute_before_commit(&self, _fork: &mut Fork) {
         panic!(Error::new("42"));
     }
 }

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -380,7 +380,7 @@ impl Service for ServiceGood {
         unimplemented!()
     }
 
-    fn execute_before_commit(&self, fork: &mut Fork) {
+    fn before_commit(&self, fork: &mut Fork) {
         let mut index = ListIndex::new(IDX_NAME, fork);
         index.push(1);
     }
@@ -405,7 +405,7 @@ impl Service for ServicePanic {
         unimplemented!()
     }
 
-    fn execute_before_commit(&self, _fork: &mut Fork) {
+    fn before_commit(&self, _fork: &mut Fork) {
         panic!("42");
     }
 }
@@ -429,7 +429,7 @@ impl Service for ServicePanicStorageError {
         unimplemented!()
     }
 
-    fn execute_before_commit(&self, _fork: &mut Fork) {
+    fn before_commit(&self, _fork: &mut Fork) {
         panic!(Error::new("42"));
     }
 }

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -824,11 +824,11 @@ mod tests {
         }
     }
 
-    struct OnCommitService;
+    struct AfterCommitService;
 
-    impl Service for OnCommitService {
+    impl Service for AfterCommitService {
         fn service_name(&self) -> &str {
-            "on_commit"
+            "after_commit"
         }
 
         fn service_id(&self) -> u16 {
@@ -844,7 +844,7 @@ mod tests {
             Ok(tx.into())
         }
 
-        fn on_commit(&self, context: &ServiceContext) {
+        fn after_commit(&self, context: &ServiceContext) {
             let tx = TxAfterCommit::new_with_height(context.height());
             context.transaction_sender().send(Box::new(tx)).unwrap();
         }
@@ -982,9 +982,9 @@ mod tests {
     }
 
     #[test]
-    fn test_sandbox_service_on_commit() {
+    fn test_sandbox_service_after_commit() {
         let sandbox = sandbox_with_services(vec![
-            Box::new(OnCommitService),
+            Box::new(AfterCommitService),
             Box::new(TimestampingService::new()),
         ]);
         let state = SandboxState::new();

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -824,11 +824,11 @@ mod tests {
         }
     }
 
-    struct HandleCommitService;
+    struct OnCommitService;
 
-    impl Service for HandleCommitService {
+    impl Service for OnCommitService {
         fn service_name(&self) -> &str {
-            "handle_commit"
+            "on_commit"
         }
 
         fn service_id(&self) -> u16 {
@@ -844,7 +844,7 @@ mod tests {
             Ok(tx.into())
         }
 
-        fn handle_commit(&self, context: &ServiceContext) {
+        fn on_commit(&self, context: &ServiceContext) {
             let tx = TxAfterCommit::new_with_height(context.height());
             context.transaction_sender().send(Box::new(tx)).unwrap();
         }
@@ -982,9 +982,9 @@ mod tests {
     }
 
     #[test]
-    fn test_sandbox_service_handle_commit() {
+    fn test_sandbox_service_on_commit() {
         let sandbox = sandbox_with_services(vec![
-            Box::new(HandleCommitService),
+            Box::new(OnCommitService),
             Box::new(TimestampingService::new()),
         ]);
         let state = SandboxState::new();

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -54,7 +54,7 @@ impl Service for CommitWatcherService {
         unreachable!("An unknown transaction received");
     }
 
-    fn on_commit(&self, _context: &ServiceContext) {
+    fn after_commit(&self, _context: &ServiceContext) {
         if let Some(oneshot) = self.0.lock().unwrap().take() {
             oneshot.send(()).unwrap();
         }

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -54,7 +54,7 @@ impl Service for CommitWatcherService {
         unreachable!("An unknown transaction received");
     }
 
-    fn handle_commit(&self, _context: &ServiceContext) {
+    fn on_commit(&self, _context: &ServiceContext) {
         if let Some(oneshot) = self.0.lock().unwrap().take() {
             oneshot.send(()).unwrap();
         }

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -116,7 +116,7 @@ impl Service for TimeService {
     }
 
     /// Creates transaction after commit of the block.
-    fn on_commit(&self, context: &ServiceContext) {
+    fn after_commit(&self, context: &ServiceContext) {
         // The transaction must be created by the validator.
         if context.validator_id().is_none() {
             return;

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -116,7 +116,7 @@ impl Service for TimeService {
     }
 
     /// Creates transaction after commit of the block.
-    fn handle_commit(&self, context: &ServiceContext) {
+    fn on_commit(&self, context: &ServiceContext) {
         // The transaction must be created by the validator.
         if context.validator_id().is_none() {
             return;

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A special service which generates transactions on `on_commit` events.
+//! A special service which generates transactions on `after_commit` events.
 
 use exonum::blockchain::{ExecutionResult, Service, ServiceContext, Transaction, TransactionSet};
 use exonum::crypto::{Hash, Signature};
@@ -43,11 +43,11 @@ impl Transaction for TxAfterCommit {
     }
 }
 
-pub struct OnCommitService;
+pub struct AfterCommitService;
 
-impl Service for OnCommitService {
+impl Service for AfterCommitService {
     fn service_name(&self) -> &str {
-        "on_commit"
+        "after_commit"
     }
 
     fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
@@ -63,7 +63,7 @@ impl Service for OnCommitService {
         Ok(tx.into())
     }
 
-    fn on_commit(&self, context: &ServiceContext) {
+    fn after_commit(&self, context: &ServiceContext) {
         let tx = TxAfterCommit::new_with_signature(context.height(), &Signature::zero());
         context.transaction_sender().send(Box::new(tx)).unwrap();
     }

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A special service which generates transactions on `handle_commit` events.
+//! A special service which generates transactions on `on_commit` events.
 
 use exonum::blockchain::{ExecutionResult, Service, ServiceContext, Transaction, TransactionSet};
 use exonum::crypto::{Hash, Signature};
@@ -43,11 +43,11 @@ impl Transaction for TxAfterCommit {
     }
 }
 
-pub struct HandleCommitService;
+pub struct OnCommitService;
 
-impl Service for HandleCommitService {
+impl Service for OnCommitService {
     fn service_name(&self) -> &str {
-        "handle_commit"
+        "on_commit"
     }
 
     fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
@@ -63,7 +63,7 @@ impl Service for HandleCommitService {
         Ok(tx.into())
     }
 
-    fn handle_commit(&self, context: &ServiceContext) {
+    fn on_commit(&self, context: &ServiceContext) {
         let tx = TxAfterCommit::new_with_signature(context.height(), &Signature::zero());
         context.transaction_sender().send(Box::new(tx)).unwrap();
     }

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -19,7 +19,7 @@ extern crate serde;
 extern crate serde_json;
 
 // HACK: Silent "dead_code" warning.
-pub use hooks::{OnCommitService, TxAfterCommit};
+pub use hooks::{AfterCommitService, TxAfterCommit};
 
 use exonum::crypto::{CryptoHash, Signature};
 use exonum::helpers::Height;
@@ -29,12 +29,12 @@ use exonum_testkit::TestKitBuilder;
 mod hooks;
 
 #[test]
-fn test_on_commit() {
+fn test_after_commit() {
     let mut testkit = TestKitBuilder::validator()
-        .with_service(OnCommitService)
+        .with_service(AfterCommitService)
         .create();
 
-    // Check that `on_commit` invoked on the correct height.
+    // Check that `after_commit` invoked on the correct height.
     for i in 1..5 {
         let block = testkit.create_block();
         if i > 1 {

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -19,7 +19,7 @@ extern crate serde;
 extern crate serde_json;
 
 // HACK: Silent "dead_code" warning.
-pub use hooks::{HandleCommitService, TxAfterCommit};
+pub use hooks::{OnCommitService, TxAfterCommit};
 
 use exonum::crypto::{CryptoHash, Signature};
 use exonum::helpers::Height;
@@ -29,12 +29,12 @@ use exonum_testkit::TestKitBuilder;
 mod hooks;
 
 #[test]
-fn test_handle_commit() {
+fn test_on_commit() {
     let mut testkit = TestKitBuilder::validator()
-        .with_service(HandleCommitService)
+        .with_service(OnCommitService)
         .create();
 
-    // Check that `handle_commit` invoked on the correct height.
+    // Check that `on_commit` invoked on the correct height.
     for i in 1..5 {
         let block = testkit.create_block();
         if i > 1 {


### PR DESCRIPTION
`execute` method name is completely cryptic.