### PR TITLE
Make 'events' mod public but doc(hidden)

### DIFF
--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_debug_implementations, missing_docs)]
+
 pub use self::internal::InternalPart;
 pub use self::network::{NetworkConfiguration, NetworkEvent, NetworkPart, NetworkRequest};
 

--- a/exonum/src/events/noise/sodium_resolver.rs
+++ b/exonum/src/events/noise/sodium_resolver.rs
@@ -24,6 +24,12 @@ impl SodiumResolver {
     }
 }
 
+impl Default for SodiumResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CryptoResolver for SodiumResolver {
     fn resolve_rng(&self) -> Option<Box<dyn Random + Send>> {
         Some(Box::new(SodiumRandom::default()))

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -80,6 +80,8 @@ pub mod blockchain;
 pub mod api;
 pub mod explorer;
 
-mod events;
+#[doc(hidden)]
+pub mod events;
+
 #[cfg(test)]
 mod sandbox;


### PR DESCRIPTION
Low-level access to events code is required for benchmarking (part of [ECR-1585]).

As `events` module is still effectively private, I'm disabling `missing_debug_implementations` and `missing_docs` lints.