### PR TITLE
Fix cryptocurrency bench

### DIFF
--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -107,8 +107,7 @@ mod timestamping {
     use super::{gen_keypair_from_rng, BoxedTx};
     use exonum::{
         blockchain::{ExecutionResult, Service, Transaction}, crypto::{CryptoHash, Hash, PublicKey},
-        encoding::Error as EncodingError, messages::{Message, RawTransaction},
-        storage::{Fork, Snapshot},
+        encoding::Error as EncodingError, messages::RawTransaction, storage::{Fork, Snapshot},
     };
     use rand::Rng;
 
@@ -153,7 +152,9 @@ mod timestamping {
 
     impl Transaction for Tx {
         fn verify(&self) -> bool {
-            self.verify_signature(self.from())
+            // We don't verify transactions within the benchmark, so in this
+            // and following transaction types the verification code is trivial.
+            true
         }
 
         fn execute(&self, _: &mut Fork) -> ExecutionResult {
@@ -163,7 +164,7 @@ mod timestamping {
 
     impl Transaction for PanickingTx {
         fn verify(&self) -> bool {
-            self.verify_signature(self.from())
+            true
         }
 
         fn execute(&self, _: &mut Fork) -> ExecutionResult {
@@ -190,8 +191,8 @@ mod cryptocurrency {
     use super::{gen_keypair_from_rng, BoxedTx};
     use exonum::{
         blockchain::{ExecutionError, ExecutionResult, Service, Transaction},
-        crypto::{Hash, PublicKey}, encoding::Error as EncodingError,
-        messages::{Message, RawTransaction}, storage::{Fork, MapIndex, ProofMapIndex, Snapshot},
+        crypto::{Hash, PublicKey}, encoding::Error as EncodingError, messages::RawTransaction,
+        storage::{Fork, MapIndex, ProofMapIndex, Snapshot},
     };
     use rand::{seq::sample_slice_ref, Rng};
 
@@ -252,7 +253,7 @@ mod cryptocurrency {
 
     impl Transaction for Tx {
         fn verify(&self) -> bool {
-            self.verify_signature(self.from())
+            true
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {
@@ -269,7 +270,7 @@ mod cryptocurrency {
 
     impl Transaction for SimpleTx {
         fn verify(&self) -> bool {
-            self.verify_signature(self.from())
+            true
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {
@@ -286,7 +287,7 @@ mod cryptocurrency {
 
     impl Transaction for RollbackTx {
         fn verify(&self) -> bool {
-            self.verify_signature(self.from())
+            true
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -214,16 +214,15 @@ fn execute_cryptocurrency(db: Box<Database>, c: &mut Criterion) {
         let snapshot = blockchain.snapshot();
         let schema = Schema::new(&snapshot);
 
-        assert!(txs.iter().all(|hash| {
-            schema.transactions_pool().contains(&hash) &&
-                !schema.transactions_locations().contains(&hash)
-        }));
+        assert!(
+            txs.iter()
+                .all(|hash| schema.transactions_pool().contains(&hash)
+                    && !schema.transactions_locations().contains(&hash))
+        );
     }
 
     let mut blockchain = create_blockchain(db, vec![Box::new(Cryptocurrency)]);
-    let keys: Vec<_> = (0..KEY_COUNT)
-        .map(|_| gen_keypair())
-        .collect();
+    let keys: Vec<_> = (0..KEY_COUNT).map(|_| gen_keypair()).collect();
 
     for i in 0..HEIGHT {
         let txs = prepare_txs(&mut blockchain, i, TRANSACTIONS_IN_BLOCK, &keys);

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -154,7 +154,7 @@ mod timestamping {
         fn verify(&self) -> bool {
             // We don't verify transactions within the benchmark, so in this
             // and following transaction types the verification code is trivial.
-            true
+            unimplemented!("never used in benchmark")
         }
 
         fn execute(&self, _: &mut Fork) -> ExecutionResult {
@@ -164,7 +164,7 @@ mod timestamping {
 
     impl Transaction for PanickingTx {
         fn verify(&self) -> bool {
-            true
+            unimplemented!("never used in benchmark")
         }
 
         fn execute(&self, _: &mut Fork) -> ExecutionResult {
@@ -253,7 +253,7 @@ mod cryptocurrency {
 
     impl Transaction for Tx {
         fn verify(&self) -> bool {
-            true
+            unimplemented!("never used in benchmark")
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {
@@ -270,7 +270,7 @@ mod cryptocurrency {
 
     impl Transaction for SimpleTx {
         fn verify(&self) -> bool {
-            true
+            unimplemented!("never used in benchmark")
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {
@@ -287,7 +287,7 @@ mod cryptocurrency {
 
     impl Transaction for RollbackTx {
         fn verify(&self) -> bool {
-            true
+            unimplemented!("never used in benchmark")
         }
 
         fn execute(&self, fork: &mut Fork) -> ExecutionResult {

--- a/exonum/benches/criterion/lib.rs
+++ b/exonum/benches/criterion/lib.rs
@@ -17,6 +17,7 @@ extern crate criterion;
 #[macro_use]
 extern crate exonum;
 extern crate futures;
+extern crate log;
 extern crate num;
 extern crate rand;
 extern crate tempdir;

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -549,4 +549,20 @@ impl<'a> Schema<&'a mut Fork> {
             Err(())
         }
     }
+
+    /// Removes all transactions from the node's pool.
+    #[doc(hidden)]
+    pub fn clear_transaction_pool(&mut self) {
+        let tx_hashes: Vec<_> = {
+            let pool = self.transactions_pool();
+            let hashes = pool.iter().collect();
+            hashes
+        };
+
+        for hash in &tx_hashes {
+            self.transactions_pool_mut().remove(hash);
+            self.transactions_mut().remove(hash);
+        }
+        self.transactions_pool_len_index_mut().set(0);
+    }
 }

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -549,21 +549,4 @@ impl<'a> Schema<&'a mut Fork> {
             Err(())
         }
     }
-
-    /// Removes all transactions from the node's pool.
-    #[doc(hidden)]
-    #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
-    pub fn clear_transaction_pool(&mut self) {
-        let tx_hashes: Vec<_> = {
-            let pool = self.transactions_pool();
-            let hashes = pool.iter().collect();
-            hashes
-        };
-
-        for hash in &tx_hashes {
-            self.transactions_pool_mut().remove(hash);
-            self.transactions_mut().remove(hash);
-        }
-        self.transactions_pool_len_index_mut().set(0);
-    }
 }

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -552,6 +552,7 @@ impl<'a> Schema<&'a mut Fork> {
 
     /// Removes all transactions from the node's pool.
     #[doc(hidden)]
+    #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
     pub fn clear_transaction_pool(&mut self) {
         let tx_hashes: Vec<_> = {
             let pool = self.transactions_pool();

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -535,11 +535,12 @@ impl<'a> Schema<&'a mut Fork> {
     }
 
     /// Removes transaction from the persistent pool.
-    #[doc(hidden)]
-    pub fn reject_transaction(&mut self, hash: &Hash) -> Result<(), ()> {
+    #[cfg(test)]
+    pub(crate) fn reject_transaction(&mut self, hash: &Hash) -> Result<(), ()> {
         let contains = self.transactions_pool_mut().contains(hash);
         self.transactions_pool_mut().remove(hash);
         self.transactions_mut().remove(hash);
+
         if contains {
             let x = self.transactions_pool_len_index().get().unwrap();
             self.transactions_pool_len_index_mut().set(x - 1);

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -74,7 +74,7 @@ impl Transaction for Tx {
 }
 
 #[test]
-fn test_encode_decode() {
+fn encode_decode() {
     encoding_struct! {
         struct Parent {
             child: Child,
@@ -93,7 +93,7 @@ fn test_encode_decode() {
 }
 
 #[test]
-fn test_u64() {
+fn u64_json_serialization() {
     encoding_struct! {
         struct Test {
             some_test: u64,
@@ -106,7 +106,7 @@ fn test_u64() {
 }
 
 #[test]
-fn test_date_time() {
+fn date_time_json_serialization() {
     encoding_struct! {
         struct Test {
             some_test: DateTime<Utc>,
@@ -130,7 +130,7 @@ encoding_struct! {
 }
 
 #[test]
-fn test_correct_encoding_struct() {
+fn correct_encoding_struct() {
     let dat: Vec<u8> = vec![
         8u8, 0, 0, 0, 18, 0, 0, 0, 16, 0, 0, 0, 1, 0, 0, 0, 17, 0, 0, 0, 1, 0, 0, 0, 1, 2,
     ];
@@ -146,7 +146,7 @@ fn test_correct_encoding_struct() {
 
 #[test]
 #[should_panic(expected = "OverlappingSegment")]
-fn test_overlap_segments() {
+fn overlap_segments() {
     let test = vec![16u8, 0, 0, 0, 1, 0, 0, 0, 16, 0, 0, 0, 1, 0, 0, 0, 1, 2];
     let mut buffer = vec![0; 8];
     test.write(&mut buffer, 0, 8);
@@ -155,7 +155,7 @@ fn test_overlap_segments() {
 
 #[test]
 #[should_panic(expected = "SpaceBetweenSegments")]
-fn test_segments_has_spaces_between() {
+fn segments_has_spaces_between() {
     let test = vec![
         16u8,
         0,
@@ -531,27 +531,27 @@ mod memorydb_tests {
     }
 
     #[test]
-    fn test_handling_tx_panic() {
+    fn handling_tx_panic() {
         let mut blockchain = create_blockchain();
         super::handling_tx_panic(&mut blockchain);
     }
 
     #[test]
     #[should_panic]
-    fn test_handling_tx_panic_storage_error() {
+    fn handling_tx_panic_storage_error() {
         let mut blockchain = create_blockchain();
         super::handling_tx_panic_storage_error(&mut blockchain);
     }
 
     #[test]
-    fn test_service_execute() {
+    fn service_execute() {
         let blockchain = create_blockchain_with_service(Box::new(ServiceGood));
         let mut db = create_database();
         super::assert_service_execute(&blockchain, &mut db);
     }
 
     #[test]
-    fn test_service_execute_panic() {
+    fn service_execute_panic() {
         let blockchain = create_blockchain_with_service(Box::new(ServicePanic));
         let mut db = create_database();
         super::assert_service_execute_panic(&blockchain, &mut db);
@@ -559,7 +559,7 @@ mod memorydb_tests {
 
     #[test]
     #[should_panic]
-    fn test_service_execute_panic_storage_error() {
+    fn service_execute_panic_storage_error() {
         let blockchain = create_blockchain_with_service(Box::new(ServicePanicStorageError));
         let mut db = create_database();
         super::assert_service_execute(&blockchain, &mut db);
@@ -620,7 +620,7 @@ mod rocksdb_tests {
     }
 
     #[test]
-    fn test_handling_tx_panic() {
+    fn handling_tx_panic() {
         let dir = create_temp_dir();
         let mut blockchain = create_blockchain(dir.path());
         super::handling_tx_panic(&mut blockchain);
@@ -628,14 +628,14 @@ mod rocksdb_tests {
 
     #[test]
     #[should_panic]
-    fn test_handling_tx_panic_storage_error() {
+    fn handling_tx_panic_storage_error() {
         let dir = create_temp_dir();
         let mut blockchain = create_blockchain(dir.path());
         super::handling_tx_panic_storage_error(&mut blockchain);
     }
 
     #[test]
-    fn test_service_execute() {
+    fn service_execute() {
         let dir = create_temp_dir();
         let blockchain = create_blockchain_with_service(dir.path(), Box::new(ServiceGood));
         let dir = create_temp_dir();
@@ -644,7 +644,7 @@ mod rocksdb_tests {
     }
 
     #[test]
-    fn test_service_execute_panic() {
+    fn service_execute_panic() {
         let dir = create_temp_dir();
         let blockchain = create_blockchain_with_service(dir.path(), Box::new(ServicePanic));
         let dir = create_temp_dir();
@@ -654,7 +654,7 @@ mod rocksdb_tests {
 
     #[test]
     #[should_panic]
-    fn test_service_execute_panic_storage_error() {
+    fn service_execute_panic_storage_error() {
         let dir = create_temp_dir();
         let blockchain =
             create_blockchain_with_service(dir.path(), Box::new(ServicePanicStorageError));

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -186,42 +186,6 @@ fn gen_tempdir_name() -> String {
     thread_rng().sample_iter(&Alphanumeric).take(10).collect()
 }
 
-fn clear_transaction_pool(blockchain: &mut Blockchain) {
-    let (_, sec_key) = gen_keypair();
-    let mut txs: Vec<_> = (1..5).map(|i| Tx::new(i, &sec_key)).collect();
-
-    let mut fork = blockchain.fork();
-    let mut schema = Schema::new(&mut fork);
-    for tx in &txs {
-        schema.add_transaction_into_pool(tx.raw().clone());
-    }
-    assert!(
-        txs.iter()
-            .all(|tx| schema.transactions_pool().contains(&tx.hash()))
-    );
-    assert_eq!(schema.transactions_pool_len(), txs.len() as u64);
-
-    schema.clear_transaction_pool();
-    assert!(
-        txs.iter()
-            .map(|tx| tx.hash())
-            .all(|hash| !schema.transactions_pool().contains(&hash)
-                && !schema.transactions().contains(&hash))
-    );
-    assert_eq!(schema.transactions_pool_len(), 0);
-
-    // Check that adding transactions in the pool works normally after clearing the pool.
-    txs.truncate(2);
-    for tx in &txs {
-        schema.add_transaction_into_pool(tx.raw().clone());
-    }
-    assert!(
-        txs.iter()
-            .all(|tx| schema.transactions_pool().contains(&tx.hash()))
-    );
-    assert_eq!(schema.transactions_pool_len(), txs.len() as u64);
-}
-
 fn handling_tx_panic(blockchain: &mut Blockchain) {
     let (_, sec_key) = gen_keypair();
 
@@ -525,12 +489,6 @@ mod memorydb_tests {
     }
 
     #[test]
-    fn clear_transaction_pool() {
-        let mut blockchain = create_blockchain();
-        super::clear_transaction_pool(&mut blockchain);
-    }
-
-    #[test]
     fn handling_tx_panic() {
         let mut blockchain = create_blockchain();
         super::handling_tx_panic(&mut blockchain);
@@ -610,13 +568,6 @@ mod rocksdb_tests {
 
     fn create_temp_dir() -> TempDir {
         TempDir::new(super::gen_tempdir_name().as_str()).unwrap()
-    }
-
-    #[test]
-    fn clear_transaction_pool() {
-        let dir = create_temp_dir();
-        let mut blockchain = create_blockchain(dir.path());
-        super::clear_transaction_pool(&mut blockchain);
     }
 
     #[test]


### PR DESCRIPTION
Unless I'm missing something, the cryptocurrency benchmark is as of now rendered unusable by at least two bugs:

- It generates duplicate transactions (each sender sends tokens to the same recipient each time). This distorts measurements and corresponds to a situation which can never occur in a real blockchain.
- ~All transactions panic because the initial balance of each account is 0, and we attempt to subtract from it. This distorts results, too.~ **Edit:** transactions don't really panic, as integer overflow is silently swallowed by the compiler in the release mode; it results in wrapping. Still, the code is not transparent; also, it's a bit of anecdotal evidence so far, but it seems that on my PC the benchmark with the overflow fixed runs ~10% slower (I don't really know why).

This PR fixes the aforementioned bugs and also introduces some other improvements. Among discussable ones is reduction of the number of transactions in a block from 1,000 to 100; this allows to sample measurements more efficiently.