### PR TITLE
API endpoint consensus_enabled returns incorrect consensus status for validator node [ECR-1352]

### DIFF
--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -330,7 +330,10 @@ pub struct ApiNodeState {
 
 impl ApiNodeState {
     fn new() -> ApiNodeState {
-        Self::default()
+        Self {
+            is_enabled: true,
+            ..Default::default()
+        }
     }
 }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -439,8 +439,6 @@ impl NodeHandler {
             system_state.current_time(),
         );
 
-        api_state.set_enabled(true);
-
         NodeHandler {
             blockchain,
             api_state,

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -439,6 +439,8 @@ impl NodeHandler {
             system_state.current_time(),
         );
 
+        let is_enabled = api_state.clone().is_enabled();
+
         NodeHandler {
             blockchain,
             api_state,
@@ -446,7 +448,7 @@ impl NodeHandler {
             state,
             channel: sender,
             peer_discovery: config.peer_discovery,
-            is_enabled: api_state.is_enabled(),
+            is_enabled,
         }
     }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -446,7 +446,7 @@ impl NodeHandler {
             state,
             channel: sender,
             peer_discovery: config.peer_discovery,
-            is_enabled: true,
+            is_enabled: api_state.is_enabled(),
         }
     }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -439,6 +439,8 @@ impl NodeHandler {
             system_state.current_time(),
         );
 
+        api_state.set_enabled(true);
+
         NodeHandler {
             blockchain,
             api_state,


### PR DESCRIPTION
API endpoint `consensus_enabled` returned` false` status at start because `SharedNodeState`'s constructor just calling `Default::default` and setting `is_enabled` by default to `false`.
So we need to set it to true manually or change the constructor.