### PR TITLE
GET {system_base_path}/peers doesn't return list of incoming connections [ECR-1375]

### DIFF
--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -404,12 +404,19 @@ impl SharedNodeState {
         let mut lock = self.state.write().expect("Expected write lock.");
 
         lock.peers_info.clear();
+        lock.incoming_connections.clear();
+        lock.outgoing_connections.clear();
         lock.majority_count = state.majority_count();
         lock.node_role = NodeRole::new(state.validator_id());
         lock.validators = state.validators().to_vec();
 
         for (p, c) in state.peers() {
             lock.peers_info.insert(c.addr(), *p);
+            lock.outgoing_connections.insert(c.addr());
+        }
+
+        for (addr, _) in state.connections() {
+            lock.incoming_connections.insert(*addr);
         }
     }
 

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -415,7 +415,7 @@ impl SharedNodeState {
             lock.outgoing_connections.insert(c.addr());
         }
 
-        for (addr, _) in state.connections() {
+        for addr in state.connections().keys() {
             lock.incoming_connections.insert(*addr);
         }
     }

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -549,7 +549,7 @@ impl State {
         &self.peers
     }
 
-    /// Returns the addresses of known connections with their public keys.
+    /// Returns the addresses of known connections with public keys of its' validators.
     pub fn connections(&self) -> &HashMap<SocketAddr, PublicKey> {
         &self.connections
     }

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -549,6 +549,11 @@ impl State {
         &self.peers
     }
 
+    /// Returns the addresses of known connections with their public keys.
+    pub fn connections(&self) -> &HashMap<SocketAddr, PublicKey> {
+        &self.connections
+    }
+
     /// Returns public key of a validator identified by id.
     pub fn consensus_public_key_of(&self, id: ValidatorId) -> Option<PublicKey> {
         let id: usize = id.into();


### PR DESCRIPTION
Now we updating `incoming/outgoing_connections` in `SharedNodeState::update` together with `peers_info`.