### PR TITLE
Inject Proposes on transaction pressure [ECR-1441]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `NoiseHandshake::finalize` now returns error if remote peer's public key is not
   in `ConnectList`. (#811)
 
+- Now nodes will switch to `min_propose_timeout` for block proposal timeout
+  faster if they receive more than `propose_timeout_threshold` transactions
+  during `max_propose_timeout`. (#844)
+
 ## 0.9.0 - 2018-07-19
 
 ### Breaking Changes

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -552,6 +552,8 @@ impl NodeHandler {
             .merge(fork.into_patch())
             .expect("Unable to save transaction to persistent pool.");
 
+        self.maybe_add_propose_timeout();
+
         let full_proposes = self.state.check_incomplete_proposes(hash);
         // Go to handle full propose if we get last transaction.
         for (hash, round) in full_proposes {
@@ -689,6 +691,7 @@ impl NodeHandler {
 
     /// Handles propose timeout. Node sends `Propose` and `Prevote` if it is a leader as result.
     pub fn handle_propose_timeout(&mut self, height: Height, round: Round) {
+        self.allow_expedited_propose = true;
         // TODO debug asserts (ECR-171)?
         if height != self.state.height() {
             // It is too late

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -533,7 +533,8 @@ impl NodeHandler {
         }
     }
 
-    /// Checks if the transaction is new and adds it to the pool.
+    /// Checks if the transaction is new and adds it to the pool. This may trigger an expedited
+    /// `Propose` timeout on this node if transaction count in the pool goes over the threshold.
     fn handle_tx_inner(&mut self, msg: RawTransaction) -> Result<(), String> {
         let hash = msg.hash();
 

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -126,6 +126,8 @@ pub struct NodeHandler {
     node_role: NodeRole,
     /// Configuration file manager.
     config_manager: Option<ConfigManager>,
+    /// Can we speed up Propose with transaction pressure?
+    allow_expedited_propose: bool,
 }
 
 /// Service configuration.
@@ -448,6 +450,7 @@ impl NodeHandler {
             is_enabled,
             node_role,
             config_manager,
+            allow_expedited_propose: true,
         }
     }
 
@@ -619,10 +622,7 @@ impl NodeHandler {
 
     /// Adds `NodeTimeout::Propose` timeout to the channel.
     pub fn add_propose_timeout(&mut self) {
-        let snapshot = self.blockchain.snapshot();
-        let timeout = if Schema::new(&snapshot).transactions_pool_len()
-            >= self.propose_timeout_threshold() as usize
-        {
+        let timeout = if self.need_faster_propose() {
             self.min_propose_timeout()
         } else {
             self.max_propose_timeout()
@@ -638,6 +638,20 @@ impl NodeHandler {
         );
         let timeout = NodeTimeout::Propose(self.state.height(), self.state.round());
         self.add_timeout(timeout, time);
+    }
+
+    fn maybe_add_propose_timeout(&mut self) {
+        if self.need_faster_propose() && self.allow_expedited_propose {
+            info!("EXPEDITED PROPOSE TIMEOUT");
+            self.add_propose_timeout();
+            self.allow_expedited_propose = false;
+        }
+    }
+
+    fn need_faster_propose(&self) -> bool {
+        let snapshot = self.blockchain.snapshot();
+        let pending_tx_count = Schema::new(&snapshot).transactions_pool_len();
+        pending_tx_count >= self.propose_timeout_threshold() as usize
     }
 
     /// Adds `NodeTimeout::Status` timeout to the channel.

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -641,8 +641,8 @@ impl NodeHandler {
     }
 
     fn maybe_add_propose_timeout(&mut self) {
-        if self.need_faster_propose() && self.allow_expedited_propose {
-            info!("EXPEDITED PROPOSE TIMEOUT");
+        if self.allow_expedited_propose && self.need_faster_propose() {
+            info!("Add expedited propose timeout");
             self.add_propose_timeout();
             self.allow_expedited_propose = false;
         }

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -18,7 +18,7 @@
 use futures::{self, sync::mpsc, Async, Future, Sink, Stream};
 
 use std::{
-    cell::{Ref, RefCell, RefMut},
+    self, cell::{Ref, RefCell, RefMut},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque}, iter::FromIterator,
     net::{IpAddr, Ipv4Addr, SocketAddr}, ops::{AddAssign, Deref}, sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -737,7 +737,7 @@ pub fn sandbox_with_services_uninitialized(services: Vec<Box<dyn Service>>) -> S
         max_message_len: 1024 * 1024,
         min_propose_timeout: PROPOSE_TIMEOUT,
         max_propose_timeout: PROPOSE_TIMEOUT,
-        propose_timeout_threshold: 0,
+        propose_timeout_threshold: std::u32::MAX,
     };
     let genesis = GenesisConfig::new_with_consensus(
         consensus,


### PR DESCRIPTION
[Previously we have tweaked the timeout between **Propose** messages](https://github.com/exonum/exonum/pull/643) to adapt to current size of transaction queue. However, this timeout is fixed at the start of the round or at block creation time. If a node suddenly receives sufficiently large number of transactions during the timeout it will still wait for `max_propose_timeout()`.

Now we are going to check the transaction count every time we add a new transaction to the queue. If we have enough queued up then we schedule a quicker **Propose** timeout with `min_propose_timeout()`.

Previously scheduled timeouts will be handled later but they will be skipped due the checks in the beginning of `handle_propose_timeout()`.

Also note that we prevent expedited timeouts from being scheduled repeatedly. This is required as the transactions are not going anywhere out of the queue only because we schedule a timeout. We reset the flag when we actually handle the nearest timeout.

Threshold value now affects node behavior by causing **Propose** messages to be sent when new transactions are generated. Using threshold of zero in sandbox means that we'll send an extra Propose every time. Set it to non-zero value to avoid this unexpected behavior. Use `u32::MAX` rather than any hardcoded value like `10_000` to avoid surprises further.