### PR TITLE
Removed `iter_from` in `BaseIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
- - A method `iter` in the `BaseIndex` module has been become unified and
-   a method `iter_from` has been removed. 
-   A method `iter` has changed a signature in trait `Snapshot`. (#772)
+- A method `iter` in the `BaseIndex` module has been become unified and
+  a method `iter_from` has been removed. 
+  A method `iter` has changed a signature in trait `Snapshot`. (#772)
 
 #### exonum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Breaking changes
 
 - A method `iter` in the `BaseIndex` module has been become unified and
-  a method `iter_from` has been removed. 
+  a method `iter_from` has been removed.
   A method `iter` has changed a signature in trait `Snapshot`. (#772)
 
 #### exonum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Breaking changes
 
+ - A method `iter` in the `BaseIndex` module has been become unified and
+   a method `iter_from` has been removed. 
+   A method `iter` has changed a signature in trait `Snapshot`. (#772)
+
 #### exonum
 
 - `Iron` based web API has been replaced by the new implementation based

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -154,7 +154,7 @@ where
     /// ```
     pub fn iter(&self) -> KeySetIndexIter<K> {
         KeySetIndexIter {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -177,7 +177,7 @@ where
     /// ```
     pub fn iter_from(&self, from: &K) -> KeySetIndexIter<K> {
         KeySetIndexIter {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 }

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -230,7 +230,7 @@ where
     /// ```
     pub fn iter(&self) -> ListIndexIter<V> {
         ListIndexIter {
-            base_iter: self.base.iter_from(&(), &0u64),
+            base_iter: self.base.iter(&(), Some(&0u64)),
         }
     }
 
@@ -255,7 +255,7 @@ where
     /// ```
     pub fn iter_from(&self, from: u64) -> ListIndexIter<V> {
         ListIndexIter {
-            base_iter: self.base.iter_from(&(), &from),
+            base_iter: self.base.iter(&(), Some(&from)),
         }
     }
 }

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -211,7 +211,7 @@ where
     /// ```
     pub fn iter(&self) -> MapIndexIter<K, V> {
         MapIndexIter {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -234,7 +234,7 @@ where
     /// ```
     pub fn keys(&self) -> MapIndexKeys<K> {
         MapIndexKeys {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -257,7 +257,7 @@ where
     /// ```
     pub fn values(&self) -> MapIndexValues<V> {
         MapIndexValues {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -284,7 +284,7 @@ where
         Q: StorageKey + ?Sized,
     {
         MapIndexIter {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 
@@ -311,7 +311,7 @@ where
         Q: StorageKey + ?Sized,
     {
         MapIndexKeys {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 
@@ -337,7 +337,7 @@ where
         Q: StorageKey + ?Sized,
     {
         MapIndexValues {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 }

--- a/exonum/src/storage/memorydb.rs
+++ b/exonum/src/storage/memorydb.rs
@@ -96,12 +96,12 @@ impl Snapshot for MemoryDB {
             .map_or(false, |table| table.contains_key(key))
     }
 
-    fn iter(&self, name: &str, from: &[u8]) -> Iter {
+    fn iter(&self, name: &str, from: Option<&[u8]>) -> Iter {
         let map_guard = self.map.read().unwrap();
         let data = match map_guard.get(name) {
             Some(table) => table
                 .iter()
-                .skip_while(|&(k, _)| k.as_slice() < from)
+                .skip_while(|&(k, _)| k.as_slice() < from.unwrap_or(&[]))
                 .map(|(k, v)| (k.to_vec(), v.to_vec()))
                 .collect(),
             None => Vec::new(),

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -411,7 +411,7 @@ where
     /// ```
     pub fn iter(&self) -> ProofListIndexIter<V> {
         ProofListIndexIter {
-            base_iter: self.base.iter(&0u8),
+            base_iter: self.base.iter(&0u8, None as Option<&[u8]>),
         }
     }
 
@@ -434,7 +434,7 @@ where
     /// ```
     pub fn iter_from(&self, from: u64) -> ProofListIndexIter<V> {
         ProofListIndexIter {
-            base_iter: self.base.iter_from(&0u8, &ProofListKey::leaf(from)),
+            base_iter: self.base.iter(&0u8, Some(&ProofListKey::leaf(from))),
         }
     }
 }

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -190,7 +190,7 @@ where
 
     fn get_root_path(&self) -> Option<ProofPath> {
         self.base
-            .iter::<_, ProofPath, _>(&())
+            .iter::<_, _, ProofPath, _>(&(), None as Option<&ProofPath>)
             .next()
             .map(|(k, _): (ProofPath, ())| k)
     }
@@ -351,7 +351,7 @@ where
     /// ```
     pub fn iter(&self) -> ProofMapIndexIter<K, V> {
         ProofMapIndexIter {
-            base_iter: self.base.iter(&LEAF_KEY_PREFIX),
+            base_iter: self.base.iter(&LEAF_KEY_PREFIX, None as Option<&[u8]>),
             _k: PhantomData,
         }
     }
@@ -376,7 +376,7 @@ where
     /// ```
     pub fn keys(&self) -> ProofMapIndexKeys<K> {
         ProofMapIndexKeys {
-            base_iter: self.base.iter(&LEAF_KEY_PREFIX),
+            base_iter: self.base.iter(&LEAF_KEY_PREFIX, None as Option<&[u8]>),
             _k: PhantomData,
         }
     }
@@ -401,7 +401,7 @@ where
     /// ```
     pub fn values(&self) -> ProofMapIndexValues<V> {
         ProofMapIndexValues {
-            base_iter: self.base.iter(&LEAF_KEY_PREFIX),
+            base_iter: self.base.iter(&LEAF_KEY_PREFIX, None as Option<&[u8]>),
         }
     }
 
@@ -426,7 +426,8 @@ where
     /// ```
     pub fn iter_from(&self, from: &K) -> ProofMapIndexIter<K, V> {
         ProofMapIndexIter {
-            base_iter: self.base.iter_from(&LEAF_KEY_PREFIX, &ProofPath::new(from)),
+            base_iter: self.base
+                .iter(&LEAF_KEY_PREFIX, Some(&ProofPath::new(from))),
             _k: PhantomData,
         }
     }
@@ -452,7 +453,8 @@ where
     /// ```
     pub fn keys_from(&self, from: &K) -> ProofMapIndexKeys<K> {
         ProofMapIndexKeys {
-            base_iter: self.base.iter_from(&LEAF_KEY_PREFIX, &ProofPath::new(from)),
+            base_iter: self.base
+                .iter(&LEAF_KEY_PREFIX, Some(&ProofPath::new(from))),
             _k: PhantomData,
         }
     }
@@ -478,7 +480,8 @@ where
     /// ```
     pub fn values_from(&self, from: &K) -> ProofMapIndexValues<V> {
         ProofMapIndexValues {
-            base_iter: self.base.iter_from(&LEAF_KEY_PREFIX, &ProofPath::new(from)),
+            base_iter: self.base
+                .iter(&LEAF_KEY_PREFIX, Some(&ProofPath::new(from))),
         }
     }
 }

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -132,12 +132,14 @@ impl Snapshot for RocksDBSnapshot {
         }
     }
 
-    fn iter<'a>(&'a self, name: &str, from: &[u8]) -> Iter<'a> {
+    fn iter<'a>(&'a self, name: &str, from: Option<&[u8]>) -> Iter<'a> {
         use rocksdb::{Direction, IteratorMode};
+        let iterator_mode = match from {
+            Some(from) => IteratorMode::From(from, Direction::Forward),
+            None => IteratorMode::Start,
+        };
         let iter = match self._db.cf_handle(name) {
-            Some(cf) => self.snapshot
-                .iterator_cf(cf, IteratorMode::From(from, Direction::Forward))
-                .unwrap(),
+            Some(cf) => self.snapshot.iterator_cf(cf, iterator_mode).unwrap(),
             None => self.snapshot.iterator(IteratorMode::Start),
         };
         Box::new(RocksDBIterator {

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -317,7 +317,7 @@ where
     /// ```
     pub fn iter(&self) -> SparseListIndexIter<V> {
         SparseListIndexIter {
-            base_iter: self.base.iter_from(&(), &0u64),
+            base_iter: self.base.iter(&(), Some(&0u64)),
         }
     }
 
@@ -340,7 +340,7 @@ where
     /// ```
     pub fn indices(&self) -> SparseListIndexKeys {
         SparseListIndexKeys {
-            base_iter: self.base.iter_from(&(), &0u64),
+            base_iter: self.base.iter(&(), Some(&0u64)),
         }
     }
 
@@ -364,7 +364,7 @@ where
     /// ```
     pub fn values(&self) -> SparseListIndexValues<V> {
         SparseListIndexValues {
-            base_iter: self.base.iter_from(&(), &0u64),
+            base_iter: self.base.iter(&(), Some(&0u64)),
         }
     }
 
@@ -389,7 +389,7 @@ where
     /// ```
     pub fn iter_from(&self, from: u64) -> SparseListIndexIter<V> {
         SparseListIndexIter {
-            base_iter: self.base.iter_from(&(), &from),
+            base_iter: self.base.iter(&(), Some(&from)),
         }
     }
 }

--- a/exonum/src/storage/tests.rs
+++ b/exonum/src/storage/tests.rs
@@ -34,7 +34,7 @@ fn fork_iter<T: Database>(db: T) {
     fn assert_iter(fork: &Fork, from: u8, assumed: &[(u8, u8)]) {
         let mut values = Vec::new();
 
-        let mut iter = fork.iter(IDX_NAME, &[from]);
+        let mut iter = fork.iter(IDX_NAME, Some(&[from]));
         while let Some((k, v)) = iter.next() {
             values.push((k[0], v[0]));
         }

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -188,7 +188,7 @@ where
     /// ```
     pub fn iter(&self) -> ValueSetIndexIter<V> {
         ValueSetIndexIter {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -214,7 +214,7 @@ where
     /// ```
     pub fn iter_from(&self, from: &Hash) -> ValueSetIndexIter<V> {
         ValueSetIndexIter {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 
@@ -237,7 +237,7 @@ where
     /// ```
     pub fn hashes(&self) -> ValueSetIndexHashes {
         ValueSetIndexHashes {
-            base_iter: self.base.iter(&()),
+            base_iter: self.base.iter(&(), None as Option<&[u8]>),
         }
     }
 
@@ -263,7 +263,7 @@ where
     /// ```
     pub fn hashes_from(&self, from: &Hash) -> ValueSetIndexHashes {
         ValueSetIndexHashes {
-            base_iter: self.base.iter_from(&(), from),
+            base_iter: self.base.iter(&(), Some(from)),
         }
     }
 }

--- a/services/configuration/src/api.rs
+++ b/services/configuration/src/api.rs
@@ -176,10 +176,7 @@ impl PublicApi {
             .map(|cfg| Self::config_with_proofs(state, cfg)))
     }
 
-    fn handle_config_by_hash(
-        state: &ServiceApiState,
-        query: HashQuery,
-    ) -> api::Result<ConfigInfo> {
+    fn handle_config_by_hash(state: &ServiceApiState, query: HashQuery) -> api::Result<ConfigInfo> {
         let snapshot = state.snapshot();
 
         let committed_config = CoreSchema::new(&snapshot).configs().get(&query.hash);


### PR DESCRIPTION
Removed `iter_from` for getting rid of code duplication. `iter` has been become unified