### PR TITLE
Fix expedited proposal reactivation [ECR-2040]

### DIFF
--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -692,7 +692,6 @@ impl NodeHandler {
 
     /// Handles propose timeout. Node sends `Propose` and `Prevote` if it is a leader as result.
     pub fn handle_propose_timeout(&mut self, height: Height, round: Round) {
-        self.allow_expedited_propose = true;
         // TODO debug asserts (ECR-171)?
         if height != self.state.height() {
             // It is too late
@@ -733,6 +732,8 @@ impl NodeHandler {
 
             trace!("Broadcast propose: {:?}", propose);
             self.broadcast(propose.raw());
+
+            self.allow_expedited_propose = true;
 
             // Save our propose into state
             let hash = self.state.add_self_propose(propose);


### PR DESCRIPTION
It turns out that `handle_propose_timeout()` calls way more common during network operation than I expected. We should actually allow expedited proposal to happen again only after we broadcast a real proposal to other nodes.

With this the nodes will no longer spam the log with bogus expedited timeout notifications. I should have found this earlier :( I remember now that someone in #844 has pointed out that this may not a good place to reset the flag.