### PR TITLE
Update actix and actix-web to 0.7.3 [ECR-2121]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Custom log formatting (along with `colored` and `term` dependencies) has been
   removed in favor of `env_logger`. (#857).
 
-- Several dependencies have been updated. (#861)
+- Several dependencies have been updated. (#861, #865)
 
 ## 0.9.1 - 2018-08-02
 

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -17,8 +17,8 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-actix = "=0.5.8"
-actix-web = "=0.6.15"
+actix = "=0.7.3"
+actix-web = "=0.7.3"
 log = "=0.4.3"
 byteorder = "1.2.3"
 hex = "=0.3.2"

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -106,7 +106,7 @@ impl ServiceApiBackend for ApiBuilder {
     }
 }
 
-// FIXME: workaround for a regression in actix-web 0.7.3 (ECR-2149)
+// TODO: remove this workaround for a regression in actix-web 0.7.3 (ECR-2149)
 fn sanitize(mut handler: RequestHandler) -> RequestHandler {
     if !handler.name.starts_with('/') {
         handler.name.insert(0, '/');

--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -185,7 +185,7 @@ impl ExplorerApi {
             }
 
             Box::new(
-                ws::start(req.clone(), Session::new(address.to_owned().unwrap())).into_future(),
+                ws::start(&req, Session::new(address.to_owned().unwrap())).into_future(),
             )
         };
 

--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -184,9 +184,7 @@ impl ExplorerApi {
                 shared_node_state.set_broadcast_server_address(address.to_owned().unwrap());
             }
 
-            Box::new(
-                ws::start(&req, Session::new(address.to_owned().unwrap())).into_future(),
-            )
+            Box::new(ws::start(&req, Session::new(address.to_owned().unwrap())).into_future())
         };
 
         backend.raw_handler(RequestHandler {

--- a/exonum/src/api/websocket.rs
+++ b/exonum/src/api/websocket.rs
@@ -32,7 +32,7 @@ pub(crate) struct Message(pub String);
 #[derive(Message)]
 #[rtype(usize)]
 pub(crate) struct Subscribe {
-    pub address: Recipient<Syn, Message>,
+    pub address: Recipient<Message>,
 }
 
 #[derive(Message)]
@@ -46,7 +46,7 @@ pub(crate) struct Broadcast {
 }
 
 pub(crate) struct Server {
-    pub subscribers: HashMap<usize, Recipient<Syn, Message>>,
+    pub subscribers: HashMap<usize, Recipient<Message>>,
     rng: RefCell<ThreadRng>,
 }
 
@@ -94,11 +94,11 @@ impl Handler<Broadcast> for Server {
 
 pub(crate) struct Session {
     pub id: usize,
-    pub server_address: Addr<Syn, Server>,
+    pub server_address: Addr<Server>,
 }
 
 impl Session {
-    pub fn new(server_address: Addr<Syn, Server>) -> Self {
+    pub fn new(server_address: Addr<Server>) -> Self {
         Self {
             id: 0,
             server_address,
@@ -110,7 +110,7 @@ impl Actor for Session {
     type Context = ws::WebsocketContext<Self, ServiceApiState>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        let address: Addr<Syn, _> = ctx.address();
+        let address: Addr<_> = ctx.address();
         self.server_address
             .send(Subscribe {
                 address: address.clone().recipient(),

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -15,7 +15,7 @@
 //! This module defines the Exonum services interfaces. Like smart contracts in some other
 //! blockchain platforms, Exonum services encapsulate business logic of the blockchain application.
 
-use actix::{Addr, Syn};
+use actix::Addr;
 use serde_json::Value;
 
 use std::{
@@ -322,7 +322,7 @@ pub struct ApiNodeState {
     node_role: NodeRole,
     majority_count: usize,
     validators: Vec<ValidatorKeys>,
-    broadcast_server_address: Option<Addr<Syn, websocket::Server>>,
+    broadcast_server_address: Option<Addr<websocket::Server>>,
 }
 
 impl fmt::Debug for ApiNodeState {
@@ -536,7 +536,7 @@ impl SharedNodeState {
             .remove(addr)
     }
 
-    pub(crate) fn set_broadcast_server_address(&self, address: Addr<Syn, websocket::Server>) {
+    pub(crate) fn set_broadcast_server_address(&self, address: Addr<websocket::Server>) {
         let mut state = self.state.write().expect("Expected write lock");
         state.broadcast_server_address = Some(address);
     }

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-actix-web = "=0.6.15"
+actix-web = "=0.7.3"
 exonum = { version = "0.9.0", path = "../exonum" }
 failure = "0.1.2"
 futures = "=0.1.23"


### PR DESCRIPTION
* `Syn`/`Unsync` markers has been removed, they are not needed anymore.

* `actix::msgs::SystemExit` has been made private. now the system should be stopped by calling `System::stop()` which will send this message. Instead of passing SystemAddr just pass the System handle itself.

* `ws::start()` now accepts a reference to HttpRequest instead of instance.

* actix-web 0.7.3 has a regression (since 0.7.0) which breaks our tests. Apply a temporary workaround for it.

Obsoletes #814, #824.