### PR TITLE
SandboxBuilder and tests for dynamic propose timeout [ECR-2033]

### DIFF
--- a/exonum/src/sandbox/consensus/recovery.rs
+++ b/exonum/src/sandbox/consensus/recovery.rs
@@ -23,7 +23,8 @@ use messages::{Connect, PeersRequest, Precommit, Prevote};
 use node;
 
 use sandbox::{
-    sandbox::{sandbox_with_services_uninitialized, timestamping_sandbox}, sandbox_tests_helper::*,
+    sandbox::{timestamping_sandbox, SandboxBuilder},
+    sandbox_tests_helper::*,
 };
 
 #[test]
@@ -432,7 +433,9 @@ fn test_recover_consensus_messages_in_other_round() {
 #[test]
 fn should_restore_peers_after_restart() {
     // create sandbox with nodes not aware about each other
-    let sandbox = sandbox_with_services_uninitialized(vec![]);
+    let sandbox = SandboxBuilder::new()
+        .do_not_initialize_connections()
+        .build();
 
     let (v0, v1) = (ValidatorId(0), ValidatorId(1));
     let (p0, s0, a0) = (sandbox.p(v0), sandbox.s(v0).clone(), sandbox.a(v0));

--- a/exonum/src/sandbox/consensus/recovery.rs
+++ b/exonum/src/sandbox/consensus/recovery.rs
@@ -23,8 +23,7 @@ use messages::{Connect, PeersRequest, Precommit, Prevote};
 use node;
 
 use sandbox::{
-    sandbox::{timestamping_sandbox, SandboxBuilder},
-    sandbox_tests_helper::*,
+    sandbox::{timestamping_sandbox, SandboxBuilder}, sandbox_tests_helper::*,
 };
 
 #[test]

--- a/exonum/src/sandbox/consensus/transactions.rs
+++ b/exonum/src/sandbox/consensus/transactions.rs
@@ -31,6 +31,31 @@ use sandbox::{
     sandbox_tests_helper::*, timestamping::{TimestampTx, TimestampingTxGenerator, DATA_SIZE},
 };
 
+const MAX_PROPOSE_TIMEOUT: Milliseconds = 200;
+const MIN_PROPOSE_TIMEOUT: Milliseconds = 10;
+const PROPOSE_THRESHOLD: u32 = 3;
+
+fn timestamping_sandbox_with_threshold() -> Sandbox {
+    let sandbox = timestamping_sandbox_builder()
+        .with_consensus(|config| {
+            config.max_propose_timeout = MAX_PROPOSE_TIMEOUT;
+            config.min_propose_timeout = MIN_PROPOSE_TIMEOUT;
+            config.propose_timeout_threshold = PROPOSE_THRESHOLD;
+        })
+        .build();
+
+    // Wait for us to become the leader.
+    sandbox.add_time(Duration::from_millis(sandbox.round_timeout()));
+    sandbox.add_time(Duration::from_millis(sandbox.round_timeout()));
+    sandbox
+}
+
+fn tx_hashes(transactions: &[TimestampTx]) -> Vec<Hash> {
+    let mut hashes = transactions.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
+    hashes.sort();
+    hashes
+}
+
 /// idea of the test is to verify request transaction scenario: other node requests
 /// transaction from our node
 #[test]
@@ -554,31 +579,6 @@ fn request_txs_when_get_propose_or_prevote() {
     );
 
     sandbox.add_time(Duration::from_millis(0));
-}
-
-const MAX_PROPOSE_TIMEOUT: Milliseconds = 200;
-const MIN_PROPOSE_TIMEOUT: Milliseconds = 10;
-const PROPOSE_THRESHOLD: u32 = 3;
-
-fn timestamping_sandbox_with_threshold() -> Sandbox {
-    let sandbox = timestamping_sandbox_builder()
-        .with_consensus(|config| {
-            config.max_propose_timeout = MAX_PROPOSE_TIMEOUT;
-            config.min_propose_timeout = MIN_PROPOSE_TIMEOUT;
-            config.propose_timeout_threshold = PROPOSE_THRESHOLD;
-        })
-        .build();
-
-    // Wait for us to become the leader.
-    sandbox.add_time(Duration::from_millis(sandbox.round_timeout()));
-    sandbox.add_time(Duration::from_millis(sandbox.round_timeout()));
-    sandbox
-}
-
-fn tx_hashes(transactions: &[TimestampTx]) -> Vec<Hash> {
-    let mut hashes = transactions.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
-    hashes.sort();
-    hashes
 }
 
 #[test]

--- a/exonum/src/sandbox/consensus/transactions.rs
+++ b/exonum/src/sandbox/consensus/transactions.rs
@@ -575,8 +575,8 @@ fn timestamping_sandbox_with_threshold() -> Sandbox {
     sandbox
 }
 
-fn tx_hashes(txes: &[TimestampTx]) -> Vec<Hash> {
-    let mut hashes = txes.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
+fn tx_hashes(transactions: &[TimestampTx]) -> Vec<Hash> {
+    let mut hashes = transactions.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
     hashes.sort();
     hashes
 }
@@ -586,11 +586,11 @@ fn regular_propose_when_no_transaction_pressure() {
     let sandbox = timestamping_sandbox_with_threshold();
 
     // Generate and receive some transactions (fewer than the threshold).
-    let txes = TimestampingTxGenerator::new(64)
+    let transactions = TimestampingTxGenerator::new(64)
         .take(PROPOSE_THRESHOLD as usize - 1)
         .collect::<Vec<_>>();
 
-    for tx in &txes {
+    for tx in &transactions {
         sandbox.recv(tx);
     }
 
@@ -598,7 +598,7 @@ fn regular_propose_when_no_transaction_pressure() {
     sandbox.add_time(Duration::from_millis(MAX_PROPOSE_TIMEOUT));
 
     let propose = ProposeBuilder::new(&sandbox)
-        .with_tx_hashes(&tx_hashes(&txes))
+        .with_tx_hashes(&tx_hashes(&transactions))
         .build();
 
     sandbox.broadcast(&propose);
@@ -610,11 +610,11 @@ fn expedited_propose_on_transaction_pressure() {
     let sandbox = timestamping_sandbox_with_threshold();
 
     // Generate and receive some transactions (at the threshold).
-    let txes = TimestampingTxGenerator::new(64)
+    let transactions = TimestampingTxGenerator::new(64)
         .take(PROPOSE_THRESHOLD as usize)
         .collect::<Vec<_>>();
 
-    for tx in &txes {
+    for tx in &transactions {
         sandbox.recv(tx);
     }
 
@@ -622,7 +622,7 @@ fn expedited_propose_on_transaction_pressure() {
     sandbox.add_time(Duration::from_millis(MIN_PROPOSE_TIMEOUT));
 
     let propose = ProposeBuilder::new(&sandbox)
-        .with_tx_hashes(&tx_hashes(&txes))
+        .with_tx_hashes(&tx_hashes(&transactions))
         .build();
 
     sandbox.broadcast(&propose);

--- a/exonum/src/sandbox/consensus/transactions.rs
+++ b/exonum/src/sandbox/consensus/transactions.rs
@@ -28,8 +28,7 @@ use node::state::TRANSACTIONS_REQUEST_TIMEOUT;
 use sandbox::{
     config_updater::TxConfig,
     sandbox::{timestamping_sandbox, timestamping_sandbox_builder, Sandbox},
-    sandbox_tests_helper::*,
-    timestamping::{TimestampTx, TimestampingTxGenerator, DATA_SIZE},
+    sandbox_tests_helper::*, timestamping::{TimestampTx, TimestampingTxGenerator, DATA_SIZE},
 };
 
 /// idea of the test is to verify request transaction scenario: other node requests


### PR DESCRIPTION
Here we introduce `SandboxBuilder` as a way to configure the `Sandbox` before usage. Currently it supports only setting a different genesis `ConsensusConfig`, but it can be extended in the future.

Tweakable consesus configuration enables writing some tests to verify dynamic Propose timeouts introduced in #844.