### PR TITLE
GET {system_base_path}/peers doesn't return list of incoming connections [ECR-1375]

### DIFF
--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -136,10 +136,7 @@ impl SystemApi {
                 .public_key = Some(p);
         }
 
-        let incoming_connections = outgoing_connections
-            .keys()
-            .cloned()
-            .collect();
+        let incoming_connections = outgoing_connections.keys().cloned().collect();
 
         PeersInfo {
             incoming_connections,

--- a/exonum/src/api/private/system.rs
+++ b/exonum/src/api/private/system.rs
@@ -136,8 +136,13 @@ impl SystemApi {
                 .public_key = Some(p);
         }
 
+        let incoming_connections = outgoing_connections
+            .keys()
+            .cloned()
+            .collect();
+
         PeersInfo {
-            incoming_connections: self.shared_api_state.incoming_connections(),
+            incoming_connections,
             outgoing_connections,
         }
     }


### PR DESCRIPTION
Now `incoming_connections` both with `outgoing_connections` not filled with any data at moment of creating `Node`. But we can find this connections in `peers_info()` method of `shared_api_state`. So I just realized incoming connections by example of outgoing ones. In all cases I knew the list of incoming and outgoing connections is the same, so I just copied keys of found `outgoing_connections`.
It's not a perfect solution, but I think we have bug not only in `incoming_connections` but in `outgoing_connections` too. 
But this is different bug.