### PR TITLE
Don't ignore files in sumbodules as dirs in cspell script [ECR-1851]

### DIFF
--- a/cspell.sh
+++ b/cspell.sh
@@ -18,15 +18,5 @@
 
 set -e
 
-./node_modules/.bin/cspell sandbox/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell exonum/{src,benches,tests}/**/*.rs
-./node_modules/.bin/cspell exonum/{src,benches,tests}/**/**/*.rs
-./node_modules/.bin/cspell exonum/fuzz/fuzz_targets/*.rs
-./node_modules/.bin/cspell testkit/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell testkit/server/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell services/configuration/{src,examples}/**/*.rs
-./node_modules/.bin/cspell services/time/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell examples/cryptocurrency/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell examples/cryptocurrency-advanced/{src,examples,tests}/**/*.rs
-./node_modules/.bin/cspell examples/timestamping/{src,examples,tests}/**/*.rs
+find . -not -path "*/target/*" -name "*.rs" | xargs ./node_modules/.bin/cspell
 find . -not -path "./3rdparty/*" -and -not -path "./node_modules/*" -name "*.md" | xargs ./node_modules/.bin/cspell

--- a/cspell.sh
+++ b/cspell.sh
@@ -20,6 +20,7 @@ set -e
 
 ./node_modules/.bin/cspell sandbox/{src,examples,tests}/**/*.rs
 ./node_modules/.bin/cspell exonum/{src,benches,tests}/**/*.rs
+./node_modules/.bin/cspell exonum/{src,benches,tests}/**/**/*.rs
 ./node_modules/.bin/cspell exonum/fuzz/fuzz_targets/*.rs
 ./node_modules/.bin/cspell testkit/{src,examples,tests}/**/*.rs
 ./node_modules/.bin/cspell testkit/server/{src,examples,tests}/**/*.rs

--- a/exonum/build.rs
+++ b/exonum/build.rs
@@ -1,3 +1,5 @@
+// spell-checker:ignore rustc
+
 use std::{env, fs::File, io::Write, path::Path, process::Command};
 
 static USER_AGENT_FILE_NAME: &str = "user_agent";

--- a/exonum/src/crypto/crypto_lib/sodiumoxide/mod.rs
+++ b/exonum/src/crypto/crypto_lib/sodiumoxide/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module implements cryptograpic backend based
+//! This module implements cryptographic backend based
 //! on [Sodium library](https://github.com/jedisct1/libsodium)
 //! through [sodiumoxide rust bindings](https://github.com/dnaq/sodiumoxide).
 //! The constants in this module are imported from Sodium.
@@ -26,6 +26,8 @@
 //! This backend also makes use of Ed25519 keys. Ed25519 is a signature system that ensures
 //! fast signing and key generation, as well as security and collision
 //! resilience.
+
+// spell-checker:ignore DIGESTBYTES, PUBLICKEYBYTES, SECRETKEYBYTES, SEEDBYTES, SIGNATUREBYTES
 
 extern crate exonum_sodiumoxide as sodiumoxide;
 

--- a/exonum/src/events/noise/mod.rs
+++ b/exonum/src/events/noise/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// spell-checker:ignore uint
+
 #[cfg(feature = "sodiumoxide-crypto")]
 #[doc(inline)]
 pub use self::wrappers::sodium_wrapper::{

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// spell-checker:ignore chacha, privkey, authtext, ciphertext
+
 use byteorder::{ByteOrder, LittleEndian};
 use rand::{thread_rng, Rng};
 use snow::{
@@ -216,7 +218,7 @@ impl Cipher for SodiumChaChaPoly {
         assert_ne!(
             self.key,
             Self::default().key,
-            "Can't dectypt with default key in SodiumChaChaPoly"
+            "Can't decrypt with default key in SodiumChaChaPoly"
         );
 
         let nonce = Self::get_ietf_nonce(nonce);

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/wrapper.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/wrapper.rs
@@ -157,8 +157,8 @@ impl NoiseWrapper {
     }
 
     // Each message consists of the payload and 16 bytes(`TAG_LENGTH`)
-    // of AEAD authentification data. Therefore to calculate an actual message
-    // length we need to substract `TAG_LENGTH` multiplied by messages count
+    // of AEAD authentication data. Therefore to calculate an actual message
+    // length we need to subtract `TAG_LENGTH` multiplied by messages count
     // from `data.len()`.
     fn decrypted_msg_len(&self, raw_message_len: usize) -> usize {
         raw_message_len - TAG_LENGTH * (raw_message_len / MAX_MESSAGE_LENGTH)

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -28,9 +28,9 @@
           filter_map,
           // Next lints produce too much noise/false positives.
           stutter, similar_names,
-          // Variant name ends with the enum's name. Similar behavior to similar_names.
+          // Variant name ends with the enum name. Similar behavior to similar_names.
           pub_enum_variant_names,
-          // Next lints allowed due to false possitive.
+          // Next lints allowed due to false positive.
           doc_markdown,
           // Can be enabled when rust-lang-nursery/rust-clippy#2894 is fixed.
           use_self,


### PR DESCRIPTION
Cspell ignores files in subdirectories.

Maybe all these globs should be replaced with `find -name "*.rs` with correct ignore?