### PR TITLE
Consistent compact Display/Debug format for crypto types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,17 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   as the last argument of the `Node::new` method.
   Otherwise, pass `None`.
 
+- `exonum::crypto` types now have truncated `Display`/`Debug` representations. (#797)
+
+  Migration path:
+
+  Use `encoding::serialize::ToHex` instead of `Display` to produce full hexadecimal
+  representation. You have to manually check if you need to switch or can keep using
+  the truncated representation.
+
+  Use `encoding::serialize::FromHex` instead of `FromStr` for reverse conversion.
+  `FromStr` implementation has been removed from crypto types to avoid errors.
+
 ### New features
 
 #### exonum

--- a/exonum/src/crypto/crypto_lib/sodiumoxide/x25519.rs
+++ b/exonum/src/crypto/crypto_lib/sodiumoxide/x25519.rs
@@ -32,8 +32,6 @@ use crypto;
 pub const PUBLIC_KEY_LENGTH: usize = 32;
 /// Length of the secret Curve25519 key.
 pub const SECRET_KEY_LENGTH: usize = 32;
-/// The size to crop the string in debug messages.
-pub const BYTES_IN_DEBUG: usize = 4;
 
 /// Converts Ed25519 keys to Curve25519.
 ///
@@ -137,9 +135,7 @@ macro_rules! implement_x25519_type {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, stringify!($name))?;
             write!(f, "(")?;
-            for i in &self.0[0..BYTES_IN_DEBUG] {
-                write!(f, "{:02X}", i)?
-            }
+            crypto::write_short_hex(f, &self.0[..])?;
             write!(f, ")")
         }
     }

--- a/exonum/src/crypto/macros.rs
+++ b/exonum/src/crypto/macros.rs
@@ -51,13 +51,6 @@ macro_rules! implement_public_crypto_wrapper {
         }
     }
 
-    impl FromStr for $name {
-        type Err = FromHexError;
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            $name::from_hex(s)
-        }
-    }
-
     impl fmt::Debug for $name {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, stringify!($name))?;

--- a/exonum/src/crypto/macros.rs
+++ b/exonum/src/crypto/macros.rs
@@ -62,16 +62,14 @@ macro_rules! implement_public_crypto_wrapper {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, stringify!($name))?;
             write!(f, "(")?;
-            for i in &self[0..BYTES_IN_DEBUG] {
-                write!(f, "{:02X}", i)?
-            }
+            write_short_hex(f, &self[..])?;
             write!(f, ")")
         }
     }
 
     impl fmt::Display for $name {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str(&self.to_hex())
+            write_short_hex(f, &self[..])
         }
     }
     )
@@ -112,10 +110,8 @@ macro_rules! implement_private_crypto_wrapper {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, stringify!($name))?;
             write!(f, "(")?;
-            for i in &self[0..BYTES_IN_DEBUG] {
-                write!(f, "{:02X}", i)?
-            }
-            write!(f, "...)")
+            write_short_hex(f, &self[..])?;
+            write!(f, ")")
         }
     }
 

--- a/exonum/src/crypto/mod.rs
+++ b/exonum/src/crypto/mod.rs
@@ -56,6 +56,16 @@ pub(crate) mod crypto_lib;
 /// The size to crop the string in debug messages.
 const BYTES_IN_DEBUG: usize = 4;
 
+fn write_short_hex(f: &mut fmt::Formatter, slice: &[u8]) -> fmt::Result {
+    for byte in slice.iter().take(BYTES_IN_DEBUG) {
+        write!(f, "{:02x}", byte)?;
+    }
+    if slice.len() > BYTES_IN_DEBUG {
+        write!(f, "...")?;
+    }
+    Ok(())
+}
+
 /// Signs a slice of bytes using the signer's secret key and returns the
 /// resulting `Signature`.
 ///
