### PR TITLE
Incorrect logic of "consensus_enabled" endpoint for auditor [ECR-1728]

### DIFF
--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -29,7 +29,7 @@ use crypto::{Hash, PublicKey, SecretKey};
 use encoding::Error as MessageError;
 use helpers::{Height, Milliseconds, ValidatorId};
 use messages::RawTransaction;
-use node::{ApiSender, Node, State, TransactionSend};
+use node::{ApiSender, Node, NodeRole, State, TransactionSend};
 use storage::{Fork, Snapshot};
 
 /// A trait that describes the business logic of a certain service.
@@ -323,7 +323,7 @@ pub struct ApiNodeState {
     // TODO: Update on event? (ECR-1632)
     peers_info: HashMap<SocketAddr, PublicKey>,
     is_enabled: bool,
-    is_validator: bool,
+    node_role: NodeRole,
     majority_count: usize,
     validators: Vec<ValidatorKeys>,
 }
@@ -405,7 +405,10 @@ impl SharedNodeState {
 
         lock.peers_info.clear();
         lock.majority_count = state.majority_count();
-        lock.is_validator = state.is_validator();
+        lock.node_role = match state.validator_id() {
+            Some(validator_id) => NodeRole::Validator(validator_id),
+            None => NodeRole::Auditor,
+        };
         lock.validators = state.validators().to_vec();
 
         for (p, c) in state.peers() {
@@ -426,7 +429,7 @@ impl SharedNodeState {
             })
             .count();
 
-        if lock.is_validator {
+        if lock.node_role.is_validator() {
             // Peers list doesn't include current node address, so we have to increment its length.
             // E.g. if we have 3 items in peers list, it means that we have 4 nodes overall.
             active_validators += 1;
@@ -451,9 +454,9 @@ impl SharedNodeState {
         state.is_enabled = is_enabled;
     }
 
-    pub(crate) fn set_validator(&self, is_validator: bool) {
+    pub(crate) fn set_node_role(&self, role: NodeRole) {
         let mut state = self.state.write().expect("Expected read lock.");
-        state.is_validator = is_validator;
+        state.node_role = role;
     }
 
     /// Returns the value of the `state_update_timeout`.

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -451,6 +451,11 @@ impl SharedNodeState {
         state.is_enabled = is_enabled;
     }
 
+    pub(crate) fn set_validator(&self, is_validator: bool) {
+        let mut state = self.state.write().expect("Expected read lock.");
+        state.is_validator = is_validator;
+    }
+
     /// Returns the value of the `state_update_timeout`.
     pub fn state_update_timeout(&self) -> Milliseconds {
         self.state_update_timeout

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -405,10 +405,7 @@ impl SharedNodeState {
 
         lock.peers_info.clear();
         lock.majority_count = state.majority_count();
-        lock.node_role = match state.validator_id() {
-            Some(validator_id) => NodeRole::Validator(validator_id),
-            None => NodeRole::Auditor,
-        };
+        lock.node_role = NodeRole::new(state.validator_id());
         lock.validators = state.validators().to_vec();
 
         for (p, c) in state.peers() {

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -450,12 +450,12 @@ impl SharedNodeState {
     /// Transfers information to the node that the consensus process on the node
     /// should halt.
     pub fn set_enabled(&self, is_enabled: bool) {
-        let mut state = self.state.write().expect("Expected read lock.");
+        let mut state = self.state.write().expect("Expected write lock.");
         state.is_enabled = is_enabled;
     }
 
     pub(crate) fn set_node_role(&self, role: NodeRole) {
-        let mut state = self.state.write().expect("Expected read lock.");
+        let mut state = self.state.write().expect("Expected write lock.");
         state.node_role = role;
     }
 

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -220,10 +220,7 @@ impl NodeHandler {
     /// Node update internal `ApiState` and `NodeRole`.
     pub fn handle_update_api_state_timeout(&mut self) {
         self.api_state.update_node_state(&self.state);
-        self.node_role = match self.state.validator_id() {
-            Some(validator_id) => NodeRole::Validator(validator_id),
-            None => NodeRole::Auditor,
-        };
+        self.node_role = NodeRole::new(self.state.validator_id());
         self.add_update_api_state_timeout();
     }
 

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -16,7 +16,7 @@ use rand::{self, Rng};
 
 use std::{error::Error, net::SocketAddr};
 
-use super::{NodeHandler, RequestData};
+use super::{NodeHandler, NodeRole, RequestData};
 use helpers::Height;
 use messages::{Any, Connect, Message, PeersRequest, RawMessage, Status};
 
@@ -220,6 +220,10 @@ impl NodeHandler {
     /// Node update internal `ApiState`.
     pub fn handle_update_api_state_timeout(&mut self) {
         self.api_state.update_node_state(&self.state);
+        self.node_role = match self.state.validator_id() {
+            Some(validator_id) => NodeRole::Validator(validator_id),
+            None => NodeRole::Auditor,
+        };
         self.add_update_api_state_timeout();
     }
 

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -217,7 +217,7 @@ impl NodeHandler {
         self.add_peer_exchange_timeout();
     }
     /// Handles `NodeTimeout::UpdateApiState`.
-    /// Node update internal `ApiState`.
+    /// Node update internal `ApiState` and `NodeRole`.
     pub fn handle_update_api_state_timeout(&mut self) {
         self.api_state.update_node_state(&self.state);
         self.node_role = match self.state.validator_id() {

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -77,6 +77,10 @@ impl NodeHandler {
                 self.connect(&address);
             }
             ExternalMessage::Enable(value) => {
+                if !self.is_validator {
+                    error!("Trying to enable auditor node");
+                    return;
+                }
                 let s = if value { "enabled" } else { "disabled" };
                 if self.is_enabled == value {
                     info!("Node is already {}", s);

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -77,7 +77,7 @@ impl NodeHandler {
                 self.connect(&address);
             }
             ExternalMessage::Enable(value) => {
-                if !self.is_validator {
+                if self.node_role.is_auditor() {
                     error!("Trying to enable consensus, but the current node is auditor and cannot affect consensus process");
                     return;
                 }

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -78,7 +78,7 @@ impl NodeHandler {
             }
             ExternalMessage::Enable(value) => {
                 if !self.is_validator {
-                    error!("Trying to enable auditor node");
+                    error!("Trying to enable consensus, but the current node is auditor and cannot affect consensus process");
                     return;
                 }
                 let s = if value { "enabled" } else { "disabled" };

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -126,7 +126,7 @@ pub struct NodeHandler {
     pub peer_discovery: Vec<SocketAddr>,
     /// Does this node participate in the consensus?
     is_enabled: bool,
-    /// Is this node validator?
+    /// Node role.
     node_role: NodeRole,
 }
 
@@ -389,12 +389,12 @@ pub struct NodeSender {
     pub api_requests: SyncSender<ExternalMessage>,
 }
 
-///
+/// Node role.
 #[derive(Debug, Clone)]
 pub enum NodeRole {
-    ///
+    /// Validator node.
     Validator(ValidatorId),
-    ///
+    /// Auditor node.
     Auditor,
 }
 
@@ -405,7 +405,7 @@ impl Default for NodeRole {
 }
 
 impl NodeRole {
-    /// Checks if node is validator
+    /// Checks if node is validator.
     pub fn is_validator(&self) -> bool {
         match self {
             NodeRole::Validator(_) => true,
@@ -413,7 +413,7 @@ impl NodeRole {
         }
     }
 
-    /// Checks if node is auditor
+    /// Checks if node is auditor.
     pub fn is_auditor(&self) -> bool {
         match self {
             NodeRole::Auditor => true,

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -405,7 +405,7 @@ impl Default for NodeRole {
 }
 
 impl NodeRole {
-    /// Constructs new NodeRole by `validator_id`
+    /// Constructs new NodeRole from `validator_id`.
     pub fn new(validator_id: Option<ValidatorId>) -> Self {
         match validator_id {
             Some(validator_id) => NodeRole::Validator(validator_id),

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -446,7 +446,7 @@ impl NodeHandler {
 
         if !is_validator {
             if is_enabled {
-                error!("Provided enabled consensus for auditor node")
+                error!("Consensus is enabled but current node is auditor")
             }
             is_enabled = false;
             api_state.set_enabled(false);

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -126,6 +126,8 @@ pub struct NodeHandler {
     pub peer_discovery: Vec<SocketAddr>,
     /// Does this node participate in the consensus?
     is_enabled: bool,
+    /// Is this node validator?
+    is_validator: bool,
 }
 
 /// Service configuration.
@@ -439,7 +441,18 @@ impl NodeHandler {
             system_state.current_time(),
         );
 
-        let is_enabled = api_state.clone().is_enabled();
+        let mut is_enabled = api_state.clone().is_enabled();
+        let is_validator = validator_id.is_some();
+
+        if !is_validator {
+            if is_enabled {
+                error!("Provided enabled consensus for auditor node")
+            }
+            is_enabled = false;
+            api_state.set_enabled(false);
+        }
+
+        api_state.set_validator(is_validator);
 
         NodeHandler {
             blockchain,
@@ -449,6 +462,7 @@ impl NodeHandler {
             channel: sender,
             peer_discovery: config.peer_discovery,
             is_enabled,
+            is_validator,
         }
     }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -488,7 +488,7 @@ impl NodeHandler {
             api_state.set_enabled(false);
         }
 
-        api_state.set_node_role(node_role   );
+        api_state.set_node_role(node_role);
 
         NodeHandler {
             blockchain,

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -390,7 +390,7 @@ pub struct NodeSender {
 }
 
 /// Node role.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum NodeRole {
     /// Validator node.
     Validator(ValidatorId),
@@ -488,7 +488,7 @@ impl NodeHandler {
             api_state.set_enabled(false);
         }
 
-        api_state.set_node_role(node_role.clone());
+        api_state.set_node_role(node_role   );
 
         NodeHandler {
             blockchain,


### PR DESCRIPTION
Add `is_validator` field in `NodeHandler` struct.
Set `is_enabled` to `false` is node is auditor, and block its changing.
Question: how can we test this functionality?