### PR TITLE
Validate ConsensusConfig::max_message_len [ECR-1055] (#621)

### DIFF
--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -26,8 +26,9 @@ use serde_json::{self, Error as JsonError};
 
 use std::collections::{BTreeMap, HashSet};
 
-use crypto::{hash, CryptoHash, Hash, PublicKey};
+use crypto::{hash, CryptoHash, Hash, PublicKey, SIGNATURE_LENGTH};
 use helpers::{Height, Milliseconds};
+use messages::HEADER_LENGTH;
 use storage::StorageValue;
 
 /// Public keys of a validator. Each validator has two public keys: the
@@ -189,9 +190,6 @@ impl StoredConfiguration {
     /// JSON. Additionally, this method performs a logic validation of the
     /// configuration. The method returns either the result of execution or an error.
     pub fn try_deserialize(serialized: &[u8]) -> Result<Self, JsonError> {
-        use crypto::SIGNATURE_LENGTH;
-        use messages::HEADER_LENGTH;
-
         const MINIMAL_BODY_SIZE: usize = 256;
         const MINIMAL_MESSAGE_LENGTH: u32 =
             (HEADER_LENGTH + MINIMAL_BODY_SIZE + SIGNATURE_LENGTH) as u32;

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -357,6 +357,14 @@ mod tests {
         serialize_deserialize(&configuration);
     }
 
+    #[test]
+    #[should_panic(expected = "max_message_len (128) must be at least 330")]
+    fn too_small_max_message_len() {
+        let mut configuration = create_test_configuration();
+        configuration.consensus.max_message_len = 128;
+        serialize_deserialize(&configuration);
+    }
+
     fn create_test_configuration() -> StoredConfiguration {
         let validator_keys = (1..4)
             .map(|i| ValidatorKeys {

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -155,7 +155,7 @@ impl ConsensusConfig {
 
         if self.max_message_len < Self::DEFAULT_MAX_MESSAGE_LEN {
             warn!(
-                "It is recommended that max_message_len ({}) be at least {}.",
+                "It is recommended that max_message_len ({}) is at least {}.",
                 self.max_message_len,
                 Self::DEFAULT_MAX_MESSAGE_LEN
             );

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -192,7 +192,7 @@ impl StoredConfiguration {
         use crypto::SIGNATURE_LENGTH;
         use messages::HEADER_LENGTH;
 
-        const MINIMAL_BODY_SIZE: usize = 1024;
+        const MINIMAL_BODY_SIZE: usize = 256;
         const MINIMAL_MESSAGE_LENGTH: u32 =
             (HEADER_LENGTH + MINIMAL_BODY_SIZE + SIGNATURE_LENGTH) as u32;
 

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -152,6 +152,14 @@ impl ConsensusConfig {
                 self.txs_block_limit, MIN_TXS_BLOCK_LIMIT, MAX_TXS_BLOCK_LIMIT
             );
         }
+
+        if self.max_message_len < Self::DEFAULT_MAX_MESSAGE_LEN {
+            warn!(
+                "It is recommended that max_message_len ({}) be at least {}.",
+                self.max_message_len,
+                Self::DEFAULT_MAX_MESSAGE_LEN
+            );
+        }
     }
 }
 


### PR DESCRIPTION
We have typical default length set to 1 MB for a reason. It is even [mentioned in documentation](https://exonum.com/doc/architecture/configuration/#genesisconsensus). Drop a warning if the user (accidentally) sets this value too low.

I pondered whether we need to output byte sizes in more user-friendly manner (i.e., as "1 MB" instead of "1048576"), but that's too much of a hassle for an event which should never happen.

Exonum binary serialization format has certain fixed-size components like message header before the body and a signature after the body. Using zero-sized bodies is not practical, but it will certainly not fly if the maximum message size does not allow even that.

I'd guess Exonum will fail to work if the message length does not allow consesus messages to get through, but accurately accounting for that size is somewhat a bother. So we give a conservative estimate of 1024 bytes for the message body.

There are places in code which subtract `EMPTY_RESPONSE_SIZE` constant from `max_message_len`:

```rust
const EMPTY_RESPONSE_SIZE: u32 =
    (HEADER_LENGTH + SIGNATURE_LENGTH + 2 * PUBLIC_KEY_LENGTH + 8) as u32;

let unoccupied_message_size =
    self.state.config().consensus.max_message_len - EMPTY_RESPONSE_SIZE;
```

So we certainly should not allow `max_message_len` to get lower than that or unsigned integer wraparound will happen. This limit seems to be based on the size of `exonum::messages::protocol::BlockRequest` message.