### PR TITLE
Schedule expedited proposals only if we're the leader [ECR-2038]

### DIFF
--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -553,7 +553,9 @@ impl NodeHandler {
             .merge(fork.into_patch())
             .expect("Unable to save transaction to persistent pool.");
 
-        self.maybe_add_propose_timeout();
+        if self.state.is_leader() {
+            self.maybe_add_propose_timeout();
+        }
 
         let full_proposes = self.state.check_incomplete_proposes(hash);
         // Go to handle full propose if we get last transaction.


### PR DESCRIPTION
A node should not attempt to schedule a proposal on each transaction if it is not a leader. It will not work, the other nodes will notice this and will complain with errors in logs. We don't want that.

(Bug introduced by #844.)