### PR TITLE
Change ConnectList representation in config [ECR-1760]

### DIFF
--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -36,7 +36,8 @@ use api::backends::actix::AllowOrigin;
 use blockchain::{config::ValidatorKeys, GenesisConfig};
 use crypto;
 use helpers::{config::ConfigFile, generate_testnet_config};
-use node::{ConnectList, NodeApiConfig, NodeConfig};
+use node::ConnectListConfig;
+use node::{NodeApiConfig, NodeConfig};
 use storage::{Database, DbOptions, RocksDB};
 
 const DATABASE_PATH: &str = "DATABASE_PATH";
@@ -606,7 +607,6 @@ impl Command for Finalize {
                 listen_address: secret_config.listen_addr,
                 external_address: our.map(|o| o.addr),
                 network: Default::default(),
-                connect_list: ConnectList::from_node_config(&list),
                 consensus_public_key: secret_config.consensus_public_key,
                 consensus_secret_key: secret_config.consensus_secret_key,
                 service_public_key: secret_config.service_public_key,
@@ -622,6 +622,7 @@ impl Command for Finalize {
                 mempool: Default::default(),
                 services_configs: Default::default(),
                 database: Default::default(),
+                connect_list: ConnectListConfig::from_node_config(&list),
             }
         };
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -34,8 +34,7 @@ use api::backends::actix::AllowOrigin;
 use blockchain::{config::ValidatorKeys, GenesisConfig};
 use crypto;
 use helpers::{config::ConfigFile, generate_testnet_config};