@@ -687,22 +697,39 @@ mod tests {
     fn debug_format() {
         // Check zero padding
         let hash = Hash::new([1; HASH_SIZE]);
-        assert_eq!(format!("{:?}", &hash), "Hash(01010101)");
+        assert_eq!(format!("{:?}", &hash), "Hash(01010101...)");
 
         let pk = PublicKey::new([15; PUBLIC_KEY_LENGTH]);
-        assert_eq!(format!("{:?}", &pk), "PublicKey(0F0F0F0F)");
+        assert_eq!(format!("{:?}", &pk), "PublicKey(0f0f0f0f...)");
         let sk = SecretKey::new([8; SECRET_KEY_LENGTH]);
         assert_eq!(format!("{:?}", &sk), "SecretKey(08080808...)");
         let signature = Signature::new([10; SIGNATURE_LENGTH]);
-        assert_eq!(format!("{:?}", &signature), "Signature(0A0A0A0A)");
+        assert_eq!(format!("{:?}", &signature), "Signature(0a0a0a0a...)");
         let seed = Seed::new([4; SEED_LENGTH]);
         assert_eq!(format!("{:?}", &seed), "Seed(04040404...)");
 
         // Check no padding
         let hash = Hash::new([128; HASH_SIZE]);
-        assert_eq!(format!("{:?}", &hash), "Hash(80808080)");
+        assert_eq!(format!("{:?}", &hash), "Hash(80808080...)");
         let sk = SecretKey::new([255; SECRET_KEY_LENGTH]);
-        assert_eq!(format!("{:?}", &sk), "SecretKey(FFFFFFFF...)");
+        assert_eq!(format!("{:?}", &sk), "SecretKey(ffffffff...)");
+    }
+
+    // Note that only public values have Display impl.
+    #[test]
+    fn display_format() {
+        // Check zero padding
+        let hash = Hash::new([1; HASH_SIZE]);
+        assert_eq!(format!("{}", &hash), "01010101...");
+
+        let pk = PublicKey::new([15; PUBLIC_KEY_LENGTH]);
+        assert_eq!(format!("{}", &pk), "0f0f0f0f...");
+        let signature = Signature::new([10; SIGNATURE_LENGTH]);
+        assert_eq!(format!("{}", &signature), "0a0a0a0a...");
+
+        // Check no padding
+        let hash = Hash::new([128; HASH_SIZE]);
+        assert_eq!(format!("{}", &hash), "80808080...");
     }
 
     #[test]

--- a/exonum/src/crypto/mod.rs
+++ b/exonum/src/crypto/mod.rs
@@ -36,7 +36,7 @@ use serde::{
 use uuid::Uuid;
 
 use std::{
-    default::Default, fmt, ops::{Index, Range, RangeFrom, RangeFull, RangeTo}, str::FromStr,
+    default::Default, fmt, ops::{Index, Range, RangeFrom, RangeFull, RangeTo},
     time::{SystemTime, UNIX_EPOCH},
 };
 

--- a/exonum/src/crypto/mod.rs
+++ b/exonum/src/crypto/mod.rs
@@ -695,7 +695,7 @@ mod tests {
 
     #[test]
     fn debug_format() {
-        // Check zero padding
+        // Check zero padding.
         let hash = Hash::new([1; HASH_SIZE]);
         assert_eq!(format!("{:?}", &hash), "Hash(01010101...)");
 
@@ -708,7 +708,7 @@ mod tests {
         let seed = Seed::new([4; SEED_LENGTH]);
         assert_eq!(format!("{:?}", &seed), "Seed(04040404...)");
 
-        // Check no padding
+        // Check no padding.
         let hash = Hash::new([128; HASH_SIZE]);
         assert_eq!(format!("{:?}", &hash), "Hash(80808080...)");
         let sk = SecretKey::new([255; SECRET_KEY_LENGTH]);
@@ -718,7 +718,7 @@ mod tests {
     // Note that only public values have Display impl.
     #[test]
     fn display_format() {
-        // Check zero padding
+        // Check zero padding.
         let hash = Hash::new([1; HASH_SIZE]);
         assert_eq!(format!("{}", &hash), "01010101...");
 
@@ -727,7 +727,7 @@ mod tests {
         let signature = Signature::new([10; SIGNATURE_LENGTH]);
         assert_eq!(format!("{}", &signature), "0a0a0a0a...");
 
-        // Check no padding
+        // Check no padding.
         let hash = Hash::new([128; HASH_SIZE]);
         assert_eq!(format!("{}", &hash), "80808080...");
     }

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -314,6 +314,7 @@ mod tests {
     use std::{fmt::Debug, str::FromStr};
 
     use chrono::{Duration, TimeZone};
+    use encoding::serialize::FromHex;
 
     // Number of samples for fuzz testing
     const FUZZ_SAMPLES: usize = 100_000;
@@ -582,7 +583,7 @@ mod tests {
 
     #[test]
     fn hash_round_trip() {
-        let hashes = [Hash::from_str(
+        let hashes = [Hash::from_hex(
             "326c1da1a00b5b4c85929dac57f3c99ceea82ed2941173d879c57b8f21ae8c78",
         ).unwrap()];
         assert_round_trip_eq(&hashes);
@@ -590,7 +591,7 @@ mod tests {
 
     #[test]
     fn public_key_round_trip() {
-        let hashes = [PublicKey::from_str(
+        let hashes = [PublicKey::from_hex(
             "1e38d80b8a9786648a471b11a9624a9519215743df7321938d70bac73dae3b84",
         ).unwrap()];
         assert_round_trip_eq(&hashes);
@@ -598,7 +599,7 @@ mod tests {
 
     #[test]
     fn signature_round_trip() {
-        let hashes = [Signature::from_str("326c1da1a00b5b4c85929dac57f3c99ceea82ed2941173d879c57b8f21ae8c781e38d80b8a9786648a471b11a9624a9519215743df7321938d70bac73dae3b84").unwrap()];
+        let hashes = [Signature::from_hex("326c1da1a00b5b4c85929dac57f3c99ceea82ed2941173d879c57b8f21ae8c781e38d80b8a9786648a471b11a9624a9519215743df7321938d70bac73dae3b84").unwrap()];
         assert_round_trip_eq(&hashes);
     }
 

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -590,7 +590,7 @@ fn test_explorer_transaction_info() {
     };
 
     let info = api.public(ApiKind::Explorer)
-        .get::<Value>(&format!("v1/transactions?hash={}", &tx.hash().to_string()))
+        .get::<Value>(&format!("v1/transactions?hash={}", &tx.hash().to_hex()))
         .unwrap_err();
     let error_body = json!({ "type": "unknown" });
     assert_matches!(
@@ -602,7 +602,7 @@ fn test_explorer_transaction_info() {
     testkit.poll_events();
 
     let info: Value = api.public(ApiKind::Explorer)
-        .get(&format!("v1/transactions?hash={}", &tx.hash().to_string()))
+        .get(&format!("v1/transactions?hash={}", &tx.hash().to_hex()))
         .unwrap();
     assert_eq!(
         info,
@@ -614,7 +614,7 @@ fn test_explorer_transaction_info() {
 
     testkit.create_block();
     let info: TransactionInfo<Value> = api.public(ApiKind::Explorer)
-        .get(&format!("v1/transactions?hash={}", &tx.hash().to_string()))
+        .get(&format!("v1/transactions?hash={}", &tx.hash().to_hex()))
         .unwrap();
     assert!(info.is_committed());
     let committed = info.as_committed().unwrap();

--- a/testkit/tests/inflating_currency/main.rs
+++ b/testkit/tests/inflating_currency/main.rs
@@ -59,7 +59,7 @@ fn create_wallet(api: &TestKitApi, name: &str) -> (TxCreateWallet, SecretKey) {
 
 fn get_balance(api: &TestKitApi, pubkey: &PublicKey) -> u64 {
     api.public(ApiKind::Service("cryptocurrency"))
-        .get(&format!("v1/balance?pub_key={}", pubkey.to_string()))
+        .get(&format!("v1/balance?pub_key={}", pubkey.to_hex()))
         .unwrap()
 }
 


### PR DESCRIPTION
It has been found strange that Display trait prints entire representations while Debug truncates them to 4 bytes. Furthermore, some Debug impls add ellipsis and some don't.

Update the macros that generate Debug impls so that they print the entire byte range. Add some new tests to ensure that Display impls are covered as well. Drop now-unused constant for display length limit.