### PR TITLE
Do not broadcast to peers not in connect list [ECR-2156]

### DIFF
--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -592,8 +592,14 @@ impl NodeHandler {
     pub fn broadcast(&mut self, message: &RawMessage) {
         let peers: Vec<SocketAddr> = self.state
             .peers()
-            .values()
-            .map(|conn| conn.addr())
+            .iter()
+            .filter_map(|(pubkey, connection)| {
+                if self.state.connect_list().is_peer_allowed(pubkey) {
+                    Some(connection.addr())
+                } else {
+                    None
+                }
+            })
             .collect();
 
         for address in peers {


### PR DESCRIPTION
This fixes a weird feedback loop that spins up when a peer of a node is removed from its connect list and the node gets restarted.

Suppose there are three validator nodes: A, B, C. All of them are interconnected at the moment, present in each other's connect lists, and maintain mutual connections. Now node A is removed from node C's connect list and node C is restarted. Nodes A and B have no clue about that so they are still connected to C and will try connecting to it from time to time. However, C now does not wish to speak to A. Direct connections from C to A will be denied by the connect list, but if A has recently attempted talking to C then A will be present in C's peer list and C will try broadcasting messages to A.

We should not really broadcast messages to peers which are not present in our connect list. The message generated by `send_to_addr()` will pass through all event handlers, but it will eventually be rejected by `ConnectionsPool::build_handshake_initiator()`. However, this is done *after* our node has connected to the peer, resulting in tons of unclear error messages caused by subsequent unexpected disconnection when the node realizes it should not talk to its peer.

Filtering out peers that are not in connect list breaks the vicious loop, we no longer attempt connections which are bound to fail, and we no longer get tons on error messages in the log.