### PR TITLE
Fix 'consensus_enabled' logic [ECR-1759]

### DIFF
--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -38,13 +38,6 @@ impl NodeHandler {
     }
 
     fn handle_network_event(&mut self, event: NetworkEvent) {
-        if !self.is_enabled {
-            info!(
-                "Ignoring a network event {:?} because the node is disabled",
-                event
-            );
-            return;
-        }
         match event {
             NetworkEvent::PeerConnected(peer, connect) => self.handle_connected(peer, connect),
             NetworkEvent::PeerDisconnected(peer) => self.handle_disconnected(peer),
@@ -56,23 +49,9 @@ impl NodeHandler {
     fn handle_api_event(&mut self, event: ExternalMessage) {
         match event {
             ExternalMessage::Transaction(tx) => {
-                if !self.is_enabled {
-                    info!(
-                        "Ignoring a transaction {:?} because the node is disabled",
-                        tx
-                    );
-                    return;
-                }
                 self.handle_incoming_tx(tx);
             }
             ExternalMessage::PeerAdd(info) => {
-                if !self.is_enabled {
-                    info!(
-                        "Ignoring a connect message to {} because the node is disabled",
-                        info
-                    );
-                    return;
-                }
                 info!("Send Connect message to {}", info);
                 self.state.add_peer_to_connect_list(info);
                 self.connect(&info.address);

--- a/exonum/src/sandbox/consensus.rs
+++ b/exonum/src/sandbox/consensus.rs
@@ -203,7 +203,8 @@ fn test_disable_and_enable() {
 
     // A fail is expected here as the node is disabled.
     sandbox.assert_state(HEIGHT_TWO, ROUND_ONE);
-    let result = try_add_one_height(&sandbox, &sandbox_state);
+    // TODO: use try_add_one_height (ECR-1817)
+    let result = try_add_one_height_with_transactions(&sandbox, &sandbox_state, &[]);
     assert!(result.is_err());
 
     // Re-enable the node.


### PR DESCRIPTION
This flag must disable only consensus related events.

This PR re-enables `NetworkEvent`s and `ExternalMessage`s.