### PR TITLE
Newer (1.27) formatting 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 rust:
   # Feel free to bump this version if you need features of newer Rust.
   # Sync with badge in README.md
-  - 1.27
+  - 1.27.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 rust:
   # Feel free to bump this version if you need features of newer Rust.
   # Sync with badge in README.md
-  - 1.26.1
+  - 1.27
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Docs.rs](https://docs.rs/exonum/badge.svg)](https://docs.rs/exonum)
 [![License: Apache-2.0](https://img.shields.io/github/license/exonum/exonum.svg)](LICENSE.md)
 [![LoC](https://tokei.rs/b1/github/exonum/exonum)](https://github.com/exonum/exonum)
-![rust 1.26.1+ required](https://img.shields.io/badge/rust-1.26.1+-blue.svg?label=Required%20Rust)
+![rust 1.27+ required](https://img.shields.io/badge/rust-1.27+-blue.svg?label=Required%20Rust)
 
 **Community:**
 [![Join the chat at https://gitter.im/exonum/exonum](https://img.shields.io/gitter/room/exonum/exonum.svg?label=Chat)](https://gitter.im/exonum/exonum)

--- a/examples/cryptocurrency-advanced/backend/src/api.rs
+++ b/examples/cryptocurrency-advanced/backend/src/api.rs
@@ -14,12 +14,11 @@
 
 //! Cryptocurrency API.
 
-use exonum::{api::{self, ServiceApiBuilder, ServiceApiState},
-             blockchain::{self, BlockProof, Transaction, TransactionSet},
-             crypto::{Hash, PublicKey},
-             helpers::Height,
-             node::TransactionSend,
-             storage::{ListProof, MapProof}};
+use exonum::{
+    api::{self, ServiceApiBuilder, ServiceApiState},
+    blockchain::{self, BlockProof, Transaction, TransactionSet}, crypto::{Hash, PublicKey},
+    helpers::Height, node::TransactionSend, storage::{ListProof, MapProof},
+};
 
 use transactions::WalletTransactions;
 use wallet::Wallet;

--- a/examples/cryptocurrency-advanced/backend/src/api.rs
+++ b/examples/cryptocurrency-advanced/backend/src/api.rs
@@ -119,7 +119,7 @@ impl CryptocurrencyApi {
         state: &ServiceApiState,
         query: WalletTransactions,
     ) -> api::Result<TransactionResponse> {
-        let transaction: Box<Transaction> = query.into();
+        let transaction: Box<dyn Transaction> = query.into();
         let tx_hash = transaction.hash();
         state.sender().send(transaction)?;
         Ok(TransactionResponse { tx_hash })

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Cryptocurrency implementation example using [exonum](http://exonum.com/).
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
+#![deny(missing_debug_implementations, unsafe_code, bare_trait_objects)]
 
 #[macro_use]
 extern crate exonum;

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -73,6 +73,7 @@ impl Service for CurrencyService {
     }
 }
 
+#[derive(Debug)]
 pub struct ServiceFactory;
 
 impl fabric::ServiceFactory for ServiceFactory {

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Cryptocurrency implementation example using [exonum](http://exonum.com/).
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 #[macro_use]
 extern crate exonum;

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -29,13 +29,11 @@ pub mod schema;
 pub mod transactions;
 pub mod wallet;
 
-use exonum::{api::ServiceApiBuilder,
-             blockchain::{Service, Transaction, TransactionSet},
-             crypto::Hash,
-             encoding::Error as EncodingError,
-             helpers::fabric::{self, Context},
-             messages::RawTransaction,
-             storage::Snapshot};
+use exonum::{
+    api::ServiceApiBuilder, blockchain::{Service, Transaction, TransactionSet}, crypto::Hash,
+    encoding::Error as EncodingError, helpers::fabric::{self, Context}, messages::RawTransaction,
+    storage::Snapshot,
+};
 
 use transactions::WalletTransactions;
 

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Cryptocurrency implementation example using [exonum](http://exonum.com/).
 
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+
 #[macro_use]
 extern crate exonum;
 #[macro_use]

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -59,12 +59,12 @@ impl Service for CurrencyService {
         CRYPTOCURRENCY_SERVICE_ID
     }
 
-    fn state_hash(&self, view: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, view: &dyn Snapshot) -> Vec<Hash> {
         let schema = CurrencySchema::new(view);
         schema.state_hash()
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, EncodingError> {
         WalletTransactions::tx_from_raw(raw).map(Into::into)
     }
 
@@ -80,7 +80,7 @@ impl fabric::ServiceFactory for ServiceFactory {
         SERVICE_NAME
     }
 
-    fn make_service(&mut self, _: &Context) -> Box<Service> {
+    fn make_service(&mut self, _: &Context) -> Box<dyn Service> {
         Box::new(CurrencyService)
     }
 }

--- a/examples/cryptocurrency-advanced/backend/src/schema.rs
+++ b/examples/cryptocurrency-advanced/backend/src/schema.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{crypto::{Hash, PublicKey},
-             storage::{Fork, ProofListIndex, ProofMapIndex, Snapshot}};
+use exonum::{
+    crypto::{Hash, PublicKey}, storage::{Fork, ProofListIndex, ProofMapIndex, Snapshot},
+};
 
 use wallet::Wallet;
 use INITIAL_BALANCE;

--- a/examples/cryptocurrency-advanced/backend/src/schema.rs
+++ b/examples/cryptocurrency-advanced/backend/src/schema.rs
@@ -33,7 +33,7 @@ impl<T> AsMut<T> for CurrencySchema<T> {
 
 impl<T> CurrencySchema<T>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
 {
     /// Constructs schema from the database view.
     pub fn new(view: T) -> Self {

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{blockchain::{ExecutionError, ExecutionResult, Transaction},
-             crypto::{CryptoHash, PublicKey},
-             messages::Message,
-             storage::Fork};
+use exonum::{
+    blockchain::{ExecutionError, ExecutionResult, Transaction}, crypto::{CryptoHash, PublicKey},
+    messages::Message, storage::Fork,
+};
 
 use schema::CurrencySchema;
 use CRYPTOCURRENCY_SERVICE_ID;

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 use exonum::{

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 use exonum::{
     blockchain::{ExecutionError, ExecutionResult, Transaction}, crypto::{CryptoHash, PublicKey},
     messages::Message, storage::Fork,

--- a/examples/cryptocurrency-advanced/backend/tests/api.rs
+++ b/examples/cryptocurrency-advanced/backend/tests/api.rs
@@ -24,15 +24,17 @@ extern crate exonum_testkit;
 #[macro_use]
 extern crate serde_json;
 
-use exonum::{api::node::public::explorer::TransactionQuery,
-             crypto::{self, CryptoHash, Hash, PublicKey, SecretKey}};
+use exonum::{
+    api::node::public::explorer::TransactionQuery,
+    crypto::{self, CryptoHash, Hash, PublicKey, SecretKey},
+};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.
-use cryptocurrency::{api::{WalletInfo, WalletQuery},
-                     transactions::{CreateWallet, Transfer},
-                     wallet::Wallet,
-                     CurrencyService};
+use cryptocurrency::{
+    api::{WalletInfo, WalletQuery}, transactions::{CreateWallet, Transfer}, wallet::Wallet,
+    CurrencyService,
+};
 
 // Imports shared test constants.
 use constants::{ALICE_NAME, BOB_NAME};

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -23,7 +23,7 @@
 //! [docs]: https://exonum.com/doc/get-started/create-service
 //! [readme]: https://github.com/exonum/cryptocurrency#readme
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 #[macro_use]
 extern crate exonum;

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -74,6 +74,7 @@ pub mod schema {
     }
 
     /// Schema of the key-value storage used by the demo cryptocurrency service.
+    #[derive(Debug)]
     pub struct CurrencySchema<T> {
         view: T,
     }
@@ -155,7 +156,7 @@ pub mod transactions {
 /// Contract errors.
 pub mod errors {
     #![allow(bare_trait_objects)]
-    
+
     use exonum::blockchain::ExecutionError;
 
     /// Error codes emitted by `TxCreateWallet` and/or `TxTransfer` transactions during execution.
@@ -284,18 +285,18 @@ pub mod api {
     use transactions::CurrencyTransactions;
 
     /// Public service API description.
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     pub struct CryptocurrencyApi;
 
     /// The structure describes the query parameters for the `get_wallet` endpoint.
-    #[derive(Serialize, Deserialize, Clone, Copy)]
+    #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
     pub struct WalletQuery {
         /// Public key of the queried wallet.
         pub pub_key: PublicKey,
     }
 
     /// The structure returned by the REST API.
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct TransactionResponse {
         /// Hash of the transaction.
         pub tx_hash: Hash,
@@ -397,6 +398,7 @@ pub mod service {
     ///
     /// [`TxCreateWallet`]: ../transactions/struct.TxCreateWallet.html
     /// [`TxTransfer`]: ../transactions/struct.TxTransfer.html
+    #[derive(Debug)]
     pub struct CurrencyService;
 
     impl Service for CurrencyService {
@@ -409,7 +411,10 @@ pub mod service {
         }
 
         // Implement a method to deserialize transactions coming to the node.
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
+        fn tx_from_raw(
+            &self,
+            raw: RawTransaction,
+        ) -> Result<Box<dyn Transaction>, encoding::Error> {
             let tx = CurrencyTransactions::tx_from_raw(raw)?;
             Ok(tx.into())
         }

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -155,6 +155,8 @@ pub mod transactions {
 
 /// Contract errors.
 pub mod errors {
+    // Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+    // ECR-1771 for the details.
     #![allow(bare_trait_objects)]
 
     use exonum::blockchain::ExecutionError;

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -23,7 +23,7 @@
 //! [docs]: https://exonum.com/doc/get-started/create-service
 //! [readme]: https://github.com/exonum/cryptocurrency#readme
 
-#![deny(missing_docs)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
 
 #[macro_use]
 extern crate exonum;

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -36,8 +36,9 @@ extern crate serde_json;
 
 /// Persistent data.
 pub mod schema {
-    use exonum::{crypto::PublicKey,
-                 storage::{Fork, MapIndex, Snapshot}};
+    use exonum::{
+        crypto::PublicKey, storage::{Fork, MapIndex, Snapshot},
+    };
 
     // Declare the data to be stored in the blockchain, namely wallets with balances.
     // See [serialization docs][1] for details.
@@ -194,9 +195,9 @@ pub mod errors {
 
 /// Contracts.
 pub mod contracts {
-    use exonum::{blockchain::{ExecutionResult, Transaction},
-                 messages::Message,
-                 storage::Fork};
+    use exonum::{
+        blockchain::{ExecutionResult, Transaction}, messages::Message, storage::Fork,
+    };
 
     use errors::Error;
     use schema::{CurrencySchema, Wallet};
@@ -272,10 +273,10 @@ pub mod contracts {
 
 /// REST API.
 pub mod api {
-    use exonum::{api::{self, ServiceApiBuilder, ServiceApiState},
-                 blockchain::Transaction,
-                 crypto::{Hash, PublicKey},
-                 node::TransactionSend};
+    use exonum::{
+        api::{self, ServiceApiBuilder, ServiceApiState}, blockchain::Transaction,
+        crypto::{Hash, PublicKey}, node::TransactionSend,
+    };
 
     use schema::{CurrencySchema, Wallet};
     use transactions::CurrencyTransactions;
@@ -345,12 +346,10 @@ pub mod api {
 
 /// Service declaration.
 pub mod service {
-    use exonum::{api::ServiceApiBuilder,
-                 blockchain::{Service, Transaction, TransactionSet},
-                 crypto::Hash,
-                 encoding,
-                 messages::RawTransaction,
-                 storage::Snapshot};
+    use exonum::{
+        api::ServiceApiBuilder, blockchain::{Service, Transaction, TransactionSet}, crypto::Hash,
+        encoding, messages::RawTransaction, storage::Snapshot,
+    };
 
     use api::CryptocurrencyApi;
     use transactions::CurrencyTransactions;

--- a/examples/cryptocurrency/tests/api.rs
+++ b/examples/cryptocurrency/tests/api.rs
@@ -26,8 +26,10 @@ extern crate exonum_testkit;
 #[macro_use]
 extern crate serde_json;
 
-use exonum::{api::{self, node::public::explorer::TransactionQuery},
-             crypto::{self, CryptoHash, Hash, PublicKey, SecretKey}};
+use exonum::{
+    api::{self, node::public::explorer::TransactionQuery},
+    crypto::{self, CryptoHash, Hash, PublicKey, SecretKey},
+};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.

--- a/examples/cryptocurrency/tests/tx_logic.rs
+++ b/examples/cryptocurrency/tests/tx_logic.rs
@@ -29,9 +29,10 @@ use exonum::crypto::{self, PublicKey, SecretKey};
 use exonum_testkit::{TestKit, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.
-use cryptocurrency::{schema::{CurrencySchema, Wallet},
-                     service::CurrencyService,
-                     transactions::{TxCreateWallet, TxTransfer}};
+use cryptocurrency::{
+    schema::{CurrencySchema, Wallet}, service::CurrencyService,
+    transactions::{TxCreateWallet, TxTransfer},
+};
 
 // Imports shared test constants.
 use constants::{ALICE_NAME, BOB_NAME};

--- a/examples/timestamping/backend/src/api.rs
+++ b/examples/timestamping/backend/src/api.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{api::{self, ServiceApiBuilder, ServiceApiState},
-             blockchain::{self, BlockProof},
-             crypto::{CryptoHash, Hash},
-             node::TransactionSend,
-             storage::MapProof};
+use exonum::{
+    api::{self, ServiceApiBuilder, ServiceApiState}, blockchain::{self, BlockProof},
+    crypto::{CryptoHash, Hash}, node::TransactionSend, storage::MapProof,
+};
 
 use schema::{Schema, TimestampEntry};
 use transactions::TxTimestamp;

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -62,12 +62,12 @@ impl blockchain::Service for Service {
         SERVICE_NAME
     }
 
-    fn state_hash(&self, view: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, view: &dyn Snapshot) -> Vec<Hash> {
         let schema = Schema::new(view);
         schema.state_hash()
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, StreamStructError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, StreamStructError> {
         let tx = TimeTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }
@@ -86,7 +86,7 @@ impl fabric::ServiceFactory for ServiceFactory {
         SERVICE_NAME
     }
 
-    fn make_service(&mut self, _: &fabric::Context) -> Box<blockchain::Service> {
+    fn make_service(&mut self, _: &fabric::Context) -> Box<dyn blockchain::Service> {
         Box::new(Service::new())
     }
 }

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 extern crate chrono;
 #[macro_use]

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+
 extern crate chrono;
 #[macro_use]
 extern crate exonum;

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
+#![deny(missing_debug_implementations, unsafe_code, bare_trait_objects)]
 
 extern crate chrono;
 #[macro_use]

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -29,13 +29,11 @@ pub mod api;
 pub mod schema;
 pub mod transactions;
 
-use exonum::{api::ServiceApiBuilder,
-             blockchain::{self, Transaction, TransactionSet},
-             crypto::Hash,
-             encoding::Error as StreamStructError,
-             helpers::fabric,
-             messages::RawTransaction,
-             storage::Snapshot};
+use exonum::{
+    api::ServiceApiBuilder, blockchain::{self, Transaction, TransactionSet}, crypto::Hash,
+    encoding::Error as StreamStructError, helpers::fabric, messages::RawTransaction,
+    storage::Snapshot,
+};
 
 use api::PublicApi;
 use schema::Schema;

--- a/examples/timestamping/backend/src/schema.rs
+++ b/examples/timestamping/backend/src/schema.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use chrono::{DateTime, Utc};
-use exonum::{crypto::Hash,
-             storage::{Fork, ProofMapIndex, Snapshot}};
+use exonum::{
+    crypto::Hash, storage::{Fork, ProofMapIndex, Snapshot},
+};
 
 encoding_struct! {
     /// Stores content's hash and some metadata about it.

--- a/examples/timestamping/backend/src/schema.rs
+++ b/examples/timestamping/backend/src/schema.rs
@@ -56,7 +56,7 @@ impl<T> Schema<T> {
 
 impl<T> Schema<T>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
 {
     pub fn timestamps(&self) -> ProofMapIndex<&T, Hash, TimestampEntry> {
         ProofMapIndex::new("timestamping.timestamps", &self.view)

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -15,10 +15,10 @@
 // Suppress a warning in `transactions!` macro call:
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
 
-use exonum::{blockchain::{ExecutionError, ExecutionResult, Transaction},
-             crypto::{CryptoHash, PublicKey},
-             messages::Message,
-             storage::Fork};
+use exonum::{
+    blockchain::{ExecutionError, ExecutionResult, Transaction}, crypto::{CryptoHash, PublicKey},
+    messages::Message, storage::Fork,
+};
 use exonum_time::schema::TimeSchema;
 
 use schema::{Schema, Timestamp, TimestampEntry};

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
 // Suppress a warning in `transactions!` macro call:
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
 

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 // Suppress a warning in `transactions!` macro call:
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]

--- a/examples/timestamping/backend/tests/api.rs
+++ b/examples/timestamping/backend/tests/api.rs
@@ -22,19 +22,18 @@ extern crate exonum;
 extern crate exonum_time;
 extern crate exonum_timestamping;
 
-use exonum::{api::node::public::explorer::TransactionQuery,
-             blockchain::Transaction,
-             crypto::{gen_keypair, hash, CryptoHash, Hash},
-             helpers::Height};
+use exonum::{
+    api::node::public::explorer::TransactionQuery, blockchain::Transaction,
+    crypto::{gen_keypair, hash, CryptoHash, Hash}, helpers::Height,
+};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 use exonum_time::{time_provider::MockTimeProvider, TimeService};
 
 use std::time::SystemTime;
 
-use exonum_timestamping::{api::TimestampQuery,
-                          schema::{Timestamp, TimestampEntry},
-                          transactions::TxTimestamp,
-                          Service};
+use exonum_timestamping::{
+    api::TimestampQuery, schema::{Timestamp, TimestampEntry}, transactions::TxTimestamp, Service,
+};
 
 fn init_testkit() -> (TestKit, MockTimeProvider) {
     let mock_provider = MockTimeProvider::new(SystemTime::now().into());

--- a/exonum/README.md
+++ b/exonum/README.md
@@ -4,7 +4,7 @@
 ![CircleCI Build Status](https://img.shields.io/circleci/project/github/exonum/exonum.svg?label=MacOS%20Build)
 [![Docs.rs](https://docs.rs/exonum/badge.svg)](https://docs.rs/exonum)
 [![License: Apache-2.0](https://img.shields.io/github/license/exonum/exonum.svg)](https://github.com/exonum/exonum/blob/master/LICENSE)
-![rust 1.26.1+ required](https://img.shields.io/badge/rust-1.26.1+-blue.svg?label=Required%20Rust)
+![rust 1.27+ required](https://img.shields.io/badge/rust-1.27+-blue.svg?label=Required%20Rust)
 
 [Exonum](https://exonum.com/) is an extensible open-source framework for
 creating blockchain applications. Exonum can be used to create cryptographically

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use criterion::{Benchmark, Criterion};
-use exonum::{blockchain::{Blockchain, ExecutionResult, Schema, Service, Transaction},
-             crypto::{gen_keypair, CryptoHash, Hash, PublicKey, SecretKey},
-             encoding::Error as EncodingError,
-             helpers::{Height, ValidatorId},
-             messages::{Message, RawTransaction},
-             node::ApiSender,
-             storage::{Database, DbOptions, Fork, Patch, ProofMapIndex, RocksDB, Snapshot}};
+use exonum::{
+    blockchain::{Blockchain, ExecutionResult, Schema, Service, Transaction},
+    crypto::{gen_keypair, CryptoHash, Hash, PublicKey, SecretKey},
+    encoding::Error as EncodingError, helpers::{Height, ValidatorId},
+    messages::{Message, RawTransaction}, node::ApiSender,
+    storage::{Database, DbOptions, Fork, Patch, ProofMapIndex, RocksDB, Snapshot},
+};
 use futures::sync::mpsc;
 use tempdir::TempDir;
 

--- a/exonum/benches/criterion/crypto.rs
+++ b/exonum/benches/criterion/crypto.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{AxisScale, Bencher, Criterion, ParameterizedBenchmark, PlotConfiguration,
-                Throughput};
+use criterion::{
+    AxisScale, Bencher, Criterion, ParameterizedBenchmark, PlotConfiguration, Throughput,
+};
 use exonum::crypto::{gen_keypair, hash, sign, verify};
 use num::pow::pow;
 

--- a/exonum/benches/criterion/storage.rs
+++ b/exonum/benches/criterion/storage.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use criterion::{Bencher, Criterion};
-use exonum::storage::{proof_map_index::PROOF_MAP_KEY_SIZE as KEY_SIZE, Database, DbOptions,
-                      ProofListIndex, ProofMapIndex, RocksDB};
+use exonum::storage::{
+    proof_map_index::PROOF_MAP_KEY_SIZE as KEY_SIZE, Database, DbOptions, ProofListIndex,
+    ProofMapIndex, RocksDB,
+};
 use rand::{Rng, SeedableRng, XorShiftRng};
 use tempdir::TempDir;
 

--- a/exonum/examples/explorer.rs
+++ b/exonum/examples/explorer.rs
@@ -19,10 +19,10 @@ extern crate exonum;
 #[macro_use]
 extern crate serde_json;
 
-use exonum::{blockchain::{Blockchain, Schema, Transaction, TransactionError},
-             crypto,
-             explorer::*,
-             helpers::{Height, ValidatorId}};
+use exonum::{
+    blockchain::{Blockchain, Schema, Transaction, TransactionError}, crypto, explorer::*,
+    helpers::{Height, ValidatorId},
+};
 
 use blockchain::{consensus_keys, create_block, create_blockchain, CreateWallet, Transfer};
 

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -41,11 +41,11 @@ pub type FutureResponse = actix_web::FutureResponse<HttpResponse, actix_web::Err
 /// Type alias for the concrete `actix-web` HTTP request.
 pub type HttpRequest = actix_web::HttpRequest<ServiceApiState>;
 /// Type alias for the inner `actix-web` HTTP requests handler.
-pub type RawHandler = Fn(HttpRequest) -> FutureResponse + 'static + Send + Sync;
+pub type RawHandler = dyn Fn(HttpRequest) -> FutureResponse + 'static + Send + Sync;
 /// Type alias for the `actix-web::App` with the ServiceApiState.
 pub type App = actix_web::App<ServiceApiState>;
 /// Type alias for the `actix-web::App` configuration.
-pub type AppConfig = Arc<Fn(App) -> App + 'static + Send + Sync>;
+pub type AppConfig = Arc<dyn Fn(App) -> App + 'static + Send + Sync>;
 
 /// Type alias for the `actix-web` HTTP server runtime address.
 type HttpServerAddr = Addr<Syn, HttpServer<<App as IntoHttpHandler>::Handler>>;

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -17,30 +17,24 @@
 pub use actix_web::middleware::cors::Cors;
 
 use actix::{msgs::SystemExit, Addr, Arbiter, Syn, System};
-use actix_web::{self,
-                error::ResponseError,
-                server::{HttpServer, IntoHttpHandler, StopServer},
-                AsyncResponder,
-                FromRequest,
-                HttpMessage,
-                HttpResponse,
-                Query};
+use actix_web::{
+    self, error::ResponseError, server::{HttpServer, IntoHttpHandler, StopServer}, AsyncResponder,
+    FromRequest, HttpMessage, HttpResponse, Query,
+};
 use failure;
 use futures::{Future, IntoFuture};
-use serde::{de::{self, DeserializeOwned},
-            ser,
-            Serialize};
+use serde::{
+    de::{self, DeserializeOwned}, ser, Serialize,
+};
 
-use std::{fmt,
-          net::SocketAddr,
-          result,
-          str::FromStr,
-          sync::{mpsc, Arc},
-          thread::{self, JoinHandle}};
+use std::{
+    fmt, net::SocketAddr, result, str::FromStr, sync::{mpsc, Arc}, thread::{self, JoinHandle},
+};
 
-use api::{error::Error as ApiError, ApiAccess, ApiAggregator, ExtendApiBackend, FutureResult,
-          Immutable, Mutable, NamedWith, Result, ServiceApiBackend, ServiceApiScope,
-          ServiceApiState};
+use api::{
+    error::Error as ApiError, ApiAccess, ApiAggregator, ExtendApiBackend, FutureResult, Immutable,
+    Mutable, NamedWith, Result, ServiceApiBackend, ServiceApiScope, ServiceApiState,
+};
 
 /// Type alias for the concrete `actix-web` HTTP response.
 pub type FutureResponse = actix_web::FutureResponse<HttpResponse, actix_web::Error>;

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 //! Error module.
 
 use std::{error, io};
@@ -19,7 +21,6 @@ use std::{error, io};
 use storage;
 
 /// List of possible API errors.
-#[allow(bare_trait_objects)]
 #[derive(Fail, Debug)]
 pub enum Error {
     /// Storage error.

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -14,7 +14,7 @@
 
 //! Error module.
 
-use std::{io, error};
+use std::{error, io};
 
 use storage;
 

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 //! Error module.

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -14,7 +14,7 @@
 
 //! Error module.
 
-use std::io;
+use std::{io, error};
 
 use storage;
 
@@ -27,7 +27,7 @@ pub enum Error {
 
     /// Input/output error.
     #[fail(display = "IO error: {}", _0)]
-    Io(#[cause] ::std::io::Error),
+    Io(#[cause] io::Error),
 
     /// Bad request.
     #[fail(display = "Bad request: {}", _0)]
@@ -39,7 +39,7 @@ pub enum Error {
 
     /// Internal error.
     #[fail(display = "Internal server error: {}", _0)]
-    InternalError(Box<::std::error::Error + Send + Sync>),
+    InternalError(Box<dyn error::Error + Send + Sync>),
 
     /// Unauthorized error.
     #[fail(display = "Unauthorized")]

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -19,6 +19,7 @@ use std::{error, io};
 use storage;
 
 /// List of possible API errors.
+#[allow(bare_trait_objects)]
 #[derive(Fail, Debug)]
 pub enum Error {
     /// Storage error.
@@ -39,7 +40,7 @@ pub enum Error {
 
     /// Internal error.
     #[fail(display = "Internal server error: {}", _0)]
-    InternalError(Box<dyn error::Error + Send + Sync>),
+    InternalError(Box<error::Error + Send + Sync>),
 
     /// Unauthorized error.
     #[fail(display = "Unauthorized")]

--- a/exonum/src/api/node/private/mod.rs
+++ b/exonum/src/api/node/private/mod.rs
@@ -46,7 +46,7 @@ impl NodeInfo {
     /// Creates new `NodeInfo` from services list.
     pub fn new<'a, I>(services: I) -> Self
     where
-        I: IntoIterator<Item = &'a Box<Service>>,
+        I: IntoIterator<Item = &'a Box<dyn Service>>,
     {
         let core_version = option_env!("CARGO_PKG_VERSION").map(|ver| ver.to_owned());
         NodeInfo {

--- a/exonum/src/api/state.rs
+++ b/exonum/src/api/state.rs
@@ -35,7 +35,7 @@ impl ServiceApiState {
     }
 
     /// Creates a read-only snapshot of the current blockchain state.
-    pub fn snapshot(&self) -> Box<Snapshot> {
+    pub fn snapshot(&self) -> Box<dyn Snapshot> {
         self.blockchain.snapshot()
     }
 

--- a/exonum/src/api/with.rs
+++ b/exonum/src/api/with.rs
@@ -21,7 +21,7 @@ use super::{error, ServiceApiState};
 /// Type alias for the usual synchronous result.
 pub type Result<I> = ::std::result::Result<I, error::Error>;
 /// Type alias for the asynchronous result that will be ready in the future.
-pub type FutureResult<I> = Box<Future<Item = I, Error = error::Error>>;
+pub type FutureResult<I> = Box<dyn Future<Item = I, Error = error::Error>>;
 
 /// API endpoint handler extractor which can extract handler from various entities.
 /// The basic idea of this structure is to extract type parameters from the given handler,

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -74,17 +74,17 @@ mod tests;
 /// Only nodes with an identical set of services and genesis block can be combined
 /// into a single network.
 pub struct Blockchain {
-    db: Arc<Database>,
-    service_map: Arc<VecMap<Box<Service>>>,
+    db: Arc<dyn Database>,
+    service_map: Arc<VecMap<Box<dyn Service>>>,
     pub(crate) service_keypair: (PublicKey, SecretKey),
     pub(crate) api_sender: ApiSender,
 }
 
 impl Blockchain {
     /// Constructs a blockchain for the given `storage` and list of `services`.
-    pub fn new<D: Into<Arc<Database>>>(
+    pub fn new<D: Into<Arc<dyn Database>>>(
         storage: D,
-        services: Vec<Box<Service>>,
+        services: Vec<Box<dyn Service>>,
         service_public_key: PublicKey,
         service_secret_key: SecretKey,
         api_sender: ApiSender,
@@ -121,12 +121,12 @@ impl Blockchain {
     /// Returns the `VecMap` for all services. This is a map which
     /// contains service identifiers and service interfaces. The VecMap
     /// allows proceeding from the service identifier to the service itself.
-    pub fn service_map(&self) -> &Arc<VecMap<Box<Service>>> {
+    pub fn service_map(&self) -> &Arc<VecMap<Box<dyn Service>>> {
         &self.service_map
     }
 
     /// Creates a read-only snapshot of the current storage state.
-    pub fn snapshot(&self) -> Box<Snapshot> {
+    pub fn snapshot(&self) -> Box<dyn Snapshot> {
         self.db.snapshot()
     }
 
@@ -533,7 +533,7 @@ impl Blockchain {
     }
 }
 
-fn before_commit(service: &Service, fork: &mut Fork) {
+fn before_commit(service: dyn Service, fork: &mut Fork) {
     fork.checkpoint();
     match panic::catch_unwind(panic::AssertUnwindSafe(|| service.before_commit(fork))) {
         Ok(..) => fork.commit(),

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -142,7 +142,7 @@ impl Blockchain {
     ///
     /// - Blockchain has a service with the `service_id` of the given raw message.
     /// - Service can deserialize the given raw message.
-    pub fn tx_from_raw(&self, raw: RawMessage) -> Result<Box<Transaction>, MessageError> {
+    pub fn tx_from_raw(&self, raw: RawMessage) -> Result<Box<dyn Transaction>, MessageError> {
         let id = raw.service_id() as usize;
         let service = self.service_map
             .get(id)
@@ -533,7 +533,7 @@ impl Blockchain {
     }
 }
 
-fn before_commit(service: dyn Service, fork: &mut Fork) {
+fn before_commit(service: &dyn Service, fork: &mut Fork) {
     fork.checkpoint();
     match panic::catch_unwind(panic::AssertUnwindSafe(|| service.before_commit(fork))) {
         Ok(..) => fork.commit(),

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -32,13 +32,15 @@
 //! [`Service`]: ./trait.Service.html
 //! [doc:create-service]: https://exonum.com/doc/get-started/create-service
 
-pub use self::{block::{Block, BlockProof, SCHEMA_MAJOR_VERSION},
-               config::{ConsensusConfig, StoredConfiguration, ValidatorKeys},
-               genesis::GenesisConfig,
-               schema::{Schema, TxLocation},
-               service::{Service, ServiceContext, SharedNodeState},
-               transaction::{ExecutionError, ExecutionResult, Transaction, TransactionError,
-                             TransactionErrorType, TransactionResult, TransactionSet}};
+pub use self::{
+    block::{Block, BlockProof, SCHEMA_MAJOR_VERSION},
+    config::{ConsensusConfig, StoredConfiguration, ValidatorKeys}, genesis::GenesisConfig,
+    schema::{Schema, TxLocation}, service::{Service, ServiceContext, SharedNodeState},
+    transaction::{
+        ExecutionError, ExecutionResult, Transaction, TransactionError, TransactionErrorType,
+        TransactionResult, TransactionSet,
+    },
+};
 
 pub mod config;
 
@@ -46,14 +48,10 @@ use byteorder::{ByteOrder, LittleEndian};
 use failure;
 use vec_map::VecMap;
 
-use std::{collections::{BTreeMap, HashMap},
-          error::Error as StdError,
-          fmt,
-          iter,
-          mem,
-          net::SocketAddr,
-          panic,
-          sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap}, error::Error as StdError, fmt, iter, mem, net::SocketAddr,
+    panic, sync::Arc,
+};
 
 use crypto::{self, CryptoHash, Hash, PublicKey, SecretKey};
 use encoding::Error as MessageError;

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -427,7 +427,6 @@ impl Blockchain {
     /// Commits to the blockchain a new block with the indicated changes (patch),
     /// hash and Precommit messages. After that invokes `after_commit`
     /// for each service in the increasing order of their identifiers.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn commit<'a, I>(
         &mut self,
         patch: &Patch,

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -16,8 +16,10 @@ use super::{config::StoredConfiguration, Block, BlockProof, Blockchain, Transact
 use crypto::{CryptoHash, Hash, PublicKey};
 use helpers::{Height, Round};
 use messages::{Connect, Precommit, RawMessage};
-use storage::{Entry, Fork, KeySetIndex, ListIndex, MapIndex, MapProof, ProofListIndex,
-              ProofMapIndex, Snapshot};
+use storage::{
+    Entry, Fork, KeySetIndex, ListIndex, MapIndex, MapProof, ProofListIndex, ProofMapIndex,
+    Snapshot,
+};
 
 /// Defines `&str` constants with given name and value.
 macro_rules! define_names {

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -83,7 +83,7 @@ pub struct Schema<T> {
 
 impl<T> Schema<T>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
 {
     /// Constructs information schema for the given `snapshot`.
     pub fn new(snapshot: T) -> Schema<T> {

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -147,7 +147,7 @@ pub trait Service: Send + Sync + 'static {
     ///
     /// [1]: struct.Schema.html#method.state_hash_aggregator
     /// [2]: struct.Blockchain.html#method.service_table_unique_key
-    fn state_hash(&self, snapshot: dyn Snapshot) -> Vec<Hash>;
+    fn state_hash(&self, snapshot: &dyn Snapshot) -> Vec<Hash>;
 
     /// Tries to create a `Transaction` from the given raw message.
     ///
@@ -257,7 +257,7 @@ impl ServiceContext {
 
     /// Returns the current database snapshot. This snapshot is used to
     /// retrieve schema information from the database.
-    pub fn snapshot(&self) -> dyn Snapshot {
+    pub fn snapshot(&self) -> &dyn Snapshot {
         self.fork.as_ref()
     }
 
@@ -287,13 +287,13 @@ impl ServiceContext {
     }
 
     /// Returns service specific global variables as a JSON value.
-    pub fn actual_service_config(&self, service: dyn Service) -> &Value {
+    pub fn actual_service_config(&self, service: &dyn Service) -> &Value {
         &self.stored_configuration.services[service.service_name()]
     }
 
     /// Returns a reference to the transaction sender, which can then be used
     /// to broadcast a transaction to other nodes in the network.
-    pub fn transaction_sender(&self) -> dyn TransactionSend {
+    pub fn transaction_sender(&self) -> &dyn TransactionSend {
         &self.api_sender
     }
 

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -17,9 +17,9 @@
 
 use serde_json::Value;
 
-use std::{collections::{HashMap, HashSet},
-          net::SocketAddr,
-          sync::{Arc, RwLock}};
+use std::{
+    collections::{HashMap, HashSet}, net::SocketAddr, sync::{Arc, RwLock},
+};
 
 use super::transaction::Transaction;
 use api::ServiceApiBuilder;

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -147,7 +147,7 @@ pub trait Service: Send + Sync + 'static {
     ///
     /// [1]: struct.Schema.html#method.state_hash_aggregator
     /// [2]: struct.Blockchain.html#method.service_table_unique_key
-    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash>;
+    fn state_hash(&self, snapshot: dyn Snapshot) -> Vec<Hash>;
 
     /// Tries to create a `Transaction` from the given raw message.
     ///
@@ -167,7 +167,7 @@ pub trait Service: Send + Sync + 'static {
     ///
     /// `transactions!` macro generates code that allows simple implementation, see
     /// [the `Service` example above](#examples).
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError>;
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError>;
 
     /// Initializes the information schema of the service
     /// and generates an initial service configuration.
@@ -257,7 +257,7 @@ impl ServiceContext {
 
     /// Returns the current database snapshot. This snapshot is used to
     /// retrieve schema information from the database.
-    pub fn snapshot(&self) -> &Snapshot {
+    pub fn snapshot(&self) -> dyn Snapshot {
         self.fork.as_ref()
     }
 
@@ -287,13 +287,13 @@ impl ServiceContext {
     }
 
     /// Returns service specific global variables as a JSON value.
-    pub fn actual_service_config(&self, service: &Service) -> &Value {
+    pub fn actual_service_config(&self, service: dyn Service) -> &Value {
         &self.stored_configuration.services[service.service_name()]
     }
 
     /// Returns a reference to the transaction sender, which can then be used
     /// to broadcast a transaction to other nodes in the network.
-    pub fn transaction_sender(&self) -> &TransactionSend {
+    pub fn transaction_sender(&self) -> dyn TransactionSend {
         &self.api_sender
     }
 
@@ -518,8 +518,8 @@ impl SharedNodeState {
     }
 }
 
-impl<'a, S: Service> From<S> for Box<Service + 'a> {
+impl<'a, S: Service> From<S> for Box<dyn Service + 'a> {
     fn from(s: S) -> Self {
-        Box::new(s) as Box<Service>
+        Box::new(s) as Box<dyn Service>
     }
 }

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -39,11 +39,11 @@ impl Service for TestService {
         "test service"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         Ok(Box::new(Tx::from_raw(raw)?))
     }
 }
@@ -372,11 +372,11 @@ impl Service for ServiceGood {
         "some_service"
     }
 
-    fn state_hash(&self, _snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _snapshot: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         unimplemented!()
     }
 
@@ -397,11 +397,11 @@ impl Service for ServicePanic {
         "some_service"
     }
 
-    fn state_hash(&self, _snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _snapshot: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         unimplemented!()
     }
 
@@ -421,11 +421,11 @@ impl Service for ServicePanicStorageError {
         "some_service"
     }
 
-    fn state_hash(&self, _snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _snapshot: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         unimplemented!()
     }
 
@@ -434,7 +434,7 @@ impl Service for ServicePanicStorageError {
     }
 }
 
-fn assert_service_execute(blockchain: &Blockchain, db: &mut Box<Database>) {
+fn assert_service_execute(blockchain: &Blockchain, db: &mut Box<dyn Database>) {
     let (_, patch) = blockchain.create_patch(ValidatorId::zero(), Height(1), &[]);
     db.merge(patch).unwrap();
     let snapshot = db.snapshot();
@@ -443,7 +443,7 @@ fn assert_service_execute(blockchain: &Blockchain, db: &mut Box<Database>) {
     assert_eq!(index.get(0), Some(1));
 }
 
-fn assert_service_execute_panic(blockchain: &Blockchain, db: &mut Box<Database>) {
+fn assert_service_execute_panic(blockchain: &Blockchain, db: &mut Box<dyn Database>) {
     let (_, patch) = blockchain.create_patch(ValidatorId::zero(), Height(1), &[]);
     db.merge(patch).unwrap();
     let snapshot = db.snapshot();
@@ -460,7 +460,7 @@ mod memorydb_tests {
 
     use super::{ServiceGood, ServicePanic, ServicePanicStorageError};
 
-    fn create_database() -> Box<Database> {
+    fn create_database() -> Box<dyn Database> {
         Box::new(MemoryDB::new())
     }
 
@@ -469,14 +469,14 @@ mod memorydb_tests {
         let api_channel = mpsc::channel(1);
         Blockchain::new(
             MemoryDB::new(),
-            vec![Box::new(super::TestService) as Box<Service>],
+            vec![Box::new(super::TestService) as Box<dyn Service>],
             service_keypair.0,
             service_keypair.1,
             ApiSender::new(api_channel.0),
         )
     }
 
-    fn create_blockchain_with_service(service: Box<Service>) -> Blockchain {
+    fn create_blockchain_with_service(service: Box<dyn Service>) -> Blockchain {
         let service_keypair = gen_keypair();
         let api_channel = mpsc::channel(1);
         Blockchain::new(
@@ -535,7 +535,7 @@ mod rocksdb_tests {
 
     use super::{ServiceGood, ServicePanic, ServicePanicStorageError};
 
-    fn create_database(path: &Path) -> Box<Database> {
+    fn create_database(path: &Path) -> Box<dyn Database> {
         let opts = DbOptions::default();
         Box::new(RocksDB::open(path, &opts).unwrap())
     }
@@ -546,14 +546,14 @@ mod rocksdb_tests {
         let api_channel = mpsc::channel(1);
         Blockchain::new(
             db,
-            vec![Box::new(super::TestService) as Box<Service>],
+            vec![Box::new(super::TestService) as Box<dyn Service>],
             service_keypair.0,
             service_keypair.1,
             ApiSender::new(api_channel.0),
         )
     }
 
-    fn create_blockchain_with_service(path: &Path, service: Box<Service>) -> Blockchain {
+    fn create_blockchain_with_service(path: &Path, service: Box<dyn Service>) -> Blockchain {
         let db = create_database(path);
         let service_keypair = gen_keypair();
         let api_channel = mpsc::channel(1);

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -274,7 +274,7 @@ impl TransactionError {
     }
 }
 
-impl<'a, T: Transaction> From<T> for Box<Transaction + 'a> {
+impl<'a, T: Transaction> From<T> for Box<dyn Transaction + 'a> {
     fn from(tx: T) -> Self {
         Box::new(tx) as Box<dyn Transaction>
     }

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -357,7 +357,9 @@ fn status_as_u16(status: &TransactionResult) -> u16 {
 /// `TransactionSet` trait describes a type which is an `enum` of several transactions.
 /// The implementation of this trait is generated automatically by the `transactions!`
 /// macro.
-pub trait TransactionSet: Into<Box<dyn Transaction>> + DeserializeOwned + Serialize + Clone {
+pub trait TransactionSet:
+    Into<Box<dyn Transaction>> + DeserializeOwned + Serialize + Clone
+{
     /// Parses a transaction from this set from a `RawMessage`.
     fn tx_from_raw(raw: RawTransaction) -> Result<Self, encoding::Error>;
 }

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -258,7 +258,7 @@ impl TransactionError {
     }
 
     /// Creates a new `TransactionError` instance from `std::thread::Result`'s `Err`.
-    pub(crate) fn from_panic(panic: &Box<Any + Send>) -> Self {
+    pub(crate) fn from_panic(panic: &Box<dyn Any + Send>) -> Self {
         Self::panic(panic_description(panic))
     }
 
@@ -276,7 +276,7 @@ impl TransactionError {
 
 impl<'a, T: Transaction> From<T> for Box<Transaction + 'a> {
     fn from(tx: T) -> Self {
-        Box::new(tx) as Box<Transaction>
+        Box::new(tx) as Box<dyn Transaction>
     }
 }
 
@@ -357,7 +357,7 @@ fn status_as_u16(status: &TransactionResult) -> u16 {
 /// `TransactionSet` trait describes a type which is an `enum` of several transactions.
 /// The implementation of this trait is generated automatically by the `transactions!`
 /// macro.
-pub trait TransactionSet: Into<Box<Transaction>> + DeserializeOwned + Serialize + Clone {
+pub trait TransactionSet: Into<Box<dyn Transaction>> + DeserializeOwned + Serialize + Clone {
     /// Parses a transaction from this set from a `RawMessage`.
     fn tx_from_raw(raw: RawTransaction) -> Result<Self, encoding::Error>;
 }
@@ -631,12 +631,12 @@ macro_rules! transactions {
 }
 
 /// Tries to get a meaningful description from the given panic.
-fn panic_description(any: &Box<Any + Send>) -> Option<String> {
+fn panic_description(any: &Box<dyn Any + Send>) -> Option<String> {
     if let Some(s) = any.downcast_ref::<&str>() {
         Some(s.to_string())
     } else if let Some(s) = any.downcast_ref::<String>() {
         Some(s.clone())
-    } else if let Some(error) = any.downcast_ref::<Box<Error + Send>>() {
+    } else if let Some(error) = any.downcast_ref::<Box<dyn Error + Send>>() {
         Some(error.description().to_string())
     } else {
         None

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -870,7 +870,10 @@ mod tests {
             vec![]
         }
 
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
+        fn tx_from_raw(
+            &self,
+            raw: RawTransactio
+        ) -> Result<Box<dyn Transaction>, encoding::Error> {
             Ok(Box::new(TxResult::from_raw(raw)?))
         }
     }

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -872,7 +872,7 @@ mod tests {
 
         fn tx_from_raw(
             &self,
-            raw: RawTransactio
+            raw: RawTransaction,
         ) -> Result<Box<dyn Transaction>, encoding::Error> {
             Ok(Box::new(TxResult::from_raw(raw)?))
         }

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -577,8 +577,8 @@ macro_rules! transactions {
             }
         }
 
-        impl Into<Box<$crate::blockchain::Transaction>> for $transaction_set {
-            fn into(self) -> Box<$crate::blockchain::Transaction> {
+        impl Into<Box<dyn $crate::blockchain::Transaction>> for $transaction_set {
+            fn into(self) -> Box<dyn $crate::blockchain::Transaction> {
                 match self {$(
                     $transaction_set::$name(tx) => Box::new(tx),
                 )*}
@@ -827,7 +827,7 @@ mod tests {
 
     #[test]
     fn box_error_panic() {
-        let error: Box<Error + Send> = Box::new("e".parse::<i32>().unwrap_err());
+        let error: Box<dyn Error + Send> = Box::new("e".parse::<i32>().unwrap_err());
         let description = error.description().to_owned();
         let error = make_panic(error);
         assert_eq!(Some(description), panic_description(&error));
@@ -839,7 +839,7 @@ mod tests {
         assert_eq!(None, panic_description(&error));
     }
 
-    fn make_panic<T: Send + 'static>(val: T) -> Box<Any + Send> {
+    fn make_panic<T: Send + 'static>(val: T) -> Box<dyn Any + Send> {
         panic::catch_unwind(panic::AssertUnwindSafe(|| panic!(val))).unwrap_err()
     }
 
@@ -848,7 +848,7 @@ mod tests {
         let api_channel = mpsc::channel(1);
         Blockchain::new(
             MemoryDB::new(),
-            vec![Box::new(TxResultService) as Box<Service>],
+            vec![Box::new(TxResultService) as Box<dyn Service>],
             service_keypair.0,
             service_keypair.1,
             ApiSender::new(api_channel.0),
@@ -866,11 +866,11 @@ mod tests {
             "test service"
         }
 
-        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
             vec![]
         }
 
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {
+        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
             Ok(Box::new(TxResult::from_raw(raw)?))
         }
     }

--- a/exonum/src/crypto/mod.rs
+++ b/exonum/src/crypto/mod.rs
@@ -35,38 +35,42 @@
 //! suited for Exonum.
 
 // spell-checker:disable
-pub use sodiumoxide::crypto::{hash::sha256::DIGESTBYTES as HASH_SIZE,
-                              sign::ed25519::{PUBLICKEYBYTES as PUBLIC_KEY_LENGTH,
-                                              SECRETKEYBYTES as SECRET_KEY_LENGTH,
-                                              SEEDBYTES as SEED_LENGTH,
-                                              SIGNATUREBYTES as SIGNATURE_LENGTH}};
+pub use sodiumoxide::crypto::{
+    hash::sha256::DIGESTBYTES as HASH_SIZE,
+    sign::ed25519::{
+        PUBLICKEYBYTES as PUBLIC_KEY_LENGTH, SECRETKEYBYTES as SECRET_KEY_LENGTH,
+        SEEDBYTES as SEED_LENGTH, SIGNATUREBYTES as SIGNATURE_LENGTH,
+    },
+};
 // spell-checker:enable
 
 use byteorder::{ByteOrder, LittleEndian};
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
-use serde::{de::{self, Deserialize, Deserializer, Visitor},
-            Serialize,
-            Serializer};
-use sodiumoxide::{self,
-                  crypto::{hash::sha256::{hash as hash_sodium, Digest as DigestSodium,
-                                          State as HashState},
-                           sign::ed25519::{gen_keypair as gen_keypair_sodium, keypair_from_seed,
-                                           sign_detached, verify_detached,
-                                           PublicKey as PublicKeySodium,
-                                           SecretKey as SecretKeySodium, Seed as SeedSodium,
-                                           Signature as SignatureSodium, State as SignState}}};
+use serde::{
+    de::{self, Deserialize, Deserializer, Visitor}, Serialize, Serializer,
+};
+use sodiumoxide::{
+    self,
+    crypto::{
+        hash::sha256::{hash as hash_sodium, Digest as DigestSodium, State as HashState},
+        sign::ed25519::{
+            gen_keypair as gen_keypair_sodium, keypair_from_seed, sign_detached, verify_detached,
+            PublicKey as PublicKeySodium, SecretKey as SecretKeySodium, Seed as SeedSodium,
+            Signature as SignatureSodium, State as SignState,
+        },
+    },
+};
 use uuid::Uuid;
 
-use std::{default::Default,
-          fmt,
-          ops::{Index, Range, RangeFrom, RangeFull, RangeTo},
-          str::FromStr,
-          time::{SystemTime, UNIX_EPOCH}};
+use std::{
+    default::Default, fmt, ops::{Index, Range, RangeFrom, RangeFull, RangeTo}, str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use encoding::{serialize::{encode_hex, FromHex, FromHexError, ToHex},
-               Field,
-               Offset};
+use encoding::{
+    serialize::{encode_hex, FromHex, FromHexError, ToHex}, Field, Offset,
+};
 use helpers::Round;
 
 #[macro_use]

--- a/exonum/src/crypto/x25519.rs
+++ b/exonum/src/crypto/x25519.rs
@@ -14,14 +14,14 @@
 
 //! X25519 related types and methods used in Diffie-Hellman key exchange.
 
-use sodiumoxide::crypto::scalarmult::curve25519::{scalarmult as sodium_scalarmult,
-                                                  scalarmult_base as sodium_scalarmult_base,
-                                                  GroupElement as Curve25519GroupElement,
-                                                  Scalar as Curve25519Scalar};
-use sodiumoxide::crypto::sign::ed25519::{convert_ed_keypair_to_curve25519,
-                                         convert_ed_pk_to_curve25519, convert_ed_sk_to_curve25519,
-                                         PublicKey as PublicKeySodium,
-                                         SecretKey as SecretKeySodium};
+use sodiumoxide::crypto::scalarmult::curve25519::{
+    scalarmult as sodium_scalarmult, scalarmult_base as sodium_scalarmult_base,
+    GroupElement as Curve25519GroupElement, Scalar as Curve25519Scalar,
+};
+use sodiumoxide::crypto::sign::ed25519::{
+    convert_ed_keypair_to_curve25519, convert_ed_pk_to_curve25519, convert_ed_sk_to_curve25519,
+    PublicKey as PublicKeySodium, SecretKey as SecretKeySodium,
+};
 
 use std::fmt;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};

--- a/exonum/src/encoding/error.rs
+++ b/exonum/src/encoding/error.rs
@@ -136,7 +136,7 @@ pub enum Error {
     /// Basic error support, for custom fields.
     Basic(Cow<'static, str>),
     /// Other error for custom fields.
-    Other(Box<StdError>),
+    Other(Box<dyn StdError>),
 }
 
 impl fmt::Display for Error {
@@ -171,7 +171,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         use std::ops::Deref;
         if let Error::Other(ref error) = *self {
             Some(error.deref())
@@ -181,8 +181,8 @@ impl StdError for Error {
     }
 }
 
-impl From<Box<StdError>> for Error {
-    fn from(t: Box<StdError>) -> Error {
+impl From<Box<dyn StdError>> for Error {
+    fn from(t: Box<dyn StdError>) -> Error {
         Error::Other(t)
     }
 }

--- a/exonum/src/encoding/fields.rs
+++ b/exonum/src/encoding/fields.rs
@@ -19,9 +19,9 @@ use chrono::{DateTime, Duration, TimeZone, Utc};
 use rust_decimal::Decimal;
 use uuid::{self, Uuid};
 
-use std::{mem,
-          net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-          result::Result as StdResult};
+use std::{
+    mem, net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr}, result::Result as StdResult,
+};
 
 use super::{CheckedOffset, Error, Offset, Result};
 use crypto::{Hash, PublicKey, Signature};

--- a/exonum/src/encoding/float.rs
+++ b/exonum/src/encoding/float.rs
@@ -18,11 +18,10 @@ use serde_json::value::{Number, Value};
 use std::{error::Error, mem};
 
 use super::{Error as EncodingError, Result as EncodingResult};
-use encoding::{serialize::json::{ExonumJson, ExonumJsonDeserialize},
-               serialize::WriteBufferWrapper,
-               CheckedOffset,
-               Field,
-               Offset};
+use encoding::{
+    serialize::json::{ExonumJson, ExonumJsonDeserialize}, serialize::WriteBufferWrapper,
+    CheckedOffset, Field, Offset,
+};
 
 /// Wrapper for the `f32` type that restricts non-finite
 /// (NaN, Infinity, negative zero and subnormal) values.
@@ -239,9 +238,9 @@ impl ExonumJson for F32 {
     }
 
     fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
-        Ok(
-            Value::Number(Number::from_f64(f64::from(self.get())).ok_or("Can't cast float as json")?),
-        )
+        Ok(Value::Number(
+            Number::from_f64(f64::from(self.get())).ok_or("Can't cast float as json")?
+        ))
     }
 }
 
@@ -269,7 +268,9 @@ impl ExonumJson for F64 {
     }
 
     fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
-        Ok(Value::Number(Number::from_f64(self.get()).ok_or("Can't cast float as json")?))
+        Ok(Value::Number(
+            Number::from_f64(self.get()).ok_or("Can't cast float as json")?
+        ))
     }
 }
 

--- a/exonum/src/encoding/mod.rs
+++ b/exonum/src/encoding/mod.rs
@@ -112,8 +112,9 @@ pub use self::{error::Error, fields::Field, segments::SegmentField};
 #[macro_use]
 pub mod serialize;
 
-use std::{convert::From,
-          ops::{Add, Div, Mul, Sub}};
+use std::{
+    convert::From, ops::{Add, Div, Mul, Sub},
+};
 
 mod error;
 #[macro_use]

--- a/exonum/src/encoding/serialize/json.rs
+++ b/exonum/src/encoding/serialize/json.rs
@@ -34,7 +34,7 @@ macro_rules! impl_default_deserialize_owned {
     (@impl $name:ty) => {
         impl $crate::encoding::serialize::json::ExonumJsonDeserialize for $name {
             fn deserialize(value: &$crate::encoding::serialize::json::reexport::Value)
-                -> Result<Self, Box<::std::error::Error>> {
+                -> Result<Self, Box<dyn (::std::error::Error)>> {
                 use $crate::encoding::serialize::json::reexport::from_value;
                 Ok(from_value(value.clone())?)
             }
@@ -56,17 +56,17 @@ pub trait ExonumJson {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>>
+    ) -> Result<(), Box<dyn Error>>
     where
         Self: Sized;
     /// serialize field as `json::Value`
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>>;
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>>;
 }
 
 /// `ExonumJsonDeserialize` is trait for objects that could be constructed from exonum json.
 pub trait ExonumJsonDeserialize {
     /// deserialize `json` value.
-    fn deserialize(value: &Value) -> Result<Self, Box<Error>>
+    fn deserialize(value: &Value) -> Result<Self, Box<dyn Error>>
     where
         Self: Sized;
 }
@@ -91,14 +91,14 @@ macro_rules! impl_deserialize_int {
                                                          buffer: &mut B,
                                                          from: Offset,
                                                          to: Offset)
-                -> Result<(), Box<Error>>
+                -> Result<(), Box<dyn Error>>
             {
                 let number = value.as_i64().ok_or("Can't cast json as integer")?;
                 buffer.write(from, to, number as $typename);
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+            fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
                 Ok(Value::Number((*self).into()))
             }
         }
@@ -113,7 +113,7 @@ macro_rules! impl_deserialize_bigint {
                                                         buffer: & mut B,
                                                         from: Offset,
                                                         to: Offset)
-            -> Result<(), Box<Error>>
+            -> Result<(), Box<dyn Error>>
             {
                 let string = value.as_str().ok_or("Can't cast json as string")?;
                 let val: $typename =  string.parse()?;
@@ -121,7 +121,7 @@ macro_rules! impl_deserialize_bigint {
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+            fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
                 Ok(Value::String(self.to_string()))
             }
         }
@@ -136,7 +136,7 @@ macro_rules! impl_deserialize_hex_segment {
                                                         buffer: & mut B,
                                                         from: Offset,
                                                         to: Offset)
-                -> Result<(), Box<Error>>
+                -> Result<(), Box<dyn Error>>
             {
                 let string = value.as_str().ok_or("Can't cast json as string")?;
                 let val = <$typename as FromHex>:: from_hex(string)?;
@@ -144,7 +144,7 @@ macro_rules! impl_deserialize_hex_segment {
                 Ok(())
             }
 
-            fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+            fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
                 let hex_str = $crate::encoding::serialize::encode_hex(&self[..]);
                 Ok(Value::String(hex_str))
             }
@@ -165,13 +165,13 @@ impl ExonumJson for bool {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let val = value.as_bool().ok_or("Can't cast json as bool")?;
         buffer.write(from, to, val);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(Value::Bool(*self))
     }
 }
@@ -182,13 +182,13 @@ impl<'a> ExonumJson for &'a str {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let val = value.as_str().ok_or("Can't cast json as string")?;
         buffer.write(from, to, val);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(Value::String(self.to_string()))
     }
 }
@@ -199,14 +199,14 @@ impl ExonumJson for DateTime<Utc> {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let helper: TimestampHelper = serde_json::from_value(value.clone())?;
         let date_time = Utc.timestamp(helper.secs.parse()?, helper.nanos);
         buffer.write(from, to, date_time);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let timestamp = TimestampHelper {
             secs: self.timestamp().to_string(),
             nanos: self.timestamp_subsec_nanos(),
@@ -221,7 +221,7 @@ impl ExonumJson for Duration {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let helper: DurationHelper = serde_json::from_value(value.clone())?;
         let seconds = helper.secs.parse()?;
 
@@ -241,7 +241,7 @@ impl ExonumJson for Duration {
         }
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let secs = self.num_seconds();
         let nanos_as_duration = *self - Duration::seconds(secs);
         // Since we're working with only nanos, no overflow is expected here.
@@ -261,13 +261,13 @@ impl ExonumJson for SocketAddr {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let addr: SocketAddr = serde_json::from_value(value.clone())?;
         buffer.write(from, to, addr);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(serde_json::to_value(&self)?)
     }
 }
@@ -278,7 +278,7 @@ impl<'a> ExonumJson for &'a [Hash] {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let arr = value.as_array().ok_or("Can't cast json as array")?;
         let mut vec: Vec<Hash> = Vec::new();
         for el in arr {
@@ -290,7 +290,7 @@ impl<'a> ExonumJson for &'a [Hash] {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let mut vec = Vec::new();
         for hash in self.iter() {
             vec.push(hash.serialize_field()?)
@@ -304,14 +304,14 @@ impl<'a> ExonumJson for &'a [u8] {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let bytes = value.as_str().ok_or("Can't cast json as string")?;
         let arr = <Vec<u8> as FromHex>::from_hex(bytes)?;
         buffer.write(from, to, arr.as_slice());
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(Value::String(::encoding::serialize::encode_hex(self)))
     }
 }
@@ -322,7 +322,7 @@ impl ExonumJson for Vec<RawMessage> {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         use messages::MessageBuffer;
         let bytes = value.as_array().ok_or("Can't cast json as array")?;
         let mut vec: Vec<_> = Vec::new();
@@ -335,7 +335,7 @@ impl ExonumJson for Vec<RawMessage> {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let vec = self.iter()
             .map(|slice| Value::String(::encoding::serialize::encode_hex(slice)))
             .collect();
@@ -348,7 +348,7 @@ where
     T: ExonumJsonDeserialize,
     for<'a> Vec<T>: Field<'a>,
 {
-    fn deserialize(value: &Value) -> Result<Self, Box<Error>> {
+    fn deserialize(value: &Value) -> Result<Self, Box<dyn Error>> {
         let bytes = value.as_array().ok_or("Can't cast json as array")?;
         let mut vec: Vec<_> = Vec::new();
         for el in bytes {
@@ -372,7 +372,7 @@ where
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let bytes = value.as_array().ok_or("Can't cast json as array")?;
         let mut vec: Vec<_> = Vec::new();
         for el in bytes {
@@ -383,7 +383,7 @@ where
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let mut vec = Vec::new();
         for item in self {
             vec.push(item.serialize_field()?);
@@ -398,7 +398,7 @@ impl ExonumJson for BitVec {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let string = value.as_str().ok_or("Can't cast json as string")?;
         let mut vec = BitVec::new();
         for (i, ch) in string.chars().enumerate() {
@@ -415,7 +415,7 @@ impl ExonumJson for BitVec {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let mut out = String::new();
         for i in self.iter() {
             if i {
@@ -435,13 +435,13 @@ impl ExonumJson for Height {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let val: u64 = value.as_str().ok_or("Can't cast json as string")?.parse()?;
         buffer.write(from, to, Height(val));
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let val: u64 = self.to_owned().into();
         Ok(Value::String(val.to_string()))
     }
@@ -453,13 +453,13 @@ impl ExonumJson for Round {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let number = value.as_i64().ok_or("Can't cast json as integer")?;
         buffer.write(from, to, Round(number as u32));
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let val: u32 = self.to_owned().into();
         Ok(Value::Number(val.into()))
     }
@@ -471,13 +471,13 @@ impl ExonumJson for ValidatorId {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let number = value.as_i64().ok_or("Can't cast json as integer")?;
         buffer.write(from, to, ValidatorId(number as u16));
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         let val: u16 = self.to_owned().into();
         Ok(Value::Number(val.into()))
     }
@@ -489,13 +489,13 @@ impl ExonumJson for Uuid {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let uuid: Self = serde_json::from_value(value.clone())?;
         buffer.write(from, to, uuid);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(serde_json::to_value(&self)?)
     }
 }
@@ -506,13 +506,13 @@ impl ExonumJson for Decimal {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>> {
+    ) -> Result<(), Box<dyn Error>> {
         let decimal: Self = serde_json::from_value(value.clone())?;
         buffer.write(from, to, decimal);
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<Value, Box<dyn Error + Send + Sync>> {
         Ok(serde_json::to_value(&self)?)
     }
 }

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -209,7 +209,7 @@ macro_rules! encoding_struct {
             #[allow(unused_mut)]
             fn serialize_field(&self)
                 -> Result<$crate::encoding::serialize::json::reexport::Value,
-                          Box<::std::error::Error + Send + Sync>>
+                          Box<dyn (::std::error::Error) + Send + Sync>>
             {
                 use $crate::encoding::serialize::json::reexport::Value;
                 let mut map = $crate::encoding::serialize::json::reexport::Map::new();

--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -193,7 +193,7 @@ macro_rules! encoding_struct {
                                         buffer: & mut B,
                                         from: $crate::encoding::Offset,
                                         to: $crate::encoding::Offset )
-                -> Result<(), Box<::std::error::Error>>
+                -> Result<(), Box<dyn (::std::error::Error)>>
                 where B: $crate::encoding::serialize::WriteBufferWrapper
             {
                 use $crate::encoding::serialize::json::ExonumJsonDeserialize;
@@ -223,7 +223,7 @@ macro_rules! encoding_struct {
         impl $crate::encoding::serialize::json::ExonumJsonDeserialize for $name {
             #[allow(unused_imports, unused_mut)]
             fn deserialize(value: &$crate::encoding::serialize::json::reexport::Value)
-                -> Result<Self, Box<::std::error::Error>> {
+                -> Result<Self, Box<dyn (::std::error::Error)>> {
                 use $crate::encoding::serialize::json::ExonumJson as ExonumJson;
                 let mut buf = vec![0; $name::__ex_header_size() as usize];
                 let _obj = value.as_object().ok_or("Can't cast json as object.")?;

--- a/exonum/src/encoding/tests.rs
+++ b/exonum/src/encoding/tests.rs
@@ -26,8 +26,9 @@ use super::{CheckedOffset, Field, Offset};
 use blockchain::{self, Block, BlockProof};
 use crypto::{gen_keypair, hash, CryptoHash};
 use helpers::{user_agent, Height, Round, ValidatorId};
-use messages::{BlockRequest, BlockResponse, Connect, Message, Precommit, Prevote, Propose,
-               RawMessage, Status};
+use messages::{
+    BlockRequest, BlockResponse, Connect, Message, Precommit, Prevote, Propose, RawMessage, Status,
+};
 
 static VALIDATOR: ValidatorId = ValidatorId(65_123);
 static HEIGHT: Height = Height(123_123_123);

--- a/exonum/src/events/benches.rs
+++ b/exonum/src/events/benches.rs
@@ -16,8 +16,9 @@ use test::Bencher;
 
 use std::{net::SocketAddr, thread};
 
-use events::{network::NetworkConfiguration,
-             tests::{connect_message, raw_message, TestEvents}};
+use events::{
+    network::NetworkConfiguration, tests::{connect_message, raw_message, TestEvents},
+};
 use node::EventsPoolCapacity;
 
 struct BenchConfig {

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -15,14 +15,13 @@
 use futures::{self, sync::mpsc, Future, Sink, Stream};
 use tokio_core::reactor::{Handle, Timeout};
 
-use std::{io,
-          time::{Duration, SystemTime}};
+use std::{
+    io, time::{Duration, SystemTime},
+};
 
-use super::{error::{into_other, other_error},
-            to_box,
-            InternalEvent,
-            InternalRequest,
-            TimeoutRequest};
+use super::{
+    error::{into_other, other_error}, to_box, InternalEvent, InternalRequest, TimeoutRequest,
+};
 
 #[derive(Debug)]
 pub struct InternalPart {

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -30,7 +30,7 @@ pub struct InternalPart {
 }
 
 impl InternalPart {
-    pub fn run(self, handle: Handle) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn run(self, handle: Handle) -> Box<dyn Future<Item = (), Error = io::Error>> {
         let internal_tx = self.internal_tx.clone();
         let fut = self.internal_requests_rx
             .for_each(move |request| {

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -21,12 +21,9 @@ pub mod internal;
 pub mod network;
 pub mod noise;
 
-use futures::{sink::Wait,
-              sync::mpsc::{self, Sender},
-              Async,
-              Future,
-              Poll,
-              Stream};
+use futures::{
+    sink::Wait, sync::mpsc::{self, Sender}, Async, Future, Poll, Stream,
+};
 
 use std::{cmp::Ordering, time::SystemTime};
 

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -79,7 +79,7 @@ pub struct HandlerPart<H: EventHandler> {
 }
 
 impl<H: EventHandler + 'static> HandlerPart<H> {
-    pub fn run(self) -> Box<Future<Item = (), Error = ()>> {
+    pub fn run(self) -> Box<dyn Future<Item = (), Error = ()>> {
         let mut handler = self.handler;
 
         let fut = EventsAggregator::new(self.internal_rx, self.network_rx, self.api_rx).for_each(
@@ -215,6 +215,6 @@ where
     }
 }
 
-fn to_box<F: Future + 'static>(f: F) -> Box<Future<Item = (), Error = F::Error>> {
+fn to_box<F: Future + 'static>(f: F) -> Box<dyn Future<Item = (), Error = F::Error>> {
     Box::new(f.map(drop))
 }

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -188,7 +188,7 @@ impl ConnectionsPool {
         &self,
         peer: SocketAddr,
         network_tx: mpsc::Sender<NetworkEvent>,
-    ) -> Box<Future<Item = (), Error = io::Error>> {
+    ) -> Box<dyn Future<Item = (), Error = io::Error>> {
         let fut = self.remove(&peer)
             .into_future()
             .map_err(other_error)
@@ -207,7 +207,7 @@ impl NetworkPart {
         self,
         handle: &Handle,
         handshake_params: &HandshakeParams,
-    ) -> Box<Future<Item = (), Error = io::Error>> {
+    ) -> Box<dyn Future<Item = (), Error = io::Error>> {
         let network_config = self.network_config;
         // Cancellation token
         let (cancel_sender, cancel_handler) = unsync::oneshot::channel();
@@ -245,7 +245,7 @@ impl NetworkPart {
 
 struct RequestHandler(
     // TODO: Replace with concrete type. (ECR-1634)
-    Box<Future<Item = (), Error = io::Error>>,
+    Box<dyn Future<Item = (), Error = io::Error>>,
 );
 
 impl RequestHandler {
@@ -335,7 +335,7 @@ impl Future for RequestHandler {
     }
 }
 
-struct Listener(Box<Future<Item = (), Error = io::Error>>);
+struct Listener(Box<dyn Future<Item = (), Error = io::Error>>);
 
 impl Listener {
     fn bind(
@@ -421,7 +421,7 @@ impl Future for Listener {
     }
 }
 
-fn conn_fut<F>(fut: F) -> Box<Future<Item = mpsc::Sender<RawMessage>, Error = io::Error>>
+fn conn_fut<F>(fut: F) -> Box<dyn Future<Item = mpsc::Sender<RawMessage>, Error = io::Error>>
 where
     F: Future<Item = mpsc::Sender<RawMessage>, Error = io::Error> + 'static,
 {

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -13,15 +13,18 @@
 // limitations under the License.
 
 use futures::{future, future::Either, sync::mpsc, unsync, Future, IntoFuture, Poll, Sink, Stream};
-use tokio_core::{net::{TcpListener, TcpStream},
-                 reactor::Handle};
-use tokio_retry::{strategy::{jitter, FixedInterval},
-                  Retry};
+use tokio_core::{
+    net::{TcpListener, TcpStream}, reactor::Handle,
+};
+use tokio_retry::{
+    strategy::{jitter, FixedInterval}, Retry,
+};
 
 use std::{cell::RefCell, collections::HashMap, io, net::SocketAddr, rc::Rc, time::Duration};
 
-use super::{error::{into_other, log_error, other_error, result_ok},
-            to_box};
+use super::{
+    error::{into_other, log_error, other_error, result_ok}, to_box,
+};
 use crypto::PublicKey;
 use events::noise::{Handshake, HandshakeParams, NoiseHandshake};
 use helpers::Milliseconds;

--- a/exonum/src/events/noise/mod.rs
+++ b/exonum/src/events/noise/mod.rs
@@ -33,7 +33,7 @@ pub mod wrapper;
 #[cfg(test)]
 mod tests;
 
-type HandshakeResult<S> = Box<Future<Item = Framed<S, MessagesCodec>, Error = io::Error>>;
+type HandshakeResult<S> = Box<dyn Future<Item = Framed<S, MessagesCodec>, Error = io::Error>>;
 
 #[derive(Debug, Clone)]
 /// Params needed to establish secured connection using Noise Protocol.

--- a/exonum/src/events/noise/mod.rs
+++ b/exonum/src/events/noise/mod.rs
@@ -13,19 +13,19 @@
 // limitations under the License.
 
 use futures::future::{done, Future};
-use tokio_io::{codec::Framed,
-               io::{read_exact, write_all},
-               AsyncRead,
-               AsyncWrite};
+use tokio_io::{
+    codec::Framed, io::{read_exact, write_all}, AsyncRead, AsyncWrite,
+};
 
 use std::io;
 
-use crypto::{x25519::{self, into_x25519_keypair, into_x25519_public_key},
-             PublicKey,
-             SecretKey};
+use crypto::{
+    x25519::{self, into_x25519_keypair, into_x25519_public_key}, PublicKey, SecretKey,
+};
 use events::noise::wrapper::NOISE_MAX_HANDSHAKE_MESSAGE_LENGTH;
-use events::{codec::MessagesCodec,
-             noise::wrapper::{NoiseWrapper, HANDSHAKE_HEADER_LENGTH}};
+use events::{
+    codec::MessagesCodec, noise::wrapper::{NoiseWrapper, HANDSHAKE_HEADER_LENGTH},
+};
 
 pub mod sodium_resolver;
 pub mod wrapper;

--- a/exonum/src/events/noise/sodium_resolver.rs
+++ b/exonum/src/events/noise/sodium_resolver.rs
@@ -101,7 +101,7 @@ impl Dh for SodiumDh25519 {
         self.pubkey = x25519::scalarmult_base(&self.privkey);
     }
 
-    fn generate(&mut self, rng: &mut Random) {
+    fn generate(&mut self, rng: &mut dyn Random) {
         let mut privkey_bytes = [0; x25519::SECRET_KEY_LENGTH];
         rng.fill_bytes(&mut privkey_bytes);
         x25519::convert_to_private_key(&mut privkey_bytes);

--- a/exonum/src/events/noise/sodium_resolver.rs
+++ b/exonum/src/events/noise/sodium_resolver.rs
@@ -8,8 +8,9 @@ use sodiumoxide::crypto::aead::chacha20poly1305 as sodium_chacha20poly1305;
 use sodiumoxide::crypto::hash::sha256 as sodium_sha256;
 
 use crypto::x25519;
-use crypto::{PUBLIC_KEY_LENGTH as SHA256_PUBLIC_KEY_LENGTH,
-             SECRET_KEY_LENGTH as SHA256_SECRET_KEY_LENGTH};
+use crypto::{
+    PUBLIC_KEY_LENGTH as SHA256_PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH as SHA256_SECRET_KEY_LENGTH,
+};
 
 pub struct SodiumResolver {
     parent: DefaultResolver,

--- a/exonum/src/events/noise/sodium_resolver.rs
+++ b/exonum/src/events/noise/sodium_resolver.rs
@@ -25,25 +25,25 @@ impl SodiumResolver {
 }
 
 impl CryptoResolver for SodiumResolver {
-    fn resolve_rng(&self) -> Option<Box<Random + Send>> {
+    fn resolve_rng(&self) -> Option<Box<dyn Random + Send>> {
         Some(Box::new(SodiumRandom::default()))
     }
 
-    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh + Send>> {
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<dyn Dh + Send>> {
         match *choice {
             DHChoice::Curve25519 => Some(Box::new(SodiumDh25519::default())),
             _ => self.parent.resolve_dh(choice),
         }
     }
 
-    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash + Send>> {
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<dyn Hash + Send>> {
         match *choice {
             HashChoice::SHA256 => Some(Box::new(SodiumSha256::default())),
             _ => self.parent.resolve_hash(choice),
         }
     }
 
-    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher + Send>> {
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<dyn Cipher + Send>> {
         match *choice {
             CipherChoice::ChaChaPoly => Some(Box::new(SodiumChaChaPoly::default())),
             _ => self.parent.resolve_cipher(choice),

--- a/exonum/src/events/noise/tests.rs
+++ b/exonum/src/events/noise/tests.rs
@@ -24,8 +24,9 @@ use std::net::SocketAddr;
 use std::thread;
 use std::time::Duration;
 
-use crypto::{gen_keypair, gen_keypair_from_seed, x25519::into_x25519_keypair, Seed,
-             PUBLIC_KEY_LENGTH};
+use crypto::{
+    gen_keypair, gen_keypair_from_seed, x25519::into_x25519_keypair, Seed, PUBLIC_KEY_LENGTH,
+};
 use events::error::into_other;
 use events::noise::{write, Handshake, HandshakeParams, HandshakeResult, NoiseHandshake};
 use tokio_io::{AsyncRead, AsyncWrite};

--- a/exonum/src/events/noise/wrapper.rs
+++ b/exonum/src/events/noise/wrapper.rs
@@ -168,6 +168,7 @@ impl fmt::Debug for NoiseWrapper {
     }
 }
 
+#[allow(bare_trait_objects)]
 #[derive(Fail, Debug, Clone)]
 pub enum NoiseError {
     #[fail(display = "Wrong handshake message length {}", _0)]

--- a/exonum/src/events/noise/wrapper.rs
+++ b/exonum/src/events/noise/wrapper.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::BytesMut;
 use failure;
@@ -168,7 +170,6 @@ impl fmt::Debug for NoiseWrapper {
     }
 }
 
-#[allow(bare_trait_objects)]
 #[derive(Fail, Debug, Clone)]
 pub enum NoiseError {
     #[fail(display = "Wrong handshake message length {}", _0)]

--- a/exonum/src/events/noise/wrapper.rs
+++ b/exonum/src/events/noise/wrapper.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 use byteorder::{ByteOrder, LittleEndian};

--- a/exonum/src/events/noise/wrapper.rs
+++ b/exonum/src/events/noise/wrapper.rs
@@ -17,8 +17,9 @@ use bytes::BytesMut;
 use failure;
 use snow::{NoiseBuilder, Session};
 
-use std::{fmt::{self, Error, Formatter},
-          io};
+use std::{
+    fmt::{self, Error, Formatter}, io,
+};
 
 use events::noise::sodium_resolver::SodiumResolver;
 use events::noise::HandshakeParams;

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -16,17 +16,16 @@ use futures::{stream::Wait, sync::mpsc, Future, Sink, Stream};
 use tokio_core::reactor::Core;
 use tokio_timer::{TimeoutStream, Timer};
 
-use std::{net::SocketAddr,
-          thread,
-          time::{self, Duration}};
+use std::{
+    net::SocketAddr, thread, time::{self, Duration},
+};
 
 use blockchain::ConsensusConfig;
 use crypto::{gen_keypair, gen_keypair_from_seed, PublicKey, Seed, Signature};
-use events::{error::log_error,
-             network::{NetworkConfiguration, NetworkPart},
-             noise::HandshakeParams,
-             NetworkEvent,
-             NetworkRequest};
+use events::{
+    error::log_error, network::{NetworkConfiguration, NetworkPart}, noise::HandshakeParams,
+    NetworkEvent, NetworkRequest,
+};
 use helpers::user_agent;
 use messages::{Connect, Message, MessageWriter, RawMessage};
 use node::{EventsPoolCapacity, NodeChannel};

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -19,14 +19,15 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::{cell::{Ref, RefCell},
-          collections::Bound,
-          fmt,
-          ops::{Index, Range, RangeFrom, RangeFull, RangeTo},
-          slice};
+use std::{
+    cell::{Ref, RefCell}, collections::Bound, fmt,
+    ops::{Index, Range, RangeFrom, RangeFull, RangeTo}, slice,
+};
 
-use blockchain::{Block, Blockchain, Schema, Transaction, TransactionError, TransactionErrorType,
-                 TransactionResult, TxLocation};
+use blockchain::{
+    Block, Blockchain, Schema, Transaction, TransactionError, TransactionErrorType,
+    TransactionResult, TxLocation,
+};
 use crypto::{CryptoHash, Hash};
 use encoding;
 use helpers::Height;

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -35,7 +35,7 @@ use messages::{Precommit, RawMessage};
 use storage::{ListProof, Snapshot};
 
 /// Transaction parsing result.
-type ParseResult = Result<Box<Transaction>, encoding::Error>;
+type ParseResult = Result<Box<dyn Transaction>, encoding::Error>;
 
 /// Range of `Height`s.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -272,7 +272,7 @@ impl<'a, 'r: 'a> IntoIterator for &'r BlockInfo<'a> {
 /// by using `BlockWithTransactions<serde_json::Value>`.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: SerializeContent"))]
-pub struct BlockWithTransactions<T = Box<Transaction>> {
+pub struct BlockWithTransactions<T = Box<dyn Transaction>> {
     /// Block header as recorded in the blockchain.
     #[serde(rename = "block")]
     pub header: Block,
@@ -437,7 +437,7 @@ impl<'a, T> IntoIterator for &'a BlockWithTransactions<T> {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: SerializeContent"))]
-pub struct CommittedTransaction<T = Box<Transaction>> {
+pub struct CommittedTransaction<T = Box<dyn Transaction>> {
     #[serde(serialize_with = "SerializeContent::serialize_content")]
     content: T,
     location: TxLocation,
@@ -608,7 +608,7 @@ impl<T> CommittedTransaction<T> {
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case", bound(serialize = "T: SerializeContent"))]
-pub enum TransactionInfo<T = Box<Transaction>> {
+pub enum TransactionInfo<T = Box<dyn Transaction>> {
     /// Transaction is in the memory pool, but not yet committed to the blockchain.
     InPool {
         /// Transaction contents.
@@ -652,7 +652,7 @@ impl<T: Serialize> SerializeContent for T {
     }
 }
 
-impl SerializeContent for Box<Transaction> {
+impl SerializeContent for Box<dyn Transaction> {
     fn serialize_content<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -710,8 +710,8 @@ impl<T> TransactionInfo<T> {
 ///
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
-    snapshot: Box<Snapshot>,
-    transaction_parser: Box<'a + Fn(RawMessage) -> ParseResult>,
+    snapshot: Box<dyn Snapshot>,
+    transaction_parser: Box<'a + dyn Fn(RawMessage) -> ParseResult>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {
@@ -769,7 +769,7 @@ impl<'a> BlockchainExplorer<'a> {
     fn committed_transaction(
         &self,
         tx_hash: &Hash,
-        maybe_content: Option<Box<Transaction>>,
+        maybe_content: Option<Box<dyn Transaction>>,
     ) -> CommittedTransaction {
         let schema = Schema::new(&self.snapshot);
 

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -711,7 +711,7 @@ impl<T> TransactionInfo<T> {
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
     snapshot: Box<dyn Snapshot>,
-    transaction_parser: Box<'a + dyn Fn(RawMessage) -> ParseResult>,
+    transaction_parser: Box<dyn dyn Fn(RawMessage) -> ParseResult + 'a>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -711,7 +711,7 @@ impl<T> TransactionInfo<T> {
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
     snapshot: Box<dyn Snapshot>,
-    transaction_parser: Box<'a + dyn Fn(RawMessage) -> ParseResult>,
+    transaction_parser: Box<'a + dyn (Fn(RawMessage) -> ParseResult)>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -711,7 +711,7 @@ impl<T> TransactionInfo<T> {
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
     snapshot: Box<dyn Snapshot>,
-    transaction_parser: Box<'a + dyn(Fn(RawMessage) -> ParseResult)>,
+    transaction_parser: Box<'a + dyn Fn(RawMessage) -> ParseResult>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -711,7 +711,7 @@ impl<T> TransactionInfo<T> {
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
     snapshot: Box<dyn Snapshot>,
-    transaction_parser: Box<dyn dyn Fn(RawMessage) -> ParseResult + 'a>,
+    transaction_parser: Box<dyn Fn(RawMessage) -> ParseResult + 'a>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -711,7 +711,7 @@ impl<T> TransactionInfo<T> {
 /// [`Snapshot`]: ../storage/trait.Snapshot.html
 pub struct BlockchainExplorer<'a> {
     snapshot: Box<dyn Snapshot>,
-    transaction_parser: Box<'a + dyn (Fn(RawMessage) -> ParseResult)>,
+    transaction_parser: Box<'a + dyn(Fn(RawMessage) -> ParseResult)>,
 }
 
 impl<'a> fmt::Debug for BlockchainExplorer<'a> {

--- a/exonum/src/helpers/config.rs
+++ b/exonum/src/helpers/config.rs
@@ -18,9 +18,9 @@ use failure::{Error, ResultExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use toml;
 
-use std::{fs::{self, File},
-          io::{Read, Write},
-          path::Path};
+use std::{
+    fs::{self, File}, io::{Read, Write}, path::Path,
+};
 
 /// Implements loading and saving TOML-encoded configurations.
 #[derive(Debug)]

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap,
-          ffi::OsString,
-          fmt,
-          panic::{self, PanicInfo}};
+use std::{
+    collections::HashMap, ffi::OsString, fmt, panic::{self, PanicInfo},
+};
 
-use super::{clap_backend::ClapBackend,
-            details::{Finalize, GenerateCommonConfig, GenerateNodeConfig, GenerateTestnet, Run,
-                      RunDev},
-            info::Info,
-            internal::{CollectedCommand, Command, Feedback},
-            keys,
-            maintenance::Maintenance,
-            CommandName,
-            ServiceFactory};
+use super::{
+    clap_backend::ClapBackend,
+    details::{Finalize, GenerateCommonConfig, GenerateNodeConfig, GenerateTestnet, Run, RunDev},
+    info::Info, internal::{CollectedCommand, Command, Feedback}, keys, maintenance::Maintenance,
+    CommandName, ServiceFactory,
+};
 use blockchain::Service;
 use node::Node;
 

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -30,7 +30,7 @@ use node::Node;
 #[derive(Default)]
 pub struct NodeBuilder {
     commands: HashMap<CommandName, CollectedCommand>,
-    service_factories: Vec<Box<ServiceFactory>>,
+    service_factories: Vec<Box<dyn ServiceFactory>>,
 }
 
 impl NodeBuilder {
@@ -43,7 +43,7 @@ impl NodeBuilder {
     }
 
     /// Appends service to the `NodeBuilder` context.
-    pub fn with_service(mut self, mut factory: Box<ServiceFactory>) -> NodeBuilder {
+    pub fn with_service(mut self, mut factory: Box<dyn ServiceFactory>) -> NodeBuilder {
         //TODO: Take endpoints, etc... (ECR-164)
 
         for (name, command) in &mut self.commands {
@@ -70,7 +70,7 @@ impl NodeBuilder {
                 let config = ctx.get(keys::NODE_CONFIG)
                     .expect("could not find node_config");
                 let db = Run::db_helper(ctx, &config.database);
-                let services: Vec<Box<Service>> = self.service_factories
+                let services: Vec<Box<dyn Service>> = self.service_factories
                     .into_iter()
                     .map(|mut factory| factory.make_service(ctx))
                     .collect();
@@ -101,7 +101,7 @@ impl NodeBuilder {
                 .iter()
                 .map(|f| f.service_name().to_owned())
                 .collect();
-            let info: Box<Command> = Box::new(Info::new(services));
+            let info: Box<dyn Command> = Box::new(Info::new(services));
             self.commands
                 .insert(info.name(), CollectedCommand::new(info));
         }
@@ -118,7 +118,7 @@ impl NodeBuilder {
 
     fn commands() -> HashMap<CommandName, CollectedCommand> {
         vec![
-            Box::new(GenerateTestnet) as Box<Command>,
+            Box::new(GenerateTestnet) as Box<dyn Command>,
             Box::new(Run),
             Box::new(RunDev),
             Box::new(GenerateNodeConfig),

--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -16,10 +16,9 @@ use clap;
 
 use std::{collections::HashMap, ffi::OsString};
 
-use super::{internal::{CollectedCommand, Feedback},
-            ArgumentType,
-            CommandName,
-            Context};
+use super::{
+    internal::{CollectedCommand, Feedback}, ArgumentType, CommandName, Context,
+};
 
 pub struct ClapBackend;
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -247,7 +247,7 @@ impl Command for RunDev {
         &self,
         commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Contex,
     ) -> Feedback {
         let db_path = Self::artifacts_path("db", &context);
         context.set_arg(DATABASE_PATH, db_path);
@@ -294,7 +294,7 @@ impl Command for GenerateCommonConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Contex,
     ) -> Feedback {
         let template_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -375,7 +375,7 @@ impl Command for GenerateNodeConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Contex,
     ) -> Feedback {
         let common_config_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -556,7 +556,7 @@ impl Command for Finalize {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Contex,
     ) -> Feedback {
         let public_configs_path = context
             .arg_multiple::<String>("PUBLIC_CONFIGS")
@@ -680,7 +680,7 @@ impl Command for GenerateTestnet {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Contex,
     ) -> Feedback {
         let dir = context.arg::<String>(OUTPUT_DIR).expect("output dir");
         let count: u8 = context.arg("COUNT").expect("count as int");

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -19,19 +19,17 @@
 
 use toml;
 
-use std::{collections::{BTreeMap, HashMap},
-          fs,
-          net::{IpAddr, SocketAddr},
-          path::{Path, PathBuf}};
+use std::{
+    collections::{BTreeMap, HashMap}, fs, net::{IpAddr, SocketAddr}, path::{Path, PathBuf},
+};
 
-use super::{internal::{CollectedCommand, Command, Feedback},
-            keys,
-            shared::{AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig,
-                     SharedConfig},
-            Argument,
-            CommandName,
-            Context,
-            DEFAULT_EXONUM_LISTEN_PORT};
+use super::{
+    internal::{CollectedCommand, Command, Feedback}, keys,
+    shared::{
+        AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig, SharedConfig,
+    },
+    Argument, CommandName, Context, DEFAULT_EXONUM_LISTEN_PORT,
+};
 use api::backends::actix::AllowOrigin;
 use blockchain::{config::ValidatorKeys, GenesisConfig};
 use crypto;

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -247,7 +247,7 @@ impl Command for RunDev {
         &self,
         commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &dyn Fn(Context) -> Contex,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let db_path = Self::artifacts_path("db", &context);
         context.set_arg(DATABASE_PATH, db_path);
@@ -294,7 +294,7 @@ impl Command for GenerateCommonConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &dyn Fn(Context) -> Contex,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let template_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -375,7 +375,7 @@ impl Command for GenerateNodeConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &dyn Fn(Context) -> Contex,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let common_config_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -556,7 +556,7 @@ impl Command for Finalize {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &dyn Fn(Context) -> Contex,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let public_configs_path = context
             .arg_multiple::<String>("PUBLIC_CONFIGS")
@@ -680,7 +680,7 @@ impl Command for GenerateTestnet {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &dyn Fn(Context) -> Contex,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let dir = context.arg::<String>(OUTPUT_DIR).expect("output dir");
         let count: u8 = context.arg("COUNT").expect("count as int");

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -122,7 +122,7 @@ impl Command for Run {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: dyn Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let config = Self::node_config(&context);
         let public_addr = Self::public_api_address(&context);

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -51,7 +51,7 @@ pub struct Run;
 
 impl Run {
     /// Returns created database instance.
-    pub fn db_helper(ctx: &Context, options: &DbOptions) -> Box<Database> {
+    pub fn db_helper(ctx: &Context, options: &DbOptions) -> Box<dyn Database> {
         let path = ctx.arg::<String>(DATABASE_PATH)
             .unwrap_or_else(|_| panic!("{} not found.", DATABASE_PATH));
         Box::new(RocksDB::open(Path::new(&path), options).expect("Can't load database file"))
@@ -122,7 +122,7 @@ impl Command for Run {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let config = Self::node_config(&context);
         let public_addr = Self::public_api_address(&context);
@@ -247,7 +247,7 @@ impl Command for RunDev {
         &self,
         commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let db_path = Self::artifacts_path("db", &context);
         context.set_arg(DATABASE_PATH, db_path);
@@ -294,7 +294,7 @@ impl Command for GenerateCommonConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let template_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -375,7 +375,7 @@ impl Command for GenerateNodeConfig {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let common_config_path = context
             .arg::<String>("COMMON_CONFIG")
@@ -556,7 +556,7 @@ impl Command for Finalize {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let public_configs_path = context
             .arg_multiple::<String>("PUBLIC_CONFIGS")
@@ -680,7 +680,7 @@ impl Command for GenerateTestnet {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         mut context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let dir = context.arg::<String>(OUTPUT_DIR).expect("output dir");
         let count: u8 = context.arg("COUNT").expect("count as int");

--- a/exonum/src/helpers/fabric/info.rs
+++ b/exonum/src/helpers/fabric/info.rs
@@ -18,10 +18,9 @@ use serde_json;
 
 use std::collections::HashMap;
 
-use super::{internal::{CollectedCommand, Command, Feedback},
-            Argument,
-            CommandName,
-            Context};
+use super::{
+    internal::{CollectedCommand, Command, Feedback}, Argument, CommandName, Context,
+};
 
 // Context entry for the type of the requested information.
 const INFO_REQUEST: &str = "INFO_REQUEST";

--- a/exonum/src/helpers/fabric/info.rs
+++ b/exonum/src/helpers/fabric/info.rs
@@ -73,7 +73,7 @@ impl Command for Info {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         context: Context,
-        _: &Fn(Context) -> Context,
+        _: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let request = context
             .arg::<String>(INFO_REQUEST)

--- a/exonum/src/helpers/fabric/info.rs
+++ b/exonum/src/helpers/fabric/info.rs
@@ -73,7 +73,7 @@ impl Command for Info {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         context: Context,
-        _: dyn Fn(Context) -> Context,
+        _: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let request = context
             .arg::<String>(INFO_REQUEST)

--- a/exonum/src/helpers/fabric/internal.rs
+++ b/exonum/src/helpers/fabric/internal.rs
@@ -36,7 +36,7 @@ pub trait Command {
         &self,
         commands: &HashMap<CommandName, CollectedCommand>,
         context: Context,
-        exts: &Fn(Context) -> Context,
+        exts: &dyn Fn(Context) -> Context,
     ) -> Feedback;
 }
 
@@ -47,13 +47,13 @@ pub trait Command {
 /// abstracted dynamic object without trait objects.
 /// 2. Additionally this state is common for all commands.
 pub struct CollectedCommand {
-    command: Box<Command>,
+    command: Box<dyn Command>,
     args: Vec<Argument>,
-    exts: Vec<Box<CommandExtension>>,
+    exts: Vec<Box<dyn CommandExtension>>,
 }
 
 impl CollectedCommand {
-    pub fn new(command: Box<Command>) -> CollectedCommand {
+    pub fn new(command: Box<dyn Command>) -> CollectedCommand {
         CollectedCommand {
             args: command.args(),
             command,
@@ -73,7 +73,7 @@ impl CollectedCommand {
         self.command.about()
     }
 
-    pub fn extend(&mut self, extender: Option<Box<CommandExtension>>) {
+    pub fn extend(&mut self, extender: Option<Box<dyn CommandExtension>>) {
         if let Some(extender) = extender {
             let args = extender.args();
             self.args.extend(args.into_iter());

--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -16,10 +16,9 @@
 
 use std::{collections::HashMap, path::Path};
 
-use super::{internal::{CollectedCommand, Command, Feedback},
-            Argument,
-            CommandName,
-            Context};
+use super::{
+    internal::{CollectedCommand, Command, Feedback}, Argument, CommandName, Context,
+};
 use blockchain::Schema;
 use helpers::config::ConfigFile;
 use node::NodeConfig;

--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -44,7 +44,7 @@ impl Maintenance {
         ConfigFile::load(path).expect("Can't load node config file")
     }
 
-    fn database(ctx: &Context, options: &DbOptions) -> Box<Database> {
+    fn database(ctx: &Context, options: &DbOptions) -> Box<dyn Database> {
         let path = ctx.arg::<String>(DATABASE_PATH)
             .unwrap_or_else(|_| panic!("{} not found.", DATABASE_PATH));
         Box::new(RocksDB::open(Path::new(&path), options).expect("Can't load database file"))
@@ -108,7 +108,7 @@ impl Command for Maintenance {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         context: Context,
-        _: &Fn(Context) -> Context,
+        _: dyn Fn(Context) -> Context,
     ) -> Feedback {
         let action = context
             .arg::<String>(MAINTENANCE_ACTION_PATH)

--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -108,7 +108,7 @@ impl Command for Maintenance {
         &self,
         _commands: &HashMap<CommandName, CollectedCommand>,
         context: Context,
-        _: dyn Fn(Context) -> Context,
+        _: &dyn Fn(Context) -> Context,
     ) -> Feedback {
         let action = context
             .arg::<String>(MAINTENANCE_ACTION_PATH)

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -14,12 +14,12 @@
 
 //! Command line commands utilities.
 
-pub use self::{builder::NodeBuilder,
-               context_key::ContextKey,
-               details::{Finalize, GenerateCommonConfig, GenerateNodeConfig, GenerateTestnet,
-                         Run, RunDev},
-               maintenance::Maintenance,
-               shared::{AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig}};
+pub use self::{
+    builder::NodeBuilder, context_key::ContextKey,
+    details::{Finalize, GenerateCommonConfig, GenerateNodeConfig, GenerateTestnet, Run, RunDev},
+    maintenance::Maintenance,
+    shared::{AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig},
+};
 
 use clap;
 use failure;

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -294,10 +294,10 @@ pub trait ServiceFactory: 'static {
     fn service_name(&self) -> &str;
     /// Returns `CommandExtension` for the specific `CommandName`.
     #[allow(unused_variables)]
-    fn command(&mut self, command: CommandName) -> Option<Box<CommandExtension>> {
+    fn command(&mut self, command: CommandName) -> Option<Box<dyn CommandExtension>> {
         None
     }
 
     /// Creates a new service instance from the context returned by the `Run` command.
-    fn make_service(&mut self, run_context: &Context) -> Box<Service>;
+    fn make_service(&mut self, run_context: &Context) -> Box<dyn Service>;
 }

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -27,9 +27,9 @@ use colored::*;
 use env_logger::{Builder, Formatter};
 use log::{Level, Record, SetLoggerError};
 
-use std::{env,
-          io::{self, Write},
-          time::SystemTime};
+use std::{
+    env, io::{self, Write}, time::SystemTime,
+};
 
 use blockchain::{GenesisConfig, ValidatorKeys};
 use crypto::gen_keypair;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information see the project readme.
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 #![cfg_attr(feature = "flame_profile", feature(plugin, custom_attribute))]
 #![cfg_attr(feature = "flame_profile", plugin(exonum_flamer))]
 #![cfg_attr(feature = "long_benchmarks", feature(test))]

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -15,9 +15,8 @@
 //! Exonum blockchain framework.
 //!
 //! For more information see the project readme.
-// spell-checker:ignore cors
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
 #![cfg_attr(feature = "flame_profile", feature(plugin, custom_attribute))]
 #![cfg_attr(feature = "flame_profile", plugin(exonum_flamer))]
 #![cfg_attr(feature = "long_benchmarks", feature(test))]

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! For more information see the project readme.
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 #![cfg_attr(feature = "long_benchmarks", feature(test))]
 
 extern crate actix;

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -16,9 +16,7 @@
 //!
 //! For more information see the project readme.
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
-#![cfg_attr(feature = "flame_profile", feature(plugin, custom_attribute))]
-#![cfg_attr(feature = "flame_profile", plugin(exonum_flamer))]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code)]
 #![cfg_attr(feature = "long_benchmarks", feature(test))]
 
 extern crate actix;

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -14,9 +14,13 @@
 
 //! Consensus and other messages and related utilities.
 
-pub use self::{protocol::*,
-               raw::{Message, MessageBuffer, MessageWriter, RawMessage, ServiceMessage,
-                     HEADER_LENGTH, PROTOCOL_MAJOR_VERSION}};
+pub use self::{
+    protocol::*,
+    raw::{
+        Message, MessageBuffer, MessageWriter, RawMessage, ServiceMessage, HEADER_LENGTH,
+        PROTOCOL_MAJOR_VERSION,
+    },
+};
 
 use bit_vec::BitVec;
 

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -125,7 +125,6 @@ impl RequestMessage {
     }
 
     /// Verifies the message signature with given public key.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn verify(&self, public_key: &PublicKey) -> bool {
         match *self {
             RequestMessage::Propose(ref msg) => msg.verify_signature(public_key),

--- a/exonum/src/messages/raw.rs
+++ b/exonum/src/messages/raw.rs
@@ -18,8 +18,9 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use std::{convert, fmt::Debug, ops::Deref, sync};
 
-use crypto::{hash, sign, verify, CryptoHash, Hash, PublicKey, SecretKey, Signature,
-             SIGNATURE_LENGTH};
+use crypto::{
+    hash, sign, verify, CryptoHash, Hash, PublicKey, SecretKey, Signature, SIGNATURE_LENGTH,
+};
 use encoding::{self, CheckedOffset, Field, Offset, Result as StreamStructResult};
 
 /// Length of the message header.

--- a/exonum/src/messages/spec.rs
+++ b/exonum/src/messages/spec.rs
@@ -292,7 +292,7 @@ macro_rules! __ex_message {
                 buffer: & mut B,
                 from: $crate::encoding::Offset,
                 to: $crate::encoding::Offset,
-            ) -> ::std::result::Result<(), Box<dyn  (::std::error::Error)>>
+            ) -> ::std::result::Result<(), Box<dyn (::std::error::Error)>>
             where B: $crate::encoding::serialize::WriteBufferWrapper
             {
                 use $crate::encoding::serialize::json::ExonumJsonDeserialize;

--- a/exonum/src/messages/spec.rs
+++ b/exonum/src/messages/spec.rs
@@ -292,7 +292,7 @@ macro_rules! __ex_message {
                 buffer: & mut B,
                 from: $crate::encoding::Offset,
                 to: $crate::encoding::Offset,
-            ) -> ::std::result::Result<(), Box<::std::error::Error>>
+            ) -> ::std::result::Result<(), Box<dyn  (::std::error::Error)>>
             where B: $crate::encoding::serialize::WriteBufferWrapper
             {
                 use $crate::encoding::serialize::json::ExonumJsonDeserialize;
@@ -307,7 +307,7 @@ macro_rules! __ex_message {
             #[allow(unused_mut)]
             fn serialize_field(&self)
                 -> ::std::result::Result<$crate::encoding::serialize::json::reexport::Value,
-                            Box<::std::error::Error + Send + Sync>>
+                            Box<dyn (::std::error::Error) + Send + Sync>>
             {
                 use $crate::encoding::serialize::json::reexport::Value;
                 use $crate::encoding::serialize::json::reexport::Map;
@@ -333,7 +333,7 @@ macro_rules! __ex_message {
         impl $crate::encoding::serialize::json::ExonumJsonDeserialize for $name {
             #[allow(unused_imports, unused_variables, unused_mut)]
             fn deserialize(value: &$crate::encoding::serialize::json::reexport::Value)
-                -> ::std::result::Result<Self, Box<::std::error::Error>>
+                -> ::std::result::Result<Self, Box<dyn (::std::error::Error)>>
             {
                 use $crate::encoding::serialize::json::ExonumJson;
                 use $crate::encoding::serialize::json::reexport::from_value;

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -18,9 +18,10 @@ use blockchain::{Schema, Transaction};
 use crypto::{CryptoHash, Hash, PublicKey};
 use events::InternalRequest;
 use helpers::{Height, Round, ValidatorId};
-use messages::{BlockRequest, BlockResponse, ConsensusMessage, Message, Precommit, Prevote,
-               PrevotesRequest, Propose, ProposeRequest, RawTransaction, TransactionsRequest,
-               TransactionsResponse};
+use messages::{
+    BlockRequest, BlockResponse, ConsensusMessage, Message, Precommit, Prevote, PrevotesRequest,
+    Propose, ProposeRequest, RawTransaction, TransactionsRequest, TransactionsResponse,
+};
 use node::{NodeHandler, RequestData};
 use storage::Patch;
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -28,7 +28,6 @@ use storage::Patch;
 // TODO Reduce view invocations. (ECR-171)
 impl NodeHandler {
     /// Validates consensus message, then redirects it to the corresponding `handle_...` function.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_consensus(&mut self, msg: ConsensusMessage) {
         if !self.is_enabled {
             info!(
@@ -220,7 +219,6 @@ impl NodeHandler {
 
     /// Handles the `Block` message. For details see the message documentation.
     // TODO: Write helper function which returns Result. (ECR-123)
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_block(&mut self, msg: &BlockResponse) {
         if let Err(err) = self.validate_block_response(msg) {
             error!("{}", err);
@@ -575,7 +573,6 @@ impl NodeHandler {
 
     /// Handles raw transaction. Transaction is ignored if it is already known, otherwise it is
     /// added to the transactions pool.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_tx(&mut self, msg: RawTransaction) {
         let tx = match self.blockchain.tx_from_raw(msg.clone()) {
             Ok(tx) => tx,
@@ -596,7 +593,6 @@ impl NodeHandler {
     }
 
     /// Handles raw transactions.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn handle_txs_batch(&mut self, msg: &TransactionsResponse) {
         if msg.to() != self.state.consensus_public_key() {
             error!(
@@ -830,7 +826,6 @@ impl NodeHandler {
 
     /// Calls `create_block` with transactions from the corresponding `Propose` and returns the
     /// block hash.
-    #[cfg_attr(feature = "flame_profile", flame)]
     pub fn execute(&mut self, propose_hash: &Hash) -> Hash {
         // if we already execute this block, return hash
         if let Some(hash) = self.state.propose_mut(propose_hash).unwrap().block_hash() {

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -628,7 +628,7 @@ impl NodeHandler {
     /// Handles external boxed transaction. Additionally transaction will be broadcast to the
     /// Node's peers.
     #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-    pub fn handle_incoming_tx(&mut self, msg: Box<Transaction>) {
+    pub fn handle_incoming_tx(&mut self, msg: Box<dyn Transaction>) {
         trace!("Handle incoming transaction");
         match self.handle_tx_inner(msg.raw().clone()) {
             Ok(_) => self.broadcast(msg.raw()),

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -61,7 +61,7 @@ pub enum ExternalMessage {
     /// Add a new connection.
     PeerAdd(ConnectInfo),
     /// Transaction that implements the `Transaction` trait.
-    Transaction(Box<Transaction>),
+    Transaction(Box<dyn Transaction>),
     /// Enable or disable the node.
     Enable(bool),
     /// Shutdown the node.
@@ -105,7 +105,7 @@ pub struct NodeHandler {
     /// Shared api state.
     pub api_state: SharedNodeState,
     /// System state.
-    pub system_state: Box<SystemStateProvider>,
+    pub system_state: Box<dyn SystemStateProvider>,
     /// Channel for messages and timeouts.
     pub channel: NodeSender,
     /// Blockchain.
@@ -325,7 +325,7 @@ impl NodeHandler {
         blockchain: Blockchain,
         external_address: SocketAddr,
         sender: NodeSender,
-        system_state: Box<SystemStateProvider>,
+        system_state: Box<dyn SystemStateProvider>,
         config: Configuration,
         api_state: SharedNodeState,
     ) -> Self {
@@ -659,7 +659,7 @@ impl fmt::Debug for NodeHandler {
 /// implementation.
 pub trait TransactionSend: Send + Sync {
     /// Sends transaction. This can include transaction verification.
-    fn send(&self, tx: Box<Transaction>) -> io::Result<()>;
+    fn send(&self, tx: Box<dyn Transaction>) -> io::Result<()>;
 }
 
 impl ApiSender {
@@ -686,7 +686,7 @@ impl ApiSender {
 }
 
 impl TransactionSend for ApiSender {
-    fn send(&self, tx: Box<Transaction>) -> io::Result<()> {
+    fn send(&self, tx: Box<dyn Transaction>) -> io::Result<()> {
         if !tx.verify() {
             let msg = "Unable to verify transaction";
             return Err(io::Error::new(io::ErrorKind::Other, msg));
@@ -786,9 +786,9 @@ impl NodeChannel {
 
 impl Node {
     /// Creates node for the given services and node configuration.
-    pub fn new<D: Into<Arc<Database>>>(
+    pub fn new<D: Into<Arc<dyn Database>>>(
         db: D,
-        services: Vec<Box<Service>>,
+        services: Vec<Box<dyn Service>>,
         node_cfg: NodeConfig,
     ) -> Self {
         crypto::init();

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -17,43 +17,34 @@
 //! For details about consensus message handling see messages module documentation.
 // spell-checker:ignore cors
 
-pub use self::{connect_list::ConnectList,
-               state::{RequestData, State, ValidatorState}};
+pub use self::{
+    connect_list::ConnectList, state::{RequestData, State, ValidatorState},
+};
 
 // TODO: Temporary solution to get access to WAIT constants. (ECR-167)
 pub mod state;
 
-use api::{backends::actix::{AllowOrigin, ApiRuntimeConfig, App, AppConfig, Cors,
-                            SystemRuntimeConfig},
-          ApiAccess,
-          ApiAggregator};
+use api::{
+    backends::actix::{AllowOrigin, ApiRuntimeConfig, App, AppConfig, Cors, SystemRuntimeConfig},
+    ApiAccess, ApiAggregator,
+};
 use failure;
 use futures::{sync::mpsc, Future, Sink};
 use tokio_core::reactor::Core;
 use toml::Value;
 
-use std::{collections::{BTreeMap, HashSet},
-          fmt,
-          io,
-          net::SocketAddr,
-          sync::Arc,
-          thread,
-          time::{Duration, SystemTime}};
+use std::{
+    collections::{BTreeMap, HashSet}, fmt, io, net::SocketAddr, sync::Arc, thread,
+    time::{Duration, SystemTime},
+};
 
 use blockchain::{Blockchain, GenesisConfig, Schema, Service, SharedNodeState, Transaction};
 use crypto::{self, CryptoHash, Hash, PublicKey, SecretKey};
-use events::{error::{into_other, log_error, other_error, LogError},
-             noise::HandshakeParams,
-             HandlerPart,
-             InternalEvent,
-             InternalPart,
-             InternalRequest,
-             NetworkConfiguration,
-             NetworkEvent,
-             NetworkPart,
-             NetworkRequest,
-             SyncSender,
-             TimeoutRequest};
+use events::{
+    error::{into_other, log_error, other_error, LogError}, noise::HandshakeParams, HandlerPart,
+    InternalEvent, InternalPart, InternalRequest, NetworkConfiguration, NetworkEvent, NetworkPart,
+    NetworkRequest, SyncSender, TimeoutRequest,
+};
 use helpers::{user_agent, Height, Milliseconds, Round, ValidatorId};
 use messages::{Connect, Message, RawMessage};
 use storage::{Database, DbOptions};

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1018,7 +1018,7 @@ mod tests {
     fn test_duplicated_transaction() {
         let (p_key, s_key) = gen_keypair();
 
-        let db = Arc::from(Box::new(MemoryDB::new()) as Box<dyn Database>) as Arc<Database>;
+        let db = Arc::from(Box::new(MemoryDB::new()) as Box<dyn Database>) as Arc<dyn Database>;
         let services = vec![];
         let node_cfg = helpers::generate_testnet_config(1, 16_500)[0].clone();
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1018,7 +1018,7 @@ mod tests {
     fn test_duplicated_transaction() {
         let (p_key, s_key) = gen_keypair();
 
-        let db = Arc::from(Box::new(MemoryDB::new()) as Box<Database>) as Arc<Database>;
+        let db = Arc::from(Box::new(MemoryDB::new()) as Box<dyn Database>) as Arc<Database>;
         let services = vec![];
         let node_cfg = helpers::generate_testnet_config(1, 16_500)[0].clone();
 

--- a/exonum/src/node/requests.rs
+++ b/exonum/src/node/requests.rs
@@ -15,8 +15,10 @@
 use super::NodeHandler;
 use blockchain::Schema;
 use crypto::{PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
-use messages::{BlockRequest, BlockResponse, Message, PrevotesRequest, ProposeRequest,
-               RequestMessage, TransactionsRequest, TransactionsResponse, HEADER_LENGTH};
+use messages::{
+    BlockRequest, BlockResponse, Message, PrevotesRequest, ProposeRequest, RequestMessage,
+    TransactionsRequest, TransactionsResponse, HEADER_LENGTH,
+};
 
 // TODO: Height should be updated after any message, not only after status (if signature is correct). (ECR-171)
 // TODO: Request propose makes sense only if we know that node is on our height. (ECR-171)

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -18,15 +18,17 @@ use bit_vec::BitVec;
 use failure;
 use serde_json::Value;
 
-use std::{collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
-          net::SocketAddr,
-          time::{Duration, SystemTime}};
+use std::{
+    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet}, net::SocketAddr,
+    time::{Duration, SystemTime},
+};
 
 use blockchain::{ConsensusConfig, StoredConfiguration, ValidatorKeys};
 use crypto::{CryptoHash, Hash, PublicKey, SecretKey};
 use helpers::{Height, Milliseconds, Round, ValidatorId};
-use messages::{BlockResponse, Connect, ConsensusMessage, Message, Precommit, Prevote, Propose,
-               RawMessage};
+use messages::{
+    BlockResponse, Connect, ConsensusMessage, Message, Precommit, Prevote, Propose, RawMessage,
+};
 use node::connect_list::ConnectList;
 use node::ConnectInfo;
 use storage::{KeySetIndex, MapIndex, Patch, Snapshot};

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -854,7 +854,7 @@ impl State {
     }
 
     /// Adds propose from other node. Returns `ProposeState` if it is a new propose.
-    pub fn add_propose<S: AsRef<Snapshot>>(
+    pub fn add_propose<S: AsRef<dyn Snapshot>>(
         &mut self,
         msg: &Propose,
         transactions: &MapIndex<S, Hash, RawMessage>,
@@ -922,7 +922,7 @@ impl State {
     ///
     /// - Already there is an incomplete block.
     /// - Received block has already committed transaction.
-    pub fn create_incomplete_block<S: AsRef<Snapshot>>(
+    pub fn create_incomplete_block<S: AsRef<dyn Snapshot>>(
         &mut self,
         msg: &BlockResponse,
         txs: &MapIndex<S, Hash, RawMessage>,

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use blockchain::{ExecutionResult, Schema, Service, StoredConfiguration, Transaction,
-                 TransactionSet};
+use blockchain::{
+    ExecutionResult, Schema, Service, StoredConfiguration, Transaction, TransactionSet,
+};
 use crypto::{Hash, PublicKey};
 use encoding::Error as MessageError;
 use helpers::Height;

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -65,11 +65,11 @@ impl Service for ConfigUpdateService {
         CONFIG_SERVICE
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         let tx = ConfigUpdaterTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/exonum/src/sandbox/consensus.rs
+++ b/exonum/src/sandbox/consensus.rs
@@ -19,19 +19,26 @@ use rand::{thread_rng, Rng};
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::{config_updater::TxConfig,
-            sandbox::{sandbox_with_services_uninitialized, timestamping_sandbox},
-            sandbox_tests_helper::*,
-            timestamping::{TimestampTx, TimestampingTxGenerator, TIMESTAMPING_SERVICE}};
+use super::{
+    config_updater::TxConfig, sandbox::{sandbox_with_services_uninitialized, timestamping_sandbox},
+    sandbox_tests_helper::*,
+    timestamping::{TimestampTx, TimestampingTxGenerator, TIMESTAMPING_SERVICE},
+};
 use blockchain::{Blockchain, Schema};
 use crypto::{gen_keypair, gen_keypair_from_seed, CryptoHash, Hash, Seed};
 use helpers::{user_agent, Height, Round};
-use messages::{BlockRequest, BlockResponse, Connect, Message, PeersRequest, Precommit, Prevote,
-               PrevotesRequest, Propose, ProposeRequest, RawMessage, Status, TransactionsRequest,
-               TransactionsResponse, CONSENSUS};
-use node::{self,
-           state::{BLOCK_REQUEST_TIMEOUT, PREVOTES_REQUEST_TIMEOUT, PROPOSE_REQUEST_TIMEOUT,
-                   TRANSACTIONS_REQUEST_TIMEOUT}};
+use messages::{
+    BlockRequest, BlockResponse, Connect, Message, PeersRequest, Precommit, Prevote,
+    PrevotesRequest, Propose, ProposeRequest, RawMessage, Status, TransactionsRequest,
+    TransactionsResponse, CONSENSUS,
+};
+use node::{
+    self,
+    state::{
+        BLOCK_REQUEST_TIMEOUT, PREVOTES_REQUEST_TIMEOUT, PROPOSE_REQUEST_TIMEOUT,
+        TRANSACTIONS_REQUEST_TIMEOUT,
+    },
+};
 
 // HANDLE CONSENSUS BASIC
 

--- a/exonum/src/sandbox/old.rs
+++ b/exonum/src/sandbox/old.rs
@@ -14,9 +14,13 @@
 
 use std::time::Duration;
 
-use super::{sandbox::timestamping_sandbox,
-            sandbox_tests_helper::{gen_timestamping_tx, VALIDATOR_0, VALIDATOR_1, VALIDATOR_2,
-                                   VALIDATOR_3, HEIGHT_ONE, ROUND_ONE, ROUND_THREE}};
+use super::{
+    sandbox::timestamping_sandbox,
+    sandbox_tests_helper::{
+        gen_timestamping_tx, VALIDATOR_0, VALIDATOR_1, VALIDATOR_2, VALIDATOR_3, HEIGHT_ONE,
+        ROUND_ONE, ROUND_THREE,
+    },
+};
 use blockchain::{Block, SCHEMA_MAJOR_VERSION};
 use crypto::{CryptoHash, Hash};
 use helpers::{Height, Round};

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -693,7 +693,7 @@ fn gen_primitive_socket_addr(idx: u8) -> SocketAddr {
 }
 
 /// Constructs an instance of a `Sandbox` and initializes connections.
-pub fn sandbox_with_services(services: Vec<Box<Service>>) -> Sandbox {
+pub fn sandbox_with_services(services: Vec<Box<dyn Service>>) -> Sandbox {
     let mut sandbox = sandbox_with_services_uninitialized(services);
     let time = sandbox.time();
     let validators_count = sandbox.validators_map.len();
@@ -702,7 +702,7 @@ pub fn sandbox_with_services(services: Vec<Box<Service>>) -> Sandbox {
 }
 
 /// Constructs an uninitialized instance of a `Sandbox`.
-pub fn sandbox_with_services_uninitialized(services: Vec<Box<Service>>) -> Sandbox {
+pub fn sandbox_with_services_uninitialized(services: Vec<Box<dyn Service>>) -> Sandbox {
     let validators = vec![
         gen_keypair_from_seed(&Seed::new([12; 32])),
         gen_keypair_from_seed(&Seed::new([13; 32])),
@@ -880,11 +880,11 @@ mod tests {
             SERVICE_ID
         }
 
-        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
             Vec::new()
         }
 
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {
+        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
             let tx = HandleCommitTransactions::tx_from_raw(raw)?;
             Ok(tx.into())
         }

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -17,27 +17,33 @@
 
 use futures::{self, sync::mpsc, Async, Future, Sink, Stream};
 
-use std::{cell::{Ref, RefCell, RefMut},
-          collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque},
-          iter::FromIterator,
-          net::{IpAddr, Ipv4Addr, SocketAddr},
-          ops::{AddAssign, Deref},
-          sync::{Arc, Mutex},
-          time::{Duration, SystemTime, UNIX_EPOCH}};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque}, iter::FromIterator,
+    net::{IpAddr, Ipv4Addr, SocketAddr}, ops::{AddAssign, Deref}, sync::{Arc, Mutex},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use super::{config_updater::ConfigUpdateService,
-            sandbox_tests_helper::{VALIDATOR_0, PROPOSE_TIMEOUT},
-            timestamping::TimestampingService};
-use blockchain::{Block, BlockProof, Blockchain, ConsensusConfig, GenesisConfig, Schema, Service,
-                 SharedNodeState, StoredConfiguration, Transaction, ValidatorKeys};
+use super::{
+    config_updater::ConfigUpdateService, sandbox_tests_helper::{VALIDATOR_0, PROPOSE_TIMEOUT},
+    timestamping::TimestampingService,
+};
+use blockchain::{
+    Block, BlockProof, Blockchain, ConsensusConfig, GenesisConfig, Schema, Service,
+    SharedNodeState, StoredConfiguration, Transaction, ValidatorKeys,
+};
 use crypto::{gen_keypair, gen_keypair_from_seed, Hash, PublicKey, SecretKey, Seed};
-use events::{network::NetworkConfiguration, Event, EventHandler, InternalEvent, InternalRequest,
-             NetworkEvent, NetworkRequest, TimeoutRequest};
+use events::{
+    network::NetworkConfiguration, Event, EventHandler, InternalEvent, InternalRequest,
+    NetworkEvent, NetworkRequest, TimeoutRequest,
+};
 use helpers::{user_agent, Height, Milliseconds, Round, ValidatorId};
 use messages::{Any, Connect, Message, RawMessage, RawTransaction, Status};
 use node::ConnectInfo;
-use node::{ApiSender, Configuration, ConnectList, ExternalMessage, ListenerConfig, NodeHandler,
-           NodeSender, ServiceConfig, State, SystemStateProvider};
+use node::{
+    ApiSender, Configuration, ConnectList, ExternalMessage, ListenerConfig, NodeHandler,
+    NodeSender, ServiceConfig, State, SystemStateProvider,
+};
 use storage::{MapProof, MemoryDB};
 
 pub type SharedTime = Arc<Mutex<SystemTime>>;
@@ -828,8 +834,10 @@ mod tests {
     use crypto::{gen_keypair_from_seed, Seed};
     use encoding;
     use messages::RawTransaction;
-    use sandbox::sandbox_tests_helper::{add_one_height, SandboxState, VALIDATOR_1, VALIDATOR_2,
-                                        VALIDATOR_3, HEIGHT_ONE, ROUND_ONE, ROUND_TWO};
+    use sandbox::sandbox_tests_helper::{
+        add_one_height, SandboxState, VALIDATOR_1, VALIDATOR_2, VALIDATOR_3, HEIGHT_ONE, ROUND_ONE,
+        ROUND_TWO,
+    };
     use storage::{Fork, Snapshot};
 
     const SERVICE_ID: u16 = 1;

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -886,7 +886,7 @@ mod tests {
 
         fn tx_from_raw(
             &self,
-            raw: RawTransaction
+            raw: RawTransaction,
         ) -> Result<Box<dyn Transaction>, encoding::Error> {
             let tx = HandleCommitTransactions::tx_from_raw(raw)?;
             Ok(tx.into())

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -884,7 +884,10 @@ mod tests {
             Vec::new()
         }
 
-        fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
+        fn tx_from_raw(
+            &self,
+            raw: RawTransaction
+        ) -> Result<Box<dyn Transaction>, encoding::Error> {
             let tx = HandleCommitTransactions::tx_from_raw(raw)?;
             Ok(tx.into())
         }

--- a/exonum/src/sandbox/sandbox_tests_helper.rs
+++ b/exonum/src/sandbox/sandbox_tests_helper.rs
@@ -17,13 +17,15 @@ use bit_vec::BitVec;
 
 use std::{cell::RefCell, collections::BTreeMap, time::Duration};
 
-use super::{sandbox::Sandbox,
-            timestamping::{TimestampTx, TimestampingTxGenerator}};
+use super::{
+    sandbox::Sandbox, timestamping::{TimestampTx, TimestampingTxGenerator},
+};
 use blockchain::{Block, SCHEMA_MAJOR_VERSION};
 use crypto::{CryptoHash, Hash, HASH_SIZE};
 use helpers::{Height, Milliseconds, Round, ValidatorId};
-use messages::{Message, Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest,
-               RawTransaction};
+use messages::{
+    Message, Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest, RawTransaction,
+};
 use storage::Database;
 
 pub type TimestampingSandbox = Sandbox;

--- a/exonum/src/sandbox/timestamping.rs
+++ b/exonum/src/sandbox/timestamping.rs
@@ -99,11 +99,11 @@ impl Service for TimestampingService {
         TIMESTAMPING_SERVICE
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         vec![Hash::new([127; 32]), Hash::new([128; 32])]
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, MessageError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, MessageError> {
         let tx = TimestampingTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -60,7 +60,7 @@ pub struct BaseIndexIter<'a, K, V> {
 
 impl<T> BaseIndex<T>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
 {
     /// Creates a new index representation based on the name and storage view.
     ///

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp::Ordering::{Equal, Greater, Less},
-          collections::{btree_map::{BTreeMap, IntoIter as BtmIntoIter, Iter as BtmIter, Range},
-                        hash_map::{Entry as HmEntry, IntoIter as HmIntoIter, Iter as HmIter},
-                        Bound::{Included, Unbounded},
-                        HashMap},
-          iter::{Iterator as StdIterator, Peekable}};
+use std::{
+    cmp::Ordering::{Equal, Greater, Less},
+    collections::{
+        btree_map::{BTreeMap, IntoIter as BtmIntoIter, Iter as BtmIter, Range},
+        hash_map::{Entry as HmEntry, IntoIter as HmIntoIter, Iter as HmIter},
+        Bound::{Included, Unbounded}, HashMap,
+    },
+    iter::{Iterator as StdIterator, Peekable},
+};
 
 use self::NextIterValue::*;
 use super::Result;

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -148,7 +148,7 @@ impl IntoIterator for Patch {
 }
 
 /// A generalized iterator over the storage views.
-pub type Iter<'a> = Box<Iterator + 'a>;
+pub type Iter<'a> = Box<dyn Iterator + 'a>;
 
 /// An enum that represents a kind of change to some key in the storage.
 #[derive(Debug, Clone, PartialEq)]
@@ -196,7 +196,7 @@ pub enum Change {
 
 // FIXME: make &mut Fork "unwind safe". (ECR-176)
 pub struct Fork {
-    snapshot: Box<Snapshot>,
+    snapshot: Box<dyn Snapshot>,
     patch: Patch,
     changelog: Vec<(String, Vec<u8>, Option<Change>)>,
     logged: bool,
@@ -246,7 +246,7 @@ enum NextIterValue {
 /// [interior-mut]: https://doc.rust-lang.org/book/second-edition/ch15-05-interior-mutability.html
 pub trait Database: Send + Sync + 'static {
     /// Creates a new snapshot of the database from its current state.
-    fn snapshot(&self) -> Box<Snapshot>;
+    fn snapshot(&self) -> Box<dyn Snapshot>;
 
     /// Creates a new fork of the database from its current state.
     fn fork(&self) -> Fork {
@@ -502,14 +502,14 @@ impl Fork {
     }
 }
 
-impl AsRef<Snapshot> for Snapshot + 'static {
-    fn as_ref(&self) -> &Snapshot {
+impl AsRef<dyn Snapshot> for dyn Snapshot + 'static {
+    fn as_ref(&self) -> dyn Snapshot {
         self
     }
 }
 
-impl AsRef<Snapshot> for Fork {
-    fn as_ref(&self) -> &Snapshot {
+impl AsRef<dyn Snapshot> for Fork {
+    fn as_ref(&self) -> &dyn Snapshot {
         self
     }
 }
@@ -624,8 +624,8 @@ impl<'a> Iterator for ForkIter<'a> {
     }
 }
 
-impl<T: Database> From<T> for Box<Database> {
+impl<T: Database> From<T> for Box<dyn Database> {
     fn from(db: T) -> Self {
-        Box::new(db) as Box<Database>
+        Box::new(db) as Box<dyn Database>
     }
 }

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -503,7 +503,7 @@ impl Fork {
 }
 
 impl AsRef<dyn Snapshot> for dyn Snapshot + 'static {
-    fn as_ref(&self) -> dyn Snapshot {
+    fn as_ref(&self) -> &dyn Snapshot {
         self
     }
 }

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -32,7 +32,7 @@ pub struct Entry<T, V> {
 
 impl<T, V> Entry<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     /// Creates a new index representation based on the name and storage view.

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 //! An implementation of `Error` type.
 
 /// The error type for I/O operations with storage.
-#[allow(bare_trait_objects)]
 #[derive(Fail, Debug, Clone)]
 #[fail(display = "{}", message)]
 pub struct Error {

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 //! An implementation of `Error` type.

--- a/exonum/src/storage/error.rs
+++ b/exonum/src/storage/error.rs
@@ -15,6 +15,7 @@
 //! An implementation of `Error` type.
 
 /// The error type for I/O operations with storage.
+#[allow(bare_trait_objects)]
 #[derive(Fail, Debug, Clone)]
 #[fail(display = "{}", message)]
 pub struct Error {

--- a/exonum/src/storage/indexes_metadata.rs
+++ b/exonum/src/storage/indexes_metadata.rs
@@ -17,11 +17,9 @@
 use std::{borrow::Cow, error::Error};
 
 use crypto::{CryptoHash, Hash};
-use encoding::{serialize::{json, WriteBufferWrapper},
-               CheckedOffset,
-               Error as EncodingError,
-               Field,
-               Offset};
+use encoding::{
+    serialize::{json, WriteBufferWrapper}, CheckedOffset, Error as EncodingError, Field, Offset,
+};
 use storage::{base_index::BaseIndex, Fork, Snapshot, StorageValue};
 
 pub const INDEXES_METADATA_TABLE_NAME: &str = "__INDEXES_METADATA__";

--- a/exonum/src/storage/indexes_metadata.rs
+++ b/exonum/src/storage/indexes_metadata.rs
@@ -110,7 +110,7 @@ impl json::ExonumJson for IndexType {
         buffer: &mut B,
         from: Offset,
         to: Offset,
-    ) -> Result<(), Box<Error>>
+    ) -> Result<(), Box<dyn Error>>
     where
         Self: Sized,
     {
@@ -119,12 +119,12 @@ impl json::ExonumJson for IndexType {
         Ok(())
     }
 
-    fn serialize_field(&self) -> Result<json::reexport::Value, Box<Error + Send + Sync>> {
+    fn serialize_field(&self) -> Result<json::reexport::Value, Box<dyn Error + Send + Sync>> {
         Ok(json::reexport::Value::from(*self as u8))
     }
 }
 
-pub fn assert_index_type(name: &str, index_type: IndexType, is_family: bool, view: &Snapshot) {
+pub fn assert_index_type(name: &str, index_type: IndexType, is_family: bool, view: dyn Snapshot) {
     let metadata = BaseIndex::indexes_metadata(view);
     if let Some(value) = metadata.get::<_, IndexMetadata>(name) {
         let stored_type = value.index_type();

--- a/exonum/src/storage/indexes_metadata.rs
+++ b/exonum/src/storage/indexes_metadata.rs
@@ -124,7 +124,7 @@ impl json::ExonumJson for IndexType {
     }
 }
 
-pub fn assert_index_type(name: &str, index_type: IndexType, is_family: bool, view: dyn Snapshot) {
+pub fn assert_index_type(name: &str, index_type: IndexType, is_family: bool, view: &dyn Snapshot) {
     let metadata = BaseIndex::indexes_metadata(view);
     if let Some(value) = metadata.get::<_, IndexMetadata>(name) {
         let stored_type = value.index_type();

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -16,11 +16,9 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot, StorageKey,
+};
 
 /// A set of items that implement `StorageKey` trait.
 ///

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -47,7 +47,7 @@ pub struct KeySetIndexIter<'a, K> {
 
 impl<T, K> KeySetIndex<T, K>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: StorageKey,
 {
     /// Creates a new index representation based on the name and storage view.
@@ -258,7 +258,7 @@ where
 
 impl<'a, T, K> ::std::iter::IntoIterator for &'a KeySetIndex<T, K>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: StorageKey,
 {
     type Item = K::Owned;

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -392,7 +392,7 @@ mod tests {
     fn signed_int_key_in_index() {
         use storage::{Database, MapIndex, MemoryDB};
 
-        let db: Box<Database> = Box::new(MemoryDB::new());
+        let db: Box<dyn Database> = Box::new(MemoryDB::new());
         let mut fork = db.fork();
         {
             let mut index: MapIndex<_, i32, u64> = MapIndex::new("test_index", &mut fork);
@@ -442,7 +442,7 @@ mod tests {
             }
         }
 
-        let db: Box<Database> = Box::new(MemoryDB::new());
+        let db: Box<dyn Database> = Box::new(MemoryDB::new());
         let mut fork = db.fork();
         {
             let mut index: MapIndex<_, QuirkyI32Key, u64> = MapIndex::new("test_index", &mut fork);
@@ -518,7 +518,7 @@ mod tests {
     fn system_time_key_in_index() {
         use storage::{Database, MapIndex, MemoryDB};
 
-        let db: Box<Database> = Box::new(MemoryDB::new());
+        let db: Box<dyn Database> = Box::new(MemoryDB::new());
         let x1 = Utc.timestamp(80, 0);
         let x2 = Utc.timestamp(10, 0);
         let y1 = Utc::now();

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -16,12 +16,10 @@
 
 use std::{cell::Cell, marker::PhantomData};
 
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 
 /// A list of items that implement `StorageValue` trait.
 ///

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -49,7 +49,7 @@ pub struct ListIndexIter<'a, V> {
 
 impl<T, V> ListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     /// Creates a new index representation based on the name and storage view.
@@ -433,7 +433,7 @@ where
 
 impl<'a, T, V> ::std::iter::IntoIterator for &'a ListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     type Item = V;

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -523,7 +523,7 @@ mod tests {
 
         const IDX_NAME: &'static str = "idx_name";
 
-        fn create_database(_: &Path) -> Box<Database> {
+        fn create_database(_: &Path) -> Box<dyn Database> {
             Box::new(MemoryDB::new())
         }
 
@@ -575,7 +575,7 @@ mod tests {
 
         const IDX_NAME: &'static str = "idx_name";
 
-        fn create_database(path: &Path) -> Box<Database> {
+        fn create_database(path: &Path) -> Box<dyn Database> {
             let opts = DbOptions::default();
             Box::new(RocksDB::open(path, &opts).unwrap())
         }

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -16,12 +16,10 @@
 
 use std::{borrow::Borrow, marker::PhantomData};
 
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 
 /// A map of keys and values.
 ///

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -503,7 +503,7 @@ mod tests {
         assert_eq!(false, index.contains(KEY));
     }
 
-    fn iter(db: Box<Database>) {
+    fn iter(db: Box<dyn Database>) {
         let mut fork = db.fork();
         let mut map_index = MapIndex::new(IDX_NAME, &mut fork);
 
@@ -579,7 +579,7 @@ mod tests {
         use storage::{Database, MemoryDB};
         use tempdir::TempDir;
 
-        fn create_database(_: &Path) -> Box<Database> {
+        fn create_database(_: &Path) -> Box<dyn Database> {
             Box::new(MemoryDB::new())
         }
 
@@ -590,7 +590,6 @@ mod tests {
             let db = create_database(path);
             super::iter(db);
         }
-
     }
 
     mod rocksdb_tests {
@@ -598,7 +597,7 @@ mod tests {
         use storage::Database;
         use tempdir::TempDir;
 
-        fn create_database(path: &Path) -> Box<Database> {
+        fn create_database(path: &Path) -> Box<dyn Database> {
             use storage::{DbOptions, RocksDB};
             let opts = DbOptions::default();
             Box::new(RocksDB::open(path, &opts).unwrap())

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -76,7 +76,7 @@ pub struct MapIndexValues<'a, V> {
 
 impl<T, K, V> MapIndex<T, K, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: StorageKey,
     V: StorageValue,
 {
@@ -415,7 +415,7 @@ where
 
 impl<'a, T, K, V> ::std::iter::IntoIterator for &'a MapIndex<T, K, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: StorageKey,
     V: StorageValue,
 {

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -14,9 +14,9 @@
 
 //! An implementation of `MemoryDB` database.
 
-use std::{clone::Clone,
-          collections::{BTreeMap, HashMap},
-          sync::{Arc, RwLock}};
+use std::{
+    clone::Clone, collections::{BTreeMap, HashMap}, sync::{Arc, RwLock},
+};
 
 use super::{db::Change, Database, Iter, Iterator, Patch, Result, Snapshot};
 

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -46,7 +46,7 @@ impl MemoryDB {
 }
 
 impl Database for MemoryDB {
-    fn snapshot(&self) -> Box<Snapshot> {
+    fn snapshot(&self) -> Box<dyn Snapshot> {
         Box::new(MemoryDB {
             map: RwLock::new(self.map.read().unwrap().clone()),
         })
@@ -133,9 +133,9 @@ impl Iterator for MemoryDBIter {
     }
 }
 
-impl From<MemoryDB> for Arc<Database> {
-    fn from(db: MemoryDB) -> Arc<Database> {
-        Arc::from(Box::new(db) as Box<Database>)
+impl From<MemoryDB> for Arc<dyn Database> {
+    fn from(db: MemoryDB) -> Arc<dyn Database> {
+        Arc::from(Box::new(db) as Box<dyn Database>)
     }
 }
 

--- a/exonum/src/storage/mod.rs
+++ b/exonum/src/storage/mod.rs
@@ -108,22 +108,16 @@
 
 #[doc(no_inline)]
 pub use self::proof_map_index::{HashedKey, MapProof, ProofMapIndex};
-pub use self::{db::{Change, Changes, ChangesIterator, Database, Fork, Iter, Iterator, Patch,
-                    PatchIterator, Snapshot},
-               entry::Entry,
-               error::Error,
-               hash::UniqueHash,
-               key_set_index::KeySetIndex,
-               keys::StorageKey,
-               list_index::ListIndex,
-               map_index::MapIndex,
-               memorydb::MemoryDB,
-               options::DbOptions,
-               proof_list_index::{ListProof, ProofListIndex},
-               rocksdb::RocksDB,
-               sparse_list_index::SparseListIndex,
-               value_set_index::ValueSetIndex,
-               values::StorageValue};
+pub use self::{
+    db::{
+        Change, Changes, ChangesIterator, Database, Fork, Iter, Iterator, Patch, PatchIterator,
+        Snapshot,
+    },
+    entry::Entry, error::Error, hash::UniqueHash, key_set_index::KeySetIndex, keys::StorageKey,
+    list_index::ListIndex, map_index::MapIndex, memorydb::MemoryDB, options::DbOptions,
+    proof_list_index::{ListProof, ProofListIndex}, rocksdb::RocksDB,
+    sparse_list_index::SparseListIndex, value_set_index::ValueSetIndex, values::StorageValue,
+};
 
 /// A specialized `Result` type for I/O operations with storage.
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -19,12 +19,10 @@ pub use self::proof::{ListProof, ListProofError};
 use std::{cell::Cell, marker::PhantomData};
 
 use self::key::ProofListKey;
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 use crypto::{hash, Hash, HashStream};
 
 mod key;

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -67,7 +67,7 @@ fn pair_hash(h1: &Hash, h2: &Hash) -> Hash {
 
 impl<T, V> ProofListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     /// Creates a new index representation based on the name and storage view.
@@ -591,7 +591,7 @@ where
 
 impl<'a, T, V> ::std::iter::IntoIterator for &'a ProofListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     type Item = V;

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -17,8 +17,9 @@ use rand::{thread_rng, Rng};
 use self::ListProof::*;
 use super::{pair_hash, ListProof, ProofListIndex};
 use crypto::{hash, CryptoHash, Hash};
-use encoding::serialize::{json::reexport::{from_str, to_string},
-                          reexport::Serialize};
+use encoding::serialize::{
+    json::reexport::{from_str, to_string}, reexport::Serialize,
+};
 use storage::Database;
 
 const IDX_NAME: &'static str = "idx_name";

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -46,7 +46,7 @@ fn gen_tempdir_name() -> String {
     thread_rng().gen_ascii_chars().take(10).collect()
 }
 
-fn list_methods(db: Box<Database>) {
+fn list_methods(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
 
@@ -67,7 +67,7 @@ fn list_methods(db: Box<Database>) {
     assert_eq!(index.get(2), Some(vec![3]));
 }
 
-fn height(db: Box<Database>) {
+fn height(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
 
@@ -93,7 +93,7 @@ fn height(db: Box<Database>) {
     assert_eq!(index.get(1), Some(vec![10]));
 }
 
-fn iter(db: Box<Database>) {
+fn iter(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut list_index = ProofListIndex::new(IDX_NAME, &mut fork);
 
@@ -108,7 +108,7 @@ fn iter(db: Box<Database>) {
     );
 }
 
-fn list_index_proof(db: Box<Database>) {
+fn list_index_proof(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
 
@@ -246,7 +246,7 @@ fn list_index_proof(db: Box<Database>) {
     );
 }
 
-fn randomly_generate_proofs(db: Box<Database>) {
+fn randomly_generate_proofs(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     let num_values = 100;
@@ -290,7 +290,7 @@ fn randomly_generate_proofs(db: Box<Database>) {
     }
 }
 
-fn index_and_proof_roots(db: Box<Database>) {
+fn index_and_proof_roots(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     assert_eq!(index.merkle_root(), Hash::zero());
@@ -418,14 +418,14 @@ fn index_and_proof_roots(db: Box<Database>) {
     assert_eq!(index.get(0), Some(vec![1, 2]));
 }
 
-fn proof_illegal_lower_bound(db: Box<Database>) {
+fn proof_illegal_lower_bound(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     index.get_range_proof(0, 1);
     index.push(vec![1]);
 }
 
-fn proof_illegal_bound_empty(db: Box<Database>) {
+fn proof_illegal_bound_empty(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     for i in 0u8..8 {
@@ -434,7 +434,7 @@ fn proof_illegal_bound_empty(db: Box<Database>) {
     index.get_range_proof(8, 9);
 }
 
-fn proof_illegal_range(db: Box<Database>) {
+fn proof_illegal_range(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     for i in 0u8..4 {
@@ -443,7 +443,7 @@ fn proof_illegal_range(db: Box<Database>) {
     index.get_range_proof(2, 2);
 }
 
-fn proof_structure(db: Box<Database>) {
+fn proof_structure(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     assert_eq!(index.merkle_root(), Hash::zero());
@@ -497,7 +497,7 @@ fn proof_structure(db: Box<Database>) {
     }
 }
 
-fn simple_merkle_root(db: Box<Database>) {
+fn simple_merkle_root(db: Box<dyn Database>) {
     let h1 = hash(&[1]);
     let h2 = hash(&[2]);
 
@@ -511,7 +511,7 @@ fn simple_merkle_root(db: Box<Database>) {
     assert_eq!(index.merkle_root(), h2);
 }
 
-fn same_merkle_root(db1: Box<Database>, db2: Box<Database>) {
+fn same_merkle_root(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut fork1 = db1.fork();
 
     let mut i1 = ProofListIndex::new(IDX_NAME, &mut fork1);
@@ -550,7 +550,7 @@ mod memorydb_tests {
     use storage::{Database, MemoryDB};
     use tempdir::TempDir;
 
-    fn create_database(_: &Path) -> Box<Database> {
+    fn create_database(_: &Path) -> Box<dyn Database> {
         Box::new(MemoryDB::new())
     }
 
@@ -662,7 +662,7 @@ mod rocksdb_tests {
     use storage::{Database, DbOptions, RocksDB};
     use tempdir::TempDir;
 
-    fn create_database(path: &Path) -> Box<Database> {
+    fn create_database(path: &Path) -> Box<dyn Database> {
         let opts = DbOptions::default();
         Box::new(RocksDB::open(path, &opts).unwrap())
     }

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -14,20 +14,21 @@
 
 //! An implementation of a Merkelized version of a map (Merkle Patricia tree).
 
-pub use self::{key::{HashedKey, ProofMapKey, ProofPath, KEY_SIZE as PROOF_MAP_KEY_SIZE},
-               proof::{CheckedMapProof, MapProof, MapProofError}};
+pub use self::{
+    key::{HashedKey, ProofMapKey, ProofPath, KEY_SIZE as PROOF_MAP_KEY_SIZE},
+    proof::{CheckedMapProof, MapProof, MapProofError},
+};
 
 use std::{fmt, marker::PhantomData};
 
-use self::{key::{BitsRange, ChildKind, LEAF_KEY_PREFIX},
-           node::{BranchNode, Node},
-           proof::{create_multiproof, create_proof}};
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use self::{
+    key::{BitsRange, ChildKind, LEAF_KEY_PREFIX}, node::{BranchNode, Node},
+    proof::{create_multiproof, create_proof},
+};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 use crypto::{CryptoHash, Hash, HashStream};
 
 mod key;

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -107,7 +107,7 @@ enum RemoveResult {
 
 impl<T, K, V> ProofMapIndex<T, K, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: ProofMapKey,
     V: StorageValue,
 {
@@ -761,7 +761,7 @@ where
 
 impl<'a, T, K, V> ::std::iter::IntoIterator for &'a ProofMapIndex<T, K, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: ProofMapKey,
     V: StorageValue,
 {
@@ -811,7 +811,7 @@ where
 
 impl<T, K, V> fmt::Debug for ProofMapIndex<T, K, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: ProofMapKey,
     V: StorageValue + fmt::Debug,
 {
@@ -825,7 +825,7 @@ where
 
         impl<'a, T, K, V> Entry<'a, T, K, V>
         where
-            T: AsRef<Snapshot>,
+            T: AsRef<dyn Snapshot>,
             K: ProofMapKey,
             V: StorageValue,
         {
@@ -849,7 +849,7 @@ where
 
         impl<'a, T, K, V> fmt::Debug for Entry<'a, T, K, V>
         where
-            T: AsRef<Snapshot>,
+            T: AsRef<dyn Snapshot>,
             K: ProofMapKey,
             V: StorageValue + fmt::Debug,
         {

--- a/exonum/src/storage/proof_map_index/node.rs
+++ b/exonum/src/storage/proof_map_index/node.rs
@@ -16,8 +16,9 @@
 
 use std::borrow::Cow;
 
-use super::{super::{StorageKey, StorageValue},
-            key::{ChildKind, ProofPath, PROOF_PATH_SIZE}};
+use super::{
+    super::{StorageKey, StorageValue}, key::{ChildKind, ProofPath, PROOF_PATH_SIZE},
+};
 use crypto::{hash, CryptoHash, Hash, HASH_SIZE};
 
 const BRANCH_NODE_SIZE: usize = 2 * (HASH_SIZE + PROOF_PATH_SIZE);

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -14,8 +14,9 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{key::{BitsRange, ChildKind, ProofMapKey, ProofPath, KEY_SIZE},
-            node::{BranchNode, Node}};
+use super::{
+    key::{BitsRange, ChildKind, ProofMapKey, ProofPath, KEY_SIZE}, node::{BranchNode, Node},
+};
 use crypto::{CryptoHash, Hash, HashStream};
 use storage::StorageValue;
 

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{
@@ -95,7 +97,6 @@ impl<'de> Deserialize<'de> for ProofPath {
 }
 
 /// An error returned when a map proof is invalid.
-#[allow(bare_trait_objects)]
 #[derive(Debug, Fail)]
 pub enum MapProofError {
     /// Non-terminal node for a map consisting of a single node.

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -95,6 +95,7 @@ impl<'de> Deserialize<'de> for ProofPath {
 }
 
 /// An error returned when a map proof is invalid.
+#[allow(bare_trait_objects)]
 #[derive(Debug, Fail)]
 pub enum MapProofError {
     /// Non-terminal node for a map consisting of a single node.

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -17,15 +17,11 @@ use serde_json;
 
 use std::{cmp, collections::HashSet, fmt::Debug, hash::Hash as StdHash};
 
-use super::{key::{BitsRange, ChildKind, KEY_SIZE, LEAF_KEY_PREFIX},
-            node::BranchNode,
-            proof::MapProofBuilder,
-            HashedKey,
-            MapProof,
-            MapProofError,
-            ProofMapIndex,
-            ProofMapKey,
-            ProofPath};
+use super::{
+    key::{BitsRange, ChildKind, KEY_SIZE, LEAF_KEY_PREFIX}, node::BranchNode,
+    proof::MapProofBuilder, HashedKey, MapProof, MapProofError, ProofMapIndex, ProofMapKey,
+    ProofPath,
+};
 use crypto::{hash, CryptoHash, Hash, HashStream};
 use encoding::serialize::reexport::{DeserializeOwned, Serialize};
 use storage::{Database, Fork, StorageValue};

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -79,7 +79,7 @@ fn gen_tempdir_name() -> String {
     rand::thread_rng().gen_ascii_chars().take(10).collect()
 }
 
-fn insert_trivial(db1: Box<Database>, db2: Box<Database>) {
+fn insert_trivial(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut storage2 = db2.fork();
 
@@ -100,7 +100,7 @@ fn insert_trivial(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index1.merkle_root(), index2.merkle_root());
 }
 
-fn insert_same_key(db: Box<Database>) {
+fn insert_same_key(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
     assert_eq!(table.merkle_root(), Hash::zero());
@@ -116,7 +116,7 @@ fn insert_same_key(db: Box<Database>) {
     assert_eq!(table.merkle_root(), hash);
 }
 
-fn insert_simple(db1: Box<Database>, db2: Box<Database>) {
+fn insert_simple(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut storage2 = db2.fork();
 
@@ -136,7 +136,7 @@ fn insert_simple(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index1.merkle_root(), index2.merkle_root());
 }
 
-fn insert_reverse(db1: Box<Database>, db2: Box<Database>) {
+fn insert_reverse(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut index1 = ProofMapIndex::new(IDX_NAME, &mut storage1);
     index1.put(&[42; 32], vec![1]);
@@ -159,7 +159,7 @@ fn insert_reverse(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index2.merkle_root(), index1.merkle_root());
 }
 
-fn remove_trivial(db1: Box<Database>, db2: Box<Database>) {
+fn remove_trivial(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut index1 = ProofMapIndex::new(IDX_NAME, &mut storage1);
     index1.put(&[255; 32], vec![6]);
@@ -174,7 +174,7 @@ fn remove_trivial(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index2.merkle_root(), Hash::zero());
 }
 
-fn remove_simple(db1: Box<Database>, db2: Box<Database>) {
+fn remove_simple(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut index1 = ProofMapIndex::new(IDX_NAME, &mut storage1);
     index1.put(&[255; 32], vec![1]);
@@ -203,7 +203,7 @@ fn remove_simple(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index1.merkle_root(), index2.merkle_root());
 }
 
-fn remove_reverse(db1: Box<Database>, db2: Box<Database>) {
+fn remove_reverse(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut storage1 = db1.fork();
     let mut index1 = ProofMapIndex::new(IDX_NAME, &mut storage1);
     index1.put(&[42; 32], vec![1]);
@@ -239,7 +239,7 @@ fn remove_reverse(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index2.merkle_root(), index1.merkle_root());
 }
 
-fn fuzz_insert(db1: Box<Database>, db2: Box<Database>) {
+fn fuzz_insert(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut data = generate_random_data(100);
     let mut rng = rand::thread_rng();
     let mut storage1 = db1.fork();
@@ -376,7 +376,7 @@ fn check_map_multiproof<K, V>(
 
 const MAX_CHECKED_ELEMENTS: usize = 1_024;
 
-fn check_proofs_for_data<K, V>(db: &Box<Database>, data: Vec<(K, V)>, nonexisting_keys: Vec<K>)
+fn check_proofs_for_data<K, V>(db: &Box<dyn Database>, data: Vec<(K, V)>, nonexisting_keys: Vec<K>)
 where
     K: ProofMapKey + Copy + PartialEq + Debug + Serialize + DeserializeOwned,
     V: StorageValue + Clone + PartialEq + Debug + Serialize + DeserializeOwned,
@@ -410,7 +410,7 @@ where
     }
 }
 
-fn check_multiproofs_for_data<K, V>(db: &Box<Database>, data: Vec<(K, V)>, nonexisting_keys: Vec<K>)
+fn check_multiproofs_for_data<K, V>(db: &Box<dyn Database>, data: Vec<(K, V)>, nonexisting_keys: Vec<K>)
 where
     K: ProofMapKey + Copy + Ord + PartialEq + StdHash + Debug + Serialize,
     V: StorageValue + Clone + PartialEq + Debug + Serialize,
@@ -514,7 +514,7 @@ fn test_invalid_map_proofs() {
     }
 }
 
-fn build_proof_in_empty_tree(db: Box<Database>) {
+fn build_proof_in_empty_tree(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -527,7 +527,7 @@ fn build_proof_in_empty_tree(db: Box<Database>) {
     check_map_proof(proof, None, &table);
 }
 
-fn build_multiproof_in_empty_tree(db: Box<Database>) {
+fn build_multiproof_in_empty_tree(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -541,7 +541,7 @@ fn build_multiproof_in_empty_tree(db: Box<Database>) {
     check_map_multiproof(proof, keys, &table);
 }
 
-fn build_proof_in_single_node_tree(db: Box<Database>) {
+fn build_proof_in_single_node_tree(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -558,7 +558,7 @@ fn build_proof_in_single_node_tree(db: Box<Database>) {
     check_map_proof(proof, None, &table);
 }
 
-fn build_multiproof_in_single_node_tree(db: Box<Database>) {
+fn build_multiproof_in_single_node_tree(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -578,7 +578,7 @@ fn build_multiproof_in_single_node_tree(db: Box<Database>) {
     check_map_multiproof(proof, keys, &table);
 }
 
-fn build_proof_in_complex_tree(db: Box<Database>) {
+fn build_proof_in_complex_tree(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -777,7 +777,7 @@ fn build_proof_in_complex_tree(db: Box<Database>) {
     check_map_proof(proof, Some([32; 32]), &table);
 }
 
-fn build_multiproof_simple(db: Box<Database>) {
+fn build_multiproof_simple(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut table = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -949,7 +949,7 @@ fn build_multiproof_simple(db: Box<Database>) {
     check_map_multiproof(proof, keys, &table);
 }
 
-fn fuzz_insert_build_proofs_in_table_filled_with_hashes(db: Box<Database>) {
+fn fuzz_insert_build_proofs_in_table_filled_with_hashes(db: Box<dyn Database>) {
     let mut rng: XorShiftRng = rand::random();
     let batch_sizes = (7..9).map(|x| 1 << x);
 
@@ -969,7 +969,7 @@ fn fuzz_insert_build_proofs_in_table_filled_with_hashes(db: Box<Database>) {
     }
 }
 
-fn fuzz_insert_build_proofs(db: Box<Database>) {
+fn fuzz_insert_build_proofs(db: Box<dyn Database>) {
     let mut rng: XorShiftRng = rand::random();
     let batch_sizes = (7..9).map(|x| (1 << x) - 1);
 
@@ -986,7 +986,7 @@ fn fuzz_insert_build_proofs(db: Box<Database>) {
     }
 }
 
-fn fuzz_insert_build_multiproofs(db: Box<Database>) {
+fn fuzz_insert_build_multiproofs(db: Box<dyn Database>) {
     let mut rng: XorShiftRng = rand::random();
     let batch_sizes = (7..9).map(|x| 1 << x);
 
@@ -1003,7 +1003,7 @@ fn fuzz_insert_build_multiproofs(db: Box<Database>) {
     }
 }
 
-fn fuzz_delete_build_proofs(db: Box<Database>) {
+fn fuzz_delete_build_proofs(db: Box<dyn Database>) {
     const SAMPLE_SIZE: usize = 200;
 
     let mut rng: XorShiftRng = rand::random();
@@ -1043,7 +1043,7 @@ fn fuzz_delete_build_proofs(db: Box<Database>) {
     }
 }
 
-fn fuzz_delete(db1: Box<Database>, db2: Box<Database>) {
+fn fuzz_delete(db1: Box<dyn Database>, db2: Box<dyn Database>) {
     let mut data = generate_random_data(100);
     let mut rng = rand::thread_rng();
     let mut storage1 = db1.fork();
@@ -1103,7 +1103,7 @@ fn fuzz_delete(db1: Box<Database>, db2: Box<Database>) {
     assert_eq!(index2.merkle_root(), saved_hash);
 }
 
-fn fuzz_insert_after_delete(db: Box<Database>) {
+fn fuzz_insert_after_delete(db: Box<dyn Database>) {
     let mut storage = db.fork();
     let mut index = ProofMapIndex::new(IDX_NAME, &mut storage);
 
@@ -1131,7 +1131,7 @@ fn fuzz_insert_after_delete(db: Box<Database>) {
     assert_eq!(index.merkle_root(), saved_hash);
 }
 
-fn iter(db: Box<Database>) {
+fn iter(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut map_index = ProofMapIndex::new(IDX_NAME, &mut fork);
 
@@ -1206,7 +1206,7 @@ fn iter(db: Box<Database>) {
     );
 }
 
-fn tree_with_hashed_key(db: Box<Database>) {
+fn tree_with_hashed_key(db: Box<dyn Database>) {
     use std::iter::FromIterator;
 
     encoding_struct! {
@@ -1339,7 +1339,7 @@ mod memorydb_tests {
     use storage::{Database, MemoryDB};
     use tempdir::TempDir;
 
-    fn create_database(_: &Path) -> Box<Database> {
+    fn create_database(_: &Path) -> Box<dyn Database> {
         Box::new(MemoryDB::new())
     }
 
@@ -1351,7 +1351,7 @@ mod rocksdb_tests {
     use storage::{Database, DbOptions, RocksDB};
     use tempdir::TempDir;
 
-    fn create_database(path: &Path) -> Box<Database> {
+    fn create_database(path: &Path) -> Box<dyn Database> {
         let opts = DbOptions::default();
         Box::new(RocksDB::open(path, &opts).unwrap())
     }

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -410,8 +410,11 @@ where
     }
 }
 
-fn check_multiproofs_for_data<K, V>(db: &Box<dyn Database>, data: Vec<(K, V)>, nonexisting_keys: Vec<K>)
-where
+fn check_multiproofs_for_data<K, V>(
+    db: &Box<dyn Database>,
+    data: Vec<(K, V)>,
+    nonexisting_keys: Vec<K>,
+) where
     K: ProofMapKey + Copy + Ord + PartialEq + StdHash + Debug + Serialize,
     V: StorageValue + Clone + PartialEq + Debug + Serialize,
 {

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -92,7 +92,7 @@ impl RocksDB {
 }
 
 impl Database for RocksDB {
-    fn snapshot(&self) -> Box<Snapshot> {
+    fn snapshot(&self) -> Box<dyn Snapshot> {
         Box::new(RocksDBSnapshot {
             snapshot: unsafe { mem::transmute(self.db.snapshot()) },
             _db: Arc::clone(&self.db),
@@ -159,9 +159,9 @@ impl Iterator for RocksDBIterator {
     }
 }
 
-impl From<RocksDB> for Arc<Database> {
-    fn from(db: RocksDB) -> Arc<Database> {
-        Arc::from(Box::new(db) as Box<Database>)
+impl From<RocksDB> for Arc<dyn Database> {
+    fn from(db: RocksDB) -> Arc<dyn Database> {
+        Arc::from(Box::new(db) as Box<dyn Database>)
     }
 }
 

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -21,12 +21,10 @@ use byteorder::{BigEndian, ByteOrder};
 
 use std::{borrow::Cow, cell::Cell, marker::PhantomData};
 
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 use crypto::{hash, CryptoHash, Hash};
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -118,7 +118,7 @@ pub struct SparseListIndexValues<'a, V> {
 
 impl<T, V> SparseListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     /// Creates a new index representation based on the name and storage view.
@@ -576,7 +576,7 @@ where
 
 impl<'a, T, V> ::std::iter::IntoIterator for &'a SparseListIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     type Item = (u64, V);

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -629,7 +629,7 @@ mod tests {
         thread_rng().gen_ascii_chars().take(10).collect()
     }
 
-    fn list_index_methods(db: Box<Database>) {
+    fn list_index_methods(db: Box<dyn Database>) {
         let mut fork = db.fork();
         let mut list_index = SparseListIndex::new(IDX_NAME, &mut fork);
 
@@ -693,7 +693,7 @@ mod tests {
         assert_eq!(43, list_index.capacity());
     }
 
-    fn list_index_iter(db: Box<Database>) {
+    fn list_index_iter(db: Box<dyn Database>) {
         let mut fork = db.fork();
         let mut list_index = SparseListIndex::new(IDX_NAME, &mut fork);
 
@@ -737,7 +737,7 @@ mod tests {
         use storage::{Database, MemoryDB};
         use tempdir::TempDir;
 
-        fn create_database(_: &Path) -> Box<Database> {
+        fn create_database(_: &Path) -> Box<dyn Database> {
             Box::new(MemoryDB::new())
         }
 
@@ -763,7 +763,7 @@ mod tests {
         use storage::{Database, DbOptions, RocksDB};
         use tempdir::TempDir;
 
-        fn create_database(path: &Path) -> Box<Database> {
+        fn create_database(path: &Path) -> Box<dyn Database> {
             let opts = DbOptions::default();
             Box::new(RocksDB::open(path, &opts).unwrap())
         }

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -16,12 +16,10 @@
 
 use std::marker::PhantomData;
 
-use super::{base_index::{BaseIndex, BaseIndexIter},
-            indexes_metadata::IndexType,
-            Fork,
-            Snapshot,
-            StorageKey,
-            StorageValue};
+use super::{
+    base_index::{BaseIndex, BaseIndexIter}, indexes_metadata::IndexType, Fork, Snapshot,
+    StorageKey, StorageValue,
+};
 use crypto::Hash;
 
 /// A set of items that implement `StorageValue` trait.

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -62,7 +62,7 @@ pub struct ValueSetIndexHashes<'a> {
 
 impl<T, V> ValueSetIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     /// Creates a new index representation based on the name and storage view.
@@ -363,7 +363,7 @@ where
 
 impl<'a, T, V> ::std::iter::IntoIterator for &'a ValueSetIndex<T, V>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     V: StorageValue,
 {
     type Item = (Hash, V);

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -23,12 +23,9 @@ extern crate toml;
 use exonum::{api::backends::actix::AllowOrigin, helpers::fabric::NodeBuilder};
 use toml::Value;
 
-use std::{ffi::OsString,
-          fs,
-          fs::{File, OpenOptions},
-          io::{Read, Write},
-          panic,
-          path::Path};
+use std::{
+    ffi::OsString, fs, fs::{File, OpenOptions}, io::{Read, Write}, panic, path::Path,
+};
 
 const CONFIG_TMP_FOLDER: &str = "/tmp/";
 const CONFIG_TESTDATA_FOLDER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testdata/config/");

--- a/exonum/tests/explorer/blockchain.rs
+++ b/exonum/tests/explorer/blockchain.rs
@@ -17,13 +17,13 @@
 extern crate futures;
 
 use self::futures::sync::mpsc;
-use exonum::{blockchain::{Blockchain, ExecutionError, ExecutionResult, Schema, Service,
-                          Transaction, TransactionSet},
-             crypto::{self, CryptoHash, Hash, PublicKey, SecretKey},
-             encoding::Error as EncodingError,
-             messages::RawTransaction,
-             node::ApiSender,
-             storage::{Fork, MemoryDB, Snapshot}};
+use exonum::{
+    blockchain::{
+        Blockchain, ExecutionError, ExecutionResult, Schema, Service, Transaction, TransactionSet,
+    },
+    crypto::{self, CryptoHash, Hash, PublicKey, SecretKey}, encoding::Error as EncodingError,
+    messages::RawTransaction, node::ApiSender, storage::{Fork, MemoryDB, Snapshot},
+};
 
 transactions! {
     Transactions {

--- a/exonum/tests/explorer/main.rs
+++ b/exonum/tests/explorer/main.rs
@@ -21,11 +21,11 @@ extern crate serde_json;
 
 use serde_json::Value as JsonValue;
 
-use exonum::{blockchain::{Schema, Transaction, TransactionErrorType, TxLocation},
-             crypto::{self, CryptoHash, Hash},
-             explorer::*,
-             helpers::Height,
-             messages::{Message, ServiceMessage}};
+use exonum::{
+    blockchain::{Schema, Transaction, TransactionErrorType, TxLocation},
+    crypto::{self, CryptoHash, Hash}, explorer::*, helpers::Height,
+    messages::{Message, ServiceMessage},
+};
 
 use blockchain::{create_block, create_blockchain, CreateWallet, Transfer};
 

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -22,17 +22,15 @@ use futures::{sync::oneshot, Future};
 use serde_json::Value;
 use tokio_timer::Timer;
 
-use std::{sync::{Arc, Mutex},
-          thread::{self, JoinHandle},
-          time::Duration};
+use std::{
+    sync::{Arc, Mutex}, thread::{self, JoinHandle}, time::Duration,
+};
 
-use exonum::{blockchain::{Service, ServiceContext, Transaction},
-             crypto::Hash,
-             encoding::Error as EncodingError,
-             helpers,
-             messages::RawTransaction,
-             node::{ApiSender, ExternalMessage, Node},
-             storage::{Database, Fork, MemoryDB, Snapshot}};
+use exonum::{
+    blockchain::{Service, ServiceContext, Transaction}, crypto::Hash,
+    encoding::Error as EncodingError, helpers, messages::RawTransaction,
+    node::{ApiSender, ExternalMessage, Node}, storage::{Database, Fork, MemoryDB, Snapshot},
+};
 
 struct CommitWatcherService(pub Mutex<Option<oneshot::Sender<()>>>);
 

--- a/exonum/tests/proof_map_index.rs
+++ b/exonum/tests/proof_map_index.rs
@@ -26,18 +26,15 @@ extern crate exonum;
 #[macro_use]
 extern crate proptest;
 
-use exonum::storage::{proof_map_index::{ProofMapKey, ProofPath},
-                      Database,
-                      MapProof,
-                      MemoryDB,
-                      ProofMapIndex,
-                      Snapshot,
-                      StorageValue};
+use exonum::storage::{
+    proof_map_index::{ProofMapKey, ProofPath}, Database, MapProof, MemoryDB, ProofMapIndex,
+    Snapshot, StorageValue,
+};
 use proptest::{num::u8::BinarySearch as U8BinarySearch, prelude::*, test_runner::Config};
 
-use std::{collections::{BTreeMap, BTreeSet},
-          fmt::Debug,
-          ops::Range};
+use std::{
+    collections::{BTreeMap, BTreeSet}, fmt::Debug, ops::Range,
+};
 
 const INDEX_NAME: &str = "index";
 

--- a/services/configuration/src/api.rs
+++ b/services/configuration/src/api.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{api::{self, ServiceApiBuilder, ServiceApiState},
-             blockchain::{Schema as CoreSchema, StoredConfiguration},
-             crypto::{CryptoHash, Hash},
-             helpers::Height,
-             node::TransactionSend,
-             storage::StorageValue};
+use exonum::{
+    api::{self, ServiceApiBuilder, ServiceApiState},
+    blockchain::{Schema as CoreSchema, StoredConfiguration}, crypto::{CryptoHash, Hash},
+    helpers::Height, node::TransactionSend, storage::StorageValue,
+};
 
 use super::{Propose, ProposeData, Schema, Vote, VoteAgainst, VotingDecision};
 

--- a/services/configuration/src/errors.rs
+++ b/services/configuration/src/errors.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{blockchain::{ExecutionError, StoredConfiguration},
-             crypto::Hash,
-             encoding::serialize::json::reexport::Error as JsonError,
-             helpers::Height};
+use exonum::{
+    blockchain::{ExecutionError, StoredConfiguration}, crypto::Hash,
+    encoding::serialize::json::reexport::Error as JsonError, helpers::Height,
+};
 
 use transactions::Propose;
 

--- a/services/configuration/src/errors.rs
+++ b/services/configuration/src/errors.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 use exonum::{

--- a/services/configuration/src/errors.rs
+++ b/services/configuration/src/errors.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(bare_trait_objects)]
+
 use exonum::{
     blockchain::{ExecutionError, StoredConfiguration}, crypto::Hash,
     encoding::serialize::json::reexport::Error as JsonError, helpers::Height,

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -111,12 +111,12 @@ impl blockchain::Service for Service {
         SERVICE_ID
     }
 
-    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, snapshot: &dyn Snapshot) -> Vec<Hash> {
         let schema = Schema::new(snapshot);
         schema.state_hash()
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, EncodingError> {
         ConfigurationTransactions::tx_from_raw(raw).map(Into::into)
     }
 
@@ -135,7 +135,7 @@ impl fabric::ServiceFactory for ServiceFactory {
         SERVICE_NAME
     }
 
-    fn make_service(&mut self, _: &Context) -> Box<blockchain::Service> {
+    fn make_service(&mut self, _: &Context) -> Box<dyn blockchain::Service> {
         Box::new(Service {})
     }
 }

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -80,13 +80,11 @@ pub use errors::ErrorCode;
 pub use schema::{MaybeVote, ProposeData, Schema, VotingDecision};
 pub use transactions::{ConfigurationTransactions, Propose, Vote, VoteAgainst};
 
-use exonum::{api::ServiceApiBuilder,
-             blockchain::{self, Transaction, TransactionSet},
-             crypto::Hash,
-             encoding::Error as EncodingError,
-             helpers::fabric::{self, Context},
-             messages::RawTransaction,
-             storage::Snapshot};
+use exonum::{
+    api::ServiceApiBuilder, blockchain::{self, Transaction, TransactionSet}, crypto::Hash,
+    encoding::Error as EncodingError, helpers::fabric::{self, Context}, messages::RawTransaction,
+    storage::Snapshot,
+};
 
 mod api;
 mod errors;

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -53,7 +53,7 @@
 //! }
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 #[macro_use]
 extern crate exonum;

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -53,7 +53,7 @@
 //! }
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
 
 #[macro_use]
 extern crate exonum;

--- a/services/configuration/src/schema.rs
+++ b/services/configuration/src/schema.rs
@@ -14,9 +14,10 @@
 
 //! Storage schema for the configuration service.
 
-use exonum::{crypto::{self, CryptoHash, Hash, PublicKey, Signature},
-             messages::{RawMessage, ServiceMessage},
-             storage::{Fork, ProofListIndex, ProofMapIndex, Snapshot, StorageValue}};
+use exonum::{
+    crypto::{self, CryptoHash, Hash, PublicKey, Signature}, messages::{RawMessage, ServiceMessage},
+    storage::{Fork, ProofListIndex, ProofMapIndex, Snapshot, StorageValue},
+};
 
 use std::{borrow::Cow, ops::Deref};
 

--- a/services/configuration/src/schema.rs
+++ b/services/configuration/src/schema.rs
@@ -204,7 +204,10 @@ where
 
     /// Returns a table of votes of validators for a particular proposal, referenced
     /// by its configuration hash.
-    pub fn votes_by_config_hash(&self, config_hash: &Hash) -> ProofListIndex<&dyn Snapshot, MaybeVote> {
+    pub fn votes_by_config_hash(
+        &self,
+        config_hash: &Hash,
+    ) -> ProofListIndex<&dyn Snapshot, MaybeVote> {
         ProofListIndex::new_in_family(VOTES, config_hash, self.view.as_ref())
     }
 

--- a/services/configuration/src/schema.rs
+++ b/services/configuration/src/schema.rs
@@ -181,7 +181,7 @@ pub struct Schema<T> {
 
 impl<T> Schema<T>
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
 {
     /// Creates a new schema.
     pub fn new(snapshot: T) -> Schema<T> {
@@ -193,18 +193,18 @@ where
     ///
     /// Consult [the crate-level docs](index.html) for details how hashes of the configuration
     /// are calculated.
-    pub fn propose_data_by_config_hash(&self) -> ProofMapIndex<&Snapshot, Hash, ProposeData> {
+    pub fn propose_data_by_config_hash(&self) -> ProofMapIndex<&dyn Snapshot, Hash, ProposeData> {
         ProofMapIndex::new(PROPOSES, self.view.as_ref())
     }
 
     /// Returns a table of hashes of proposed configurations in the commit order.
-    pub fn config_hash_by_ordinal(&self) -> ProofListIndex<&Snapshot, Hash> {
+    pub fn config_hash_by_ordinal(&self) -> ProofListIndex<&dyn Snapshot, Hash> {
         ProofListIndex::new(PROPOSE_HASHES, self.view.as_ref())
     }
 
     /// Returns a table of votes of validators for a particular proposal, referenced
     /// by its configuration hash.
-    pub fn votes_by_config_hash(&self, config_hash: &Hash) -> ProofListIndex<&Snapshot, MaybeVote> {
+    pub fn votes_by_config_hash(&self, config_hash: &Hash) -> ProofListIndex<&dyn Snapshot, MaybeVote> {
         ProofListIndex::new_in_family(VOTES, config_hash, self.view.as_ref())
     }
 

--- a/services/configuration/src/tests/api.rs
+++ b/services/configuration/src/tests/api.rs
@@ -14,15 +14,20 @@
 
 // spell-checker:ignore postpropose, postvote
 
-use exonum::{blockchain::{Schema, StoredConfiguration},
-             crypto::{CryptoHash, Hash},
-             helpers::{Height, ValidatorId}};
+use exonum::{
+    blockchain::{Schema, StoredConfiguration}, crypto::{CryptoHash, Hash},
+    helpers::{Height, ValidatorId},
+};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi};
 
-use super::{new_tx_config_propose, new_tx_config_vote, new_tx_config_vote_against, to_boxed,
-            ConfigurationSchema, ConfigurationTestKit};
-use api::{ConfigHashInfo, ConfigInfo, FilterQuery, HashQuery, ProposeHashInfo, ProposeResponse,
-          VoteResponse, VotesInfo};
+use super::{
+    new_tx_config_propose, new_tx_config_vote, new_tx_config_vote_against, to_boxed,
+    ConfigurationSchema, ConfigurationTestKit,
+};
+use api::{
+    ConfigHashInfo, ConfigInfo, FilterQuery, HashQuery, ProposeHashInfo, ProposeResponse,
+    VoteResponse, VotesInfo,
+};
 
 trait ConfigurationApiTest {
     fn actual_config(&self) -> ConfigHashInfo;

--- a/services/configuration/src/tests/mod.rs
+++ b/services/configuration/src/tests/mod.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{blockchain::{Schema, StoredConfiguration, Transaction},
-             crypto::{hash, CryptoHash, Hash, HASH_SIZE},
-             helpers::{Height, ValidatorId},
-             storage::StorageValue};
+use exonum::{
+    blockchain::{Schema, StoredConfiguration, Transaction},
+    crypto::{hash, CryptoHash, Hash, HASH_SIZE}, helpers::{Height, ValidatorId},
+    storage::StorageValue,
+};
 use exonum_testkit::{TestKit, TestKitBuilder, TestNode};
 
 use std::str;
 
-use {Propose, Schema as ConfigurationSchema, Service as ConfigurationService, Vote, VoteAgainst,
-     VotingDecision};
+use {
+    Propose, Schema as ConfigurationSchema, Service as ConfigurationService, Vote, VoteAgainst,
+    VotingDecision,
+};
 
 mod api;
 

--- a/services/configuration/src/tests/mod.rs
+++ b/services/configuration/src/tests/mod.rs
@@ -28,8 +28,8 @@ use {
 
 mod api;
 
-pub fn to_boxed<T: Transaction>(tx: T) -> Box<Transaction> {
-    Box::new(tx) as Box<Transaction>
+pub fn to_boxed<T: Transaction>(tx: T) -> Box<dyn Transaction> {
+    Box::new(tx) as Box<dyn Transaction>
 }
 
 pub fn new_tx_config_propose(node: &TestNode, cfg_proposal: StoredConfiguration) -> Propose {

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -14,11 +14,11 @@
 
 //! Transaction definitions for the configuration service.
 
-use exonum::{blockchain::{ExecutionResult, Schema as CoreSchema, StoredConfiguration, Transaction},
-             crypto::{CryptoHash, Hash, PublicKey},
-             messages::Message,
-             node::State,
-             storage::{Fork, Snapshot}};
+use exonum::{
+    blockchain::{ExecutionResult, Schema as CoreSchema, StoredConfiguration, Transaction},
+    crypto::{CryptoHash, Hash, PublicKey}, messages::Message, node::State,
+    storage::{Fork, Snapshot},
+};
 
 use errors::Error as ServiceError;
 use schema::{MaybeVote, ProposeData, Schema};

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -104,14 +104,14 @@ transactions! {
 ///
 /// The index of the validator authoring the transaction, or `None` if no validator matches
 /// the supplied public key.
-fn validator_index(snapshot: &Snapshot, key: &PublicKey) -> Option<usize> {
+fn validator_index(snapshot: &dyn Snapshot, key: &PublicKey) -> Option<usize> {
     let actual_config = CoreSchema::new(snapshot).actual_configuration();
     let keys = actual_config.validator_keys;
     keys.iter().position(|k| k.service_key == *key)
 }
 
 /// Checks if there is enough votes for a particular configuration hash.
-fn enough_votes_to_commit(snapshot: &Snapshot, cfg_hash: &Hash) -> bool {
+fn enough_votes_to_commit(snapshot: &dyn Snapshot, cfg_hash: &Hash) -> bool {
     let actual_config = CoreSchema::new(snapshot).actual_configuration();
 
     let schema = Schema::new(snapshot);
@@ -131,7 +131,7 @@ impl Propose {
     /// # Return value
     ///
     /// Configuration parsed from the transaction together with its hash.
-    fn precheck(&self, snapshot: &Snapshot) -> Result<(StoredConfiguration, Hash), ServiceError> {
+    fn precheck(&self, snapshot: &dyn Snapshot) -> Result<(StoredConfiguration, Hash), ServiceError> {
         use self::ServiceError::*;
         use exonum::storage::StorageValue;
 
@@ -160,7 +160,7 @@ impl Propose {
     fn check_config_candidate(
         &self,
         candidate: &StoredConfiguration,
-        snapshot: &Snapshot,
+        snapshot: &dyn Snapshot,
     ) -> Result<(), ServiceError> {
         use self::ServiceError::*;
 
@@ -279,7 +279,7 @@ impl<'a> VotingDecisionRef<'a> {
     /// # Return value
     ///
     /// Returns a configuration this transaction is for on success, or an error (if any).
-    fn precheck(&self, snapshot: &Snapshot) -> Result<StoredConfiguration, ServiceError> {
+    fn precheck(&self, snapshot: &dyn Snapshot) -> Result<StoredConfiguration, ServiceError> {
         use self::ServiceError::*;
 
         let following_config = CoreSchema::new(snapshot).following_configuration();

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -131,7 +131,10 @@ impl Propose {
     /// # Return value
     ///
     /// Configuration parsed from the transaction together with its hash.
-    fn precheck(&self, snapshot: &dyn Snapshot) -> Result<(StoredConfiguration, Hash), ServiceError> {
+    fn precheck(
+        &self,
+        snapshot: &dyn Snapshot,
+    ) -> Result<(StoredConfiguration, Hash), ServiceError> {
         use self::ServiceError::*;
         use exonum::storage::StorageValue;
 

--- a/services/time/examples/simple_service.rs
+++ b/services/time/examples/simple_service.rs
@@ -24,12 +24,11 @@ extern crate serde;
 extern crate serde_json;
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use exonum::{blockchain::{ExecutionResult, Service, Transaction, TransactionSet},
-             crypto::{gen_keypair, Hash, PublicKey},
-             encoding,
-             helpers::Height,
-             messages::{Message, RawTransaction},
-             storage::{Fork, ProofMapIndex, Snapshot}};
+use exonum::{
+    blockchain::{ExecutionResult, Service, Transaction, TransactionSet},
+    crypto::{gen_keypair, Hash, PublicKey}, encoding, helpers::Height,
+    messages::{Message, RawTransaction}, storage::{Fork, ProofMapIndex, Snapshot},
+};
 use exonum_testkit::TestKitBuilder;
 use exonum_time::{schema::TimeSchema, time_provider::MockTimeProvider, TimeService};
 

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -60,13 +60,13 @@ pub const SERVICE_NAME: &str = "exonum_time";
 #[derive(Debug)]
 pub struct TimeService {
     /// Current time.
-    time: Box<TimeProvider>,
+    time: Box<dyn TimeProvider>,
 }
 
 impl Default for TimeService {
     fn default() -> TimeService {
         TimeService {
-            time: Box::new(SystemTimeProvider) as Box<TimeProvider>,
+            time: Box::new(SystemTimeProvider) as Box<dyn TimeProvider>,
         }
     }
 }
@@ -78,7 +78,7 @@ impl TimeService {
     }
 
     /// Create a new `TimeService` with time provider `T`.
-    pub fn with_provider<T: Into<Box<TimeProvider>>>(time_provider: T) -> TimeService {
+    pub fn with_provider<T: Into<Box<dyn TimeProvider>>>(time_provider: T) -> TimeService {
         TimeService {
             time: time_provider.into(),
         }
@@ -90,7 +90,7 @@ impl Service for TimeService {
         SERVICE_NAME
     }
 
-    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, snapshot: &dyn Snapshot) -> Vec<Hash> {
         let schema = TimeSchema::new(snapshot);
         schema.state_hash()
     }
@@ -99,7 +99,7 @@ impl Service for TimeService {
         SERVICE_ID
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, encoding::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, encoding::Error> {
         TimeTransactions::tx_from_raw(raw).map(Into::into)
     }
 
@@ -139,7 +139,7 @@ impl ServiceFactory for TimeServiceFactory {
         SERVICE_NAME
     }
 
-    fn make_service(&mut self, _: &Context) -> Box<Service> {
+    fn make_service(&mut self, _: &Context) -> Box<dyn Service> {
         Box::new(TimeService::new())
     }
 }

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! [docs:time]: https://exonum.com/doc/advanced/time
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 extern crate chrono;
 #[macro_use]

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -40,13 +40,12 @@ pub mod time_provider;
 /// Node transactions.
 pub mod transactions;
 
-use exonum::{api::ServiceApiBuilder,
-             blockchain::{Service, ServiceContext, Transaction, TransactionSet},
-             crypto::Hash,
-             encoding::{self, serialize::json::reexport::Value},
-             helpers::fabric::{Context, ServiceFactory},
-             messages::RawTransaction,
-             storage::{Fork, Snapshot}};
+use exonum::{
+    api::ServiceApiBuilder, blockchain::{Service, ServiceContext, Transaction, TransactionSet},
+    crypto::Hash, encoding::{self, serialize::json::reexport::Value},
+    helpers::fabric::{Context, ServiceFactory}, messages::RawTransaction,
+    storage::{Fork, Snapshot},
+};
 use schema::TimeSchema;
 
 use time_provider::{SystemTimeProvider, TimeProvider};

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! [docs:time]: https://exonum.com/doc/advanced/time
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
 
 extern crate chrono;
 #[macro_use]

--- a/services/time/src/schema.rs
+++ b/services/time/src/schema.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
-use exonum::{crypto::{Hash, PublicKey},
-             storage::{Entry, Fork, ProofMapIndex, Snapshot}};
+use exonum::{
+    crypto::{Hash, PublicKey}, storage::{Entry, Fork, ProofMapIndex, Snapshot},
+};
 
 /// `Exonum-time` service database schema.
 #[derive(Debug)]

--- a/services/time/src/schema.rs
+++ b/services/time/src/schema.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use chrono::{DateTime, Utc};
 use exonum::{
     crypto::{Hash, PublicKey}, storage::{Entry, Fork, ProofMapIndex, Snapshot},
@@ -9,19 +23,19 @@ pub struct TimeSchema<T> {
     view: T,
 }
 
-impl<T: AsRef<Snapshot>> TimeSchema<T> {
+impl<T: AsRef<dyn Snapshot>> TimeSchema<T> {
     /// Constructs schema for the given `snapshot`.
     pub fn new(view: T) -> Self {
         TimeSchema { view }
     }
 
     /// Returns the table that stores `DateTime` for every validator.
-    pub fn validators_times(&self) -> ProofMapIndex<&Snapshot, PublicKey, DateTime<Utc>> {
+    pub fn validators_times(&self) -> ProofMapIndex<&dyn Snapshot, PublicKey, DateTime<Utc>> {
         ProofMapIndex::new("exonum_time.validators_times", self.view.as_ref())
     }
 
     /// Returns stored time.
-    pub fn time(&self) -> Entry<&Snapshot, DateTime<Utc>> {
+    pub fn time(&self) -> Entry<&dyn Snapshot, DateTime<Utc>> {
         Entry::new("exonum_time.time", self.view.as_ref())
     }
 

--- a/services/time/src/time_provider.rs
+++ b/services/time/src/time_provider.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use chrono::{DateTime, Duration, TimeZone, Utc};
 
 use std::sync::{Arc, RwLock};
@@ -103,8 +117,8 @@ impl TimeProvider for MockTimeProvider {
     }
 }
 
-impl From<MockTimeProvider> for Box<TimeProvider> {
+impl From<MockTimeProvider> for Box<dyn TimeProvider> {
     fn from(mock_time_provider: MockTimeProvider) -> Self {
-        Box::new(mock_time_provider) as Box<TimeProvider>
+        Box::new(mock_time_provider) as Box<dyn TimeProvider>
     }
 }

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
-use exonum::{blockchain::{ExecutionError, ExecutionResult, Schema, Transaction},
-             crypto::PublicKey,
-             messages::Message,
-             storage::{Fork, Snapshot}};
+use exonum::{
+    blockchain::{ExecutionError, ExecutionResult, Schema, Transaction}, crypto::PublicKey,
+    messages::Message, storage::{Fork, Snapshot},
+};
 
 use schema::TimeSchema;
 

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Workaround for `failure` see https://github.com/rust-lang-nursery/failure/issues/223 and
+// ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
 use chrono::{DateTime, Utc};

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -1,3 +1,19 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(bare_trait_objects)]
+
 use chrono::{DateTime, Utc};
 use exonum::{
     blockchain::{ExecutionError, ExecutionResult, Schema, Transaction}, crypto::PublicKey,
@@ -44,7 +60,7 @@ transactions! {
 }
 
 impl TxTime {
-    fn check_signed_by_validator(&self, snapshot: &Snapshot) -> ExecutionResult {
+    fn check_signed_by_validator(&self, snapshot: &dyn Snapshot) -> ExecutionResult {
         let keys = Schema::new(&snapshot).actual_configuration().validator_keys;
         let signed = keys.iter().any(|k| k.service_key == *self.pub_key());
         if !signed {

--- a/services/time/tests/test_exonum_time.rs
+++ b/services/time/tests/test_exonum_time.rs
@@ -21,13 +21,16 @@ extern crate exonum_time;
 extern crate pretty_assertions;
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use exonum::{blockchain::{Schema, Transaction, TransactionErrorType},
-             crypto::{gen_keypair, CryptoHash, PublicKey},
-             helpers::{Height, ValidatorId},
-             storage::Snapshot};
+use exonum::{
+    blockchain::{Schema, Transaction, TransactionErrorType},
+    crypto::{gen_keypair, CryptoHash, PublicKey}, helpers::{Height, ValidatorId},
+    storage::Snapshot,
+};
 use exonum_testkit::{ApiKind, TestKitApi, TestKitBuilder, TestNode};
-use exonum_time::{api::ValidatorTime, schema::TimeSchema, time_provider::MockTimeProvider,
-                  transactions::Error, transactions::TxTime, TimeService};
+use exonum_time::{
+    api::ValidatorTime, schema::TimeSchema, time_provider::MockTimeProvider, transactions::Error,
+    transactions::TxTime, TimeService,
+};
 
 use std::{collections::HashMap, iter::FromIterator};
 

--- a/testkit/examples/configuration_change.rs
+++ b/testkit/examples/configuration_change.rs
@@ -17,9 +17,9 @@ extern crate exonum_testkit;
 extern crate serde;
 extern crate serde_json;
 
-use exonum::{blockchain::Schema,
-             crypto::CryptoHash,
-             helpers::{Height, ValidatorId}};
+use exonum::{
+    blockchain::Schema, crypto::CryptoHash, helpers::{Height, ValidatorId},
+};
 use exonum_testkit::TestKitBuilder;
 
 fn main() {

--- a/testkit/examples/timestamping.rs
+++ b/testkit/examples/timestamping.rs
@@ -18,12 +18,12 @@ extern crate exonum;
 extern crate exonum_testkit;
 extern crate serde_json;
 
-use exonum::{api::node::public::explorer::{BlocksQuery, BlocksRange, TransactionQuery},
-             blockchain::{ExecutionResult, Schema, Service, Transaction, TransactionSet},
-             crypto::{gen_keypair, CryptoHash, Hash, PublicKey},
-             encoding,
-             messages::{Message, RawTransaction},
-             storage::{Fork, Snapshot}};
+use exonum::{
+    api::node::public::explorer::{BlocksQuery, BlocksRange, TransactionQuery},
+    blockchain::{ExecutionResult, Schema, Service, Transaction, TransactionSet},
+    crypto::{gen_keypair, CryptoHash, Hash, PublicKey}, encoding,
+    messages::{Message, RawTransaction}, storage::{Fork, Snapshot},
+};
 use exonum_testkit::{ApiKind, TestKitBuilder};
 
 // Simple service implementation.

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -92,7 +92,7 @@ impl TestKitApi {
     /// Sends a transaction to the node via `ApiSender`.
     pub fn send<T>(&self, transaction: T)
     where
-        T: Into<Box<Transaction>>,
+        T: Into<Box<dyn Transaction>>,
     {
         self.api_sender
             .send(transaction.into())

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -23,10 +23,11 @@ use serde_urlencoded;
 
 use std::fmt::{self, Display};
 
-use exonum::{api::{self, ApiAggregator, ServiceApiState},
-             blockchain::{SharedNodeState, Transaction},
-             encoding::serialize::reexport::{DeserializeOwned, Serialize},
-             node::{ApiSender, TransactionSend}};
+use exonum::{
+    api::{self, ApiAggregator, ServiceApiState}, blockchain::{SharedNodeState, Transaction},
+    encoding::serialize::reexport::{DeserializeOwned, Serialize},
+    node::{ApiSender, TransactionSend},
+};
 
 use TestKit;
 

--- a/testkit/src/checkpoint_db.rs
+++ b/testkit/src/checkpoint_db.rs
@@ -44,7 +44,7 @@ impl<T: Database> CheckpointDb<T> {
 }
 
 impl<T: Database> Database for CheckpointDb<T> {
-    fn snapshot(&self) -> Box<Snapshot> {
+    fn snapshot(&self) -> Box<dyn Snapshot> {
         self.inner
             .read()
             .expect("Cannot lock CheckpointDb for snapshot")
@@ -63,9 +63,9 @@ impl<T: Database> Database for CheckpointDb<T> {
     }
 }
 
-impl<T: Database> From<CheckpointDb<T>> for Arc<Database> {
-    fn from(db: CheckpointDb<T>) -> Arc<Database> {
-        Arc::from(Box::new(db) as Box<Database>)
+impl<T: Database> From<CheckpointDb<T>> for Arc<dyn Database> {
+    fn from(db: CheckpointDb<T>) -> Arc<dyn Database> {
+        Arc::from(Box::new(db) as Box<dyn Database>)
     }
 }
 
@@ -113,7 +113,7 @@ impl<T: Database> CheckpointDbInner<T> {
         }
     }
 
-    fn snapshot(&self) -> Box<Snapshot> {
+    fn snapshot(&self) -> Box<dyn Snapshot> {
         self.db.snapshot()
     }
 

--- a/testkit/src/compare.rs
+++ b/testkit/src/compare.rs
@@ -215,11 +215,11 @@ impl<T: PartialEq + ::std::fmt::Debug> Comparison<T> {
 /// method with a signature like `fn<S: AsRef<Snapshot>>(view: S) -> Self`.
 pub trait ComparableSnapshot<S> {
     /// Compares this snapshot with an older one.
-    fn compare(self, old: S) -> Comparison<Box<Snapshot>>;
+    fn compare(self, old: S) -> Comparison<Box<dyn Snapshot>>;
 }
 
-impl ComparableSnapshot<Box<Snapshot>> for Box<Snapshot> {
-    fn compare(self, old: Box<Snapshot>) -> Comparison<Box<Snapshot>> {
+impl ComparableSnapshot<Box<dyn Snapshot>> for Box<dyn Snapshot> {
+    fn compare(self, old: Box<dyn Snapshot>) -> Comparison<Box<dyn Snapshot>> {
         Comparison::new(old, self)
     }
 }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -164,16 +164,15 @@ use tokio_core::reactor::Core;
 use std::sync::{Arc, RwLock};
 use std::{fmt, net::SocketAddr};
 
-use exonum::{api::{backends::actix::{ApiRuntimeConfig, SystemRuntimeConfig},
-                   ApiAccess},
-             blockchain::{Blockchain, Schema as CoreSchema, Service, StoredConfiguration,
-                          Transaction},
-             crypto::{self, Hash},
-             explorer::{BlockWithTransactions, BlockchainExplorer},
-             helpers::{Height, ValidatorId},
-             messages::RawMessage,
-             node::{ApiSender, ExternalMessage, State as NodeState},
-             storage::{MemoryDB, Patch, Snapshot}};
+use exonum::{
+    api::{
+        backends::actix::{ApiRuntimeConfig, SystemRuntimeConfig}, ApiAccess,
+    },
+    blockchain::{Blockchain, Schema as CoreSchema, Service, StoredConfiguration, Transaction},
+    crypto::{self, Hash}, explorer::{BlockWithTransactions, BlockchainExplorer},
+    helpers::{Height, ValidatorId}, messages::RawMessage,
+    node::{ApiSender, ExternalMessage, State as NodeState}, storage::{MemoryDB, Patch, Snapshot},
+};
 
 use checkpoint_db::{CheckpointDb, CheckpointDbHandler};
 use poll_events::poll_events;

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -132,7 +132,7 @@
 //! }
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_objects)]
 
 extern crate actix_web;
 #[cfg_attr(test, macro_use)]

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -270,7 +270,7 @@ mod server;
 pub struct TestKitBuilder {
     our_validator_id: Option<ValidatorId>,
     validator_count: Option<u16>,
-    services: Vec<Box<Service>>,
+    services: Vec<Box<dyn Service>>,
     logger: bool,
 }
 
@@ -329,7 +329,7 @@ impl TestKitBuilder {
     /// Adds a service to the testkit.
     pub fn with_service<S>(mut self, service: S) -> Self
     where
-        S: Into<Box<Service>>,
+        S: Into<Box<dyn Service>>,
     {
         self.services.push(service.into());
         self
@@ -371,7 +371,7 @@ impl TestKitBuilder {
 pub struct TestKit {
     blockchain: Blockchain,
     db_handler: CheckpointDbHandler<MemoryDB>,
-    events_stream: Box<Stream<Item = (), Error = ()> + Send + Sync>,
+    events_stream: Box<dyn Stream<Item = (), Error = ()> + Send + Sync>,
     network: TestNetwork,
     api_sender: ApiSender,
     cfg_proposal: Option<ConfigurationProposalState>,
@@ -391,12 +391,12 @@ impl TestKit {
     /// Creates a new `TestKit` with a single validator with the given service.
     pub fn for_service<S>(service: S) -> Self
     where
-        S: Into<Box<Service>>,
+        S: Into<Box<dyn Service>>,
     {
         TestKitBuilder::validator().with_service(service).create()
     }
 
-    fn assemble(services: Vec<Box<Service>>, network: TestNetwork) -> Self {
+    fn assemble(services: Vec<Box<dyn Service>>, network: TestNetwork) -> Self {
         let api_channel = mpsc::channel(1_000);
         let api_sender = ApiSender::new(api_channel.0.clone());
 
@@ -414,7 +414,7 @@ impl TestKit {
         let genesis = network.genesis_config();
         blockchain.initialize(genesis.clone()).unwrap();
 
-        let events_stream: Box<Stream<Item = (), Error = ()> + Send + Sync> = {
+        let events_stream: Box<dyn Stream<Item = (), Error = ()> + Send + Sync> = {
             let mut blockchain = blockchain.clone();
             Box::new(api_channel.1.and_then(move |event| {
                 let mut fork = blockchain.fork();
@@ -459,7 +459,7 @@ impl TestKit {
     }
 
     /// Returns a snapshot of the current blockchain state.
-    pub fn snapshot(&self) -> Box<Snapshot> {
+    pub fn snapshot(&self) -> Box<dyn Snapshot> {
         self.blockchain.snapshot()
     }
 
@@ -558,9 +558,9 @@ impl TestKit {
     /// commit execution results to the blockchain. The execution result is the same
     /// as if transactions were included into a new block; for example,
     /// transactions included into one of previous blocks do not lead to any state changes.
-    pub fn probe_all<I>(&mut self, transactions: I) -> Box<Snapshot>
+    pub fn probe_all<I>(&mut self, transactions: I) -> Box<dyn Snapshot>
     where
-        I: IntoIterator<Item = Box<Transaction>>,
+        I: IntoIterator<Item = Box<dyn Transaction>>,
     {
         self.poll_events();
         // Filter out already committed transactions; otherwise,
@@ -582,8 +582,8 @@ impl TestKit {
     /// commit execution results to the blockchain. The execution result is the same
     /// as if a transaction was included into a new block; for example,
     /// a transaction included into one of previous blocks does not lead to any state changes.
-    pub fn probe<T: Transaction>(&mut self, transaction: T) -> Box<Snapshot> {
-        self.probe_all(vec![Box::new(transaction) as Box<Transaction>])
+    pub fn probe<T: Transaction>(&mut self, transaction: T) -> Box<dyn Snapshot> {
+        self.probe_all(vec![Box::new(transaction) as Box<dyn Transaction>])
     }
 
     fn do_create_block(&mut self, tx_hashes: &[crypto::Hash]) -> BlockWithTransactions {
@@ -679,7 +679,7 @@ impl TestKit {
     /// - Panics if any of transactions has been already committed to the blockchain.
     pub fn create_block_with_transactions<I>(&mut self, txs: I) -> BlockWithTransactions
     where
-        I: IntoIterator<Item = Box<Transaction>>,
+        I: IntoIterator<Item = Box<dyn Transaction>>,
     {
         let tx_hashes: Vec<_> = {
             let blockchain = self.blockchain_mut();
@@ -965,7 +965,7 @@ impl TestKit {
     /// # Returned value
     ///
     /// Future that runs the event stream of this testkit to completion.
-    fn remove_events_stream(&mut self) -> Box<Future<Item = (), Error = ()>> {
+    fn remove_events_stream(&mut self) -> Box<dyn Future<Item = (), Error = ()>> {
         let stream = std::mem::replace(&mut self.events_stream, Box::new(futures::stream::empty()));
         Box::new(stream.for_each(|_| Ok(())))
     }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -132,7 +132,7 @@
 //! }
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]
 
 extern crate actix_web;
 #[cfg_attr(test, macro_use)]

--- a/testkit/src/network.rs
+++ b/testkit/src/network.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{blockchain::{ConsensusConfig, GenesisConfig, StoredConfiguration, ValidatorKeys},
-             crypto::{self, CryptoHash},
-             helpers::{Height, Round, ValidatorId},
-             messages::{Precommit, Propose}};
+use exonum::{
+    blockchain::{ConsensusConfig, GenesisConfig, StoredConfiguration, ValidatorKeys},
+    crypto::{self, CryptoHash}, helpers::{Height, Round, ValidatorId},
+    messages::{Precommit, Propose},
+};
 use serde::{Deserialize, Serialize};
 use serde_json;
 

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum::{api::{self, ApiAggregator, ServiceApiBuilder, ServiceApiScope, ServiceApiState},
-             blockchain::{SharedNodeState, Transaction},
-             crypto,
-             explorer::{BlockWithTransactions, BlockchainExplorer},
-             helpers::Height};
+use exonum::{
+    api::{self, ApiAggregator, ServiceApiBuilder, ServiceApiScope, ServiceApiState},
+    blockchain::{SharedNodeState, Transaction}, crypto,
+    explorer::{BlockWithTransactions, BlockchainExplorer}, helpers::Height,
+};
 
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -214,11 +214,11 @@ mod tests {
                 "sample"
             }
 
-            fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+            fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
                 Vec::new()
             }
 
-            fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, EncodingError> {
+            fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, EncodingError> {
                 use exonum::blockchain::TransactionSet;
 
                 Any::tx_from_raw(raw).map(Any::into)

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -58,7 +58,7 @@ impl TestkitServerApi {
     fn create_block(
         &self,
         tx_hashes: Option<Vec<crypto::Hash>>,
-    ) -> api::Result<BlockWithTransactions<Box<Transaction>>> {
+    ) -> api::Result<BlockWithTransactions<Box<dyn Transaction>>> {
         let mut testkit = self.write();
         let block_info = if let Some(tx_hashes) = tx_hashes {
             let maybe_missing_tx = tx_hashes.iter().find(|h| !testkit.is_tx_in_pool(h));
@@ -82,7 +82,7 @@ impl TestkitServerApi {
     fn rollback(
         &self,
         height: Height,
-    ) -> api::Result<Option<BlockWithTransactions<Box<Transaction>>>> {
+    ) -> api::Result<Option<BlockWithTransactions<Box<dyn Transaction>>>> {
         if height == Height(0) {
             Err(api::Error::BadRequest(
                 "Cannot rollback past genesis block".into(),

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -218,7 +218,10 @@ mod tests {
                 Vec::new()
             }
 
-            fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, EncodingError> {
+            fn tx_from_raw(
+                &self,
+                raw: RawTransaction,
+            ) -> Result<Box<dyn Transaction>, EncodingError> {
                 use exonum::blockchain::TransactionSet;
 
                 Any::tx_from_raw(raw).map(Any::into)

--- a/testkit/tests/change_configuration.rs
+++ b/testkit/tests/change_configuration.rs
@@ -21,9 +21,9 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-use exonum::{blockchain::Schema,
-             crypto::CryptoHash,
-             helpers::{Height, ValidatorId}};
+use exonum::{
+    blockchain::Schema, crypto::CryptoHash, helpers::{Height, ValidatorId},
+};
 use exonum_testkit::TestKitBuilder;
 
 #[test]

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 //! Sample counter service.
-use exonum::{api,
-             blockchain::{ExecutionError, ExecutionResult, Service, Transaction, TransactionSet},
-             crypto::{Hash, PublicKey},
-             encoding,
-             messages::{Message, RawTransaction},
-             node::TransactionSend,
-             storage::{Entry, Fork, Snapshot}};
+use exonum::{
+    api, blockchain::{ExecutionError, ExecutionResult, Service, Transaction, TransactionSet},
+    crypto::{Hash, PublicKey}, encoding, messages::{Message, RawTransaction},
+    node::TransactionSend, storage::{Entry, Fork, Snapshot},
+};
 
 pub const SERVICE_ID: u16 = 1;
 

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -28,16 +28,18 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-use exonum::{api::{node::public::explorer::TransactionQuery, Error as ApiError},
-             blockchain::{Transaction, TransactionErrorType as ErrorType},
-             crypto::{self, CryptoHash, PublicKey},
-             encoding::serialize::{json::ExonumJson, FromHex},
-             helpers::Height,
-             messages::Message};
+use exonum::{
+    api::{node::public::explorer::TransactionQuery, Error as ApiError},
+    blockchain::{Transaction, TransactionErrorType as ErrorType},
+    crypto::{self, CryptoHash, PublicKey}, encoding::serialize::{json::ExonumJson, FromHex},
+    helpers::Height, messages::Message,
+};
 use exonum_testkit::{ApiKind, ComparableSnapshot, TestKit, TestKitApi, TestKitBuilder};
 use serde_json::Value;
 
-use counter::{CounterSchema, CounterService, TransactionResponse, TxIncrement, TxReset, ADMIN_KEY};
+use counter::{
+    CounterSchema, CounterService, TransactionResponse, TxIncrement, TxReset, ADMIN_KEY,
+};
 
 mod counter;
 
@@ -392,9 +394,7 @@ fn test_snapshot_comparison_panic() {
         .map(CounterSchema::new)
         .map(CounterSchema::count)
         .map(|&c| c.unwrap())
-        .assert("Counter has increased", |&old, &new| {
-            new == old + tx.by()
-        });
+        .assert("Counter has increased", |&old, &new| new == old + tx.by());
 }
 
 #[test]

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -15,15 +15,11 @@
 extern crate serde;
 extern crate serde_json;
 
-use exonum::{api,
-             blockchain::{ExecutionResult, Schema as CoreSchema, Service, Transaction,
-                          TransactionSet},
-             crypto::{Hash, PublicKey},
-             encoding,
-             helpers::Height,
-             messages::{Message, RawTransaction},
-             node::TransactionSend,
-             storage::{Fork, MapIndex, Snapshot}};
+use exonum::{
+    api, blockchain::{ExecutionResult, Schema as CoreSchema, Service, Transaction, TransactionSet},
+    crypto::{Hash, PublicKey}, encoding, helpers::Height, messages::{Message, RawTransaction},
+    node::TransactionSend, storage::{Fork, MapIndex, Snapshot},
+};
 
 // // // // // // // // // // CONSTANTS // // // // // // // // // //
 

--- a/testkit/tests/inflating_currency/main.rs
+++ b/testkit/tests/inflating_currency/main.rs
@@ -26,9 +26,9 @@ extern crate rand;
 #[macro_use]
 extern crate serde_derive;
 
-use exonum::{blockchain::Transaction,
-             crypto::{self, CryptoHash, PublicKey, SecretKey},
-             helpers::Height};
+use exonum::{
+    blockchain::Transaction, crypto::{self, CryptoHash, PublicKey, SecretKey}, helpers::Height,
+};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 use rand::Rng;
 

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -14,12 +14,11 @@
 
 //! A special service which generates transactions on `after_commit` events.
 
-use exonum::{blockchain::{ExecutionResult, Service, ServiceContext, Transaction, TransactionSet},
-             crypto::{Hash, Signature},
-             encoding,
-             helpers::Height,
-             messages::RawTransaction,
-             storage::{Fork, Snapshot}};
+use exonum::{
+    blockchain::{ExecutionResult, Service, ServiceContext, Transaction, TransactionSet},
+    crypto::{Hash, Signature}, encoding, helpers::Height, messages::RawTransaction,
+    storage::{Fork, Snapshot},
+};
 
 const SERVICE_ID: u16 = 512;
 

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -21,9 +21,9 @@ extern crate serde_json;
 // HACK: Silent "dead_code" warning.
 pub use hooks::{AfterCommitService, TxAfterCommit};
 
-use exonum::{crypto::{CryptoHash, Signature},
-             helpers::Height,
-             messages::Message};
+use exonum::{
+    crypto::{CryptoHash, Signature}, helpers::Height, messages::Message,
+};
 use exonum_testkit::TestKitBuilder;
 
 mod hooks;

--- a/testkit/tests/system_api.rs
+++ b/testkit/tests/system_api.rs
@@ -17,10 +17,12 @@ extern crate exonum_testkit;
 #[macro_use]
 extern crate pretty_assertions;
 
-use exonum::{api::node::{private::NodeInfo,
-                         public::system::{ConsensusStatusInfo, HealthCheckInfo}},
-             helpers::user_agent,
-             messages::PROTOCOL_MAJOR_VERSION};
+use exonum::{
+    api::node::{
+        private::NodeInfo, public::system::{ConsensusStatusInfo, HealthCheckInfo},
+    },
+    helpers::user_agent, messages::PROTOCOL_MAJOR_VERSION,
+};
 use exonum_testkit::{ApiKind, TestKitBuilder};
 
 #[test]


### PR DESCRIPTION
- 1.27 formatting (better indentation).
- `![deny(missing_debug_implementations, missing_docs, unsafe_code, bare_trait_object)]` everywhere.