-use node::ConnectListConfig;
-use node::{NodeApiConfig, NodeConfig};
+use node::{ConnectListConfig, NodeApiConfig, NodeConfig};
 use storage::{Database, DbOptions, RocksDB};
 
 const DATABASE_PATH: &str = "DATABASE_PATH";

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -33,8 +33,7 @@ use std::{env,
 
 use blockchain::{GenesisConfig, ValidatorKeys};
 use crypto::gen_keypair;
-use node::ConnectList;
-use node::NodeConfig;
+use node::{ConnectListConfig, NodeConfig};
 
 mod types;
 
@@ -82,7 +81,7 @@ pub fn generate_testnet_config(count: u8, start_port: u16) -> Vec<NodeConfig> {
             service_public_key: service.0,
             service_secret_key: service.1,
             genesis: genesis.clone(),
-            connect_list: ConnectList::from_validator_keys(&genesis.validator_keys, &peers),
+            connect_list: ConnectListConfig::from_validator_keys(&genesis.validator_keys, &peers),
             api: Default::default(),
             mempool: Default::default(),
             services_configs: Default::default(),

--- a/exonum/src/node/connect_list.rs
+++ b/exonum/src/node/connect_list.rs
@@ -33,7 +33,7 @@ impl ConnectList {
     pub fn from_config(config: ConnectListConfig) -> Self {
         let peers: BTreeMap<PublicKey, SocketAddr> = config
             .peers
-            .iter()
+            .into_iter()
             .map(|peer| (peer.public_key, peer.address))
             .collect();
 

--- a/exonum/src/node/connect_list.rs
+++ b/exonum/src/node/connect_list.rs
@@ -17,10 +17,8 @@
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 
-use blockchain::ValidatorKeys;
 use crypto::PublicKey;
-use helpers::fabric::NodePublicConfig;
-use node::ConnectInfo;
+use node::{ConnectInfo, ConnectListConfig};
 
 /// `ConnectList` stores mapping between IP-addresses and public keys.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -31,6 +29,17 @@ pub struct ConnectList {
 }
 
 impl ConnectList {
+    /// Creates `ConnectList` from config.
+    pub fn from_config(config: ConnectListConfig) -> Self {
+        let peers: BTreeMap<PublicKey, SocketAddr> = config
+            .peers
+            .iter()
+            .map(|peer| (peer.public_key, peer.address))
+            .collect();
+
+        ConnectList { peers }
+    }
+
     /// Returns `true` if a peer with the given public key can connect.
     pub fn is_peer_allowed(&self, peer: &PublicKey) -> bool {
         self.peers.contains_key(peer)
@@ -46,37 +55,12 @@ impl ConnectList {
         self.peers.insert(peer.public_key, peer.address);
     }
 
-    /// Creates `ConnectList` from validators keys and corresponding IP addresses.
-    pub fn from_validator_keys(validators_keys: &[ValidatorKeys], peers: &[SocketAddr]) -> Self {
-        let peers: BTreeMap<PublicKey, SocketAddr> = peers
-            .iter()
-            .zip(validators_keys.iter())
-            .map(|(p, v)| (v.consensus_key, *p))
-            .collect();
-
-        ConnectList { peers }
-    }
-
-    /// Creates `ConnectList` from validators public configs.
-    pub fn from_node_config(list: &[NodePublicConfig]) -> Self {
-        let peers: BTreeMap<PublicKey, SocketAddr> = list.iter()
-            .map(|config| (config.validator_keys.consensus_key, config.addr))
-            .collect();
-
-        ConnectList { peers }
-    }
-
     /// Get public key corresponding to validator with `address`.
     pub fn find_key_by_address(&self, address: &SocketAddr) -> Option<&PublicKey> {
         self.peers
             .iter()
             .find(|(_, a)| a == &address)
             .map(|(p, _)| p)
-    }
-
-    /// `ConnectList` peers addresses.
-    pub fn addresses(&self) -> Vec<SocketAddr> {
-        self.peers.values().cloned().collect()
     }
 }
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -352,7 +352,7 @@ impl ConnectListConfig {
 
     /// Creates `ConnectList` from validators keys and corresponding IP addresses.
     pub fn from_validator_keys(validators_keys: &[ValidatorKeys], peers: &[SocketAddr]) -> Self {
-        let peers: Vec<_> = peers
+        let peers = peers
             .iter()
             .zip(validators_keys.iter())
             .map(|(a, v)| ConnectInfo {

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -38,8 +38,9 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use blockchain::ValidatorKeys;
-use blockchain::{Blockchain, GenesisConfig, Schema, Service, SharedNodeState, Transaction};
+use blockchain::{
+    Blockchain, GenesisConfig, Schema, Service, SharedNodeState, Transaction, ValidatorKeys,
+};
 use crypto::{self, CryptoHash, Hash, PublicKey, SecretKey};
 use events::{
     error::{into_other, log_error, other_error, LogError}, noise::HandshakeParams, HandlerPart,
@@ -330,7 +331,7 @@ pub struct ConnectListConfig {
 impl ConnectListConfig {
     /// Creates `ConnectList` from validators public configs.
     pub fn from_node_config(list: &[NodePublicConfig]) -> Self {
-        let peers: Vec<_> = list.iter()
+        let peers = list.iter()
             .map(|config| ConnectInfo {
                 public_key: config.validator_keys.consensus_key,
                 address: config.addr,

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -46,7 +46,7 @@ use events::{
     InternalEvent, InternalPart, InternalRequest, NetworkConfiguration, NetworkEvent, NetworkPart,
     NetworkRequest, SyncSender, TimeoutRequest,
 };
-use helpers::{user_agent, Height, Milliseconds, Round, ValidatorId};
+use helpers::{fabric::NodePublicConfig, user_agent, Height, Milliseconds, Round, ValidatorId};
 use messages::{Connect, Message, RawMessage};
 use storage::{Database, DbOptions};
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -355,9 +355,9 @@ impl ConnectListConfig {
         let peers: Vec<_> = peers
             .iter()
             .zip(validators_keys.iter())
-            .map(|(p, v)| ConnectInfo {
+            .map(|(a, v)| ConnectInfo {
+                address: *a,
                 public_key: v.consensus_key,
-                address: *p,
             })
             .collect();
 

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -36,6 +36,7 @@ use events::{network::NetworkConfiguration, Event, EventHandler, InternalEvent, 
 use helpers::{user_agent, Height, Milliseconds, Round, ValidatorId};
 use messages::{Any, Connect, Message, RawMessage, RawTransaction, Status};
 use node::ConnectInfo;
+use node::ConnectListConfig;
 use node::{ApiSender, Configuration, ConnectList, ExternalMessage, ListenerConfig, NodeHandler,
            NodeSender, ServiceConfig, State, SystemStateProvider};
 use storage::{MapProof, MemoryDB};
@@ -743,7 +744,8 @@ pub fn sandbox_with_services_uninitialized(services: Vec<Box<Service>>) -> Sandb
             }),
     );
 
-    let connect_list = ConnectList::from_validator_keys(&genesis.validator_keys, &addresses);
+    let connect_list_config =
+        ConnectListConfig::from_validator_keys(&genesis.validator_keys, &addresses);
 
     blockchain.initialize(genesis).unwrap();
 
@@ -752,7 +754,7 @@ pub fn sandbox_with_services_uninitialized(services: Vec<Box<Service>>) -> Sandb
             address: addresses[0],
             consensus_public_key: validators[0].0,
             consensus_secret_key: validators[0].1.clone(),
-            connect_list: connect_list.clone(),
+            connect_list: ConnectList::from_config(connect_list_config),
         },
         service: ServiceConfig {
             service_public_key: service_keys[0].0,

--- a/exonum/tests/testdata/config/config01.toml
+++ b/exonum/tests/testdata/config/config01.toml
@@ -43,5 +43,6 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"

--- a/exonum/tests/testdata/config/config02.toml
+++ b/exonum/tests/testdata/config/config02.toml
@@ -46,6 +46,10 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config03.toml
+++ b/exonum/tests/testdata/config/config03.toml
@@ -49,7 +49,14 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config04.toml
+++ b/exonum/tests/testdata/config/config04.toml
@@ -52,8 +52,18 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
-41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80 = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config12.toml
+++ b/exonum/tests/testdata/config/config12.toml
@@ -46,6 +46,10 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config13.toml
+++ b/exonum/tests/testdata/config/config13.toml
@@ -49,7 +49,15 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+

--- a/exonum/tests/testdata/config/config14.toml
+++ b/exonum/tests/testdata/config/config14.toml
@@ -52,8 +52,18 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
-41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80 = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config23.toml
+++ b/exonum/tests/testdata/config/config23.toml
@@ -49,7 +49,14 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config24.toml
+++ b/exonum/tests/testdata/config/config24.toml
@@ -52,8 +52,18 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
-41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80 = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"

--- a/exonum/tests/testdata/config/config34.toml
+++ b/exonum/tests/testdata/config/config34.toml
@@ -52,8 +52,18 @@ tcp_connect_max_retries = 10
 [database]
 create_if_missing = true
 
-[connect_list.peers]
-16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
-648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6333"
-924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e = "127.0.0.1:6333"
-41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80 = "127.0.0.1:6333"
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[connect_list.peers]]
+address = "127.0.0.1:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"


### PR DESCRIPTION
Change `ConnectList` representation in config from:
```toml
[connect_list.peers]
16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72 = "127.0.0.1:6333"
648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3 = "127.0.0.1:6334"
```
to:
```toml
[[connect_list.peers]]
address = "127.0.0.1:6333"
public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"

[[connect_list.peers]]
address = "127.0.0.1:6334"
public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
```
This was to done to simplify parsing.