### PR TITLE
Disable auto bench detection to silence the warning [ECR-1617]

### DIFF
--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 keywords = ["database", "distributed", "blockchain", "framework", "exonum"]
 categories = ["cryptography", "database-implementations"]
 description = "An extensible framework for blockchain software projects."
+autobenches = false
 
 [badges]
 travis-ci = { repository = "exonum/exonum" }


### PR DESCRIPTION
```text
warning: An explicit [[bench]] section is specified in Cargo.toml which currently                                            
disables Cargo from automatically inferring other benchmark targets.                                                         
This inference behavior will change in the Rust 2018 edition and the following                                               
files will be included as a benchmark target:                                                                                
                                                                                                                             
* /home/ozkriff/bitfury/exonum/exonum/benches/storage.rs

This is likely to break cargo build or cargo test as these files may not be
ready to be compiled as a benchmark target today. You can future-proof yourself
and disable this warning by adding `autobenches = false` to your [package]
section. You may also move the files to a location where Cargo would not
automatically infer them to be a target, such as in subfolders.

For more information on this warning you can consult
https://github.com/rust-lang/cargo/issues/5330
```

I'm not sure if it's the right solution, but at least it removes the warning.