### PR TITLE
Add all_entries_unchecked method [ECR-1959]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   `first_round_timeout`. Value of this percentage is defined in
   `ConsensusConfig::TIMEOUT_LINEAR_INCREASE_PERCENT` constant (10%). (#848)
 
+- `missing_keys`, `entries`, `all_entries` methods of `CheckedMapProof` and
+  `MapProof::missing_keys_unchecked` method now return `impl Iterator` instead
+  of `Vec`. (#918)
+
 ### New Features
 
 #### exonum
@@ -54,6 +58,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Added `/v1/blocks/subscribe` endpoint for following block commit events
   through WebSockets (#792).
+
+- Added `MapProof::all_entries_unchecked` method. It is used for more efficient
+  calculations in Exonum Java Bindings, but can be used for debug purposes
+  as well. (#918)
 
 ### Bug Fixes
 

--- a/examples/cryptocurrency-advanced/backend/tests/api.rs
+++ b/examples/cryptocurrency-advanced/backend/tests/api.rs
@@ -235,12 +235,12 @@ impl CryptocurrencyApi {
             .unwrap();
 
         let to_wallet = wallet_info.wallet_proof.to_wallet.check().unwrap();
-        to_wallet
+        let wallet = to_wallet
             .all_entries()
-            .iter()
             .find(|(ref k, _)| **k == pub_key)
             .and_then(|tuple| tuple.1)
-            .cloned()
+            .cloned();
+        wallet
     }
 
     /// Sends a transfer transaction over HTTP and checks the synchronous result.
@@ -265,8 +265,7 @@ impl CryptocurrencyApi {
         assert!(
             to_wallet
                 .missing_keys()
-                .iter()
-                .find(|v| ***v == pub_key)
+                .find(|v| **v == pub_key)
                 .is_some()
         )
     }

--- a/examples/cryptocurrency-advanced/backend/tests/api.rs
+++ b/examples/cryptocurrency-advanced/backend/tests/api.rs
@@ -262,12 +262,7 @@ impl CryptocurrencyApi {
             .unwrap();
 
         let to_wallet = wallet_info.wallet_proof.to_wallet.check().unwrap();
-        assert!(
-            to_wallet
-                .missing_keys()
-                .find(|v| **v == pub_key)
-                .is_some()
-        )
+        assert!(to_wallet.missing_keys().find(|v| **v == pub_key).is_some())
     }
 
     /// Asserts that the transaction with the given hash has a specified status.

--- a/exonum/src/sandbox/consensus/basic.rs
+++ b/exonum/src/sandbox/consensus/basic.rs
@@ -187,13 +187,13 @@ fn test_query_state_hash() {
         let proof = proof_configs.check().unwrap();
         assert_eq!(proof.merkle_root(), state_hash);
         assert_ne!(configs_rh, Hash::zero());
-        assert_eq!(proof.entries(), vec![(&configs_key, &configs_rh)]);
+        assert_eq!(proof.entries().collect::<Vec<_>>(), vec![(&configs_key, &configs_rh)]);
 
         let proof_configs = sandbox.get_proof_to_service_table(TIMESTAMPING_SERVICE, 0);
         let proof = proof_configs.check().unwrap();
         assert_eq!(proof.merkle_root(), state_hash);
         assert_eq!(
-            proof.entries(),
+            proof.entries().collect::<Vec<_>>(),
             vec![(&timestamp_t1_key, &Hash::new([127; HASH_SIZE]))]
         );
 
@@ -201,7 +201,7 @@ fn test_query_state_hash() {
         let proof = proof_configs.check().unwrap();
         assert_eq!(proof.merkle_root(), state_hash);
         assert_eq!(
-            proof.entries(),
+            proof.entries().collect::<Vec<_>>(),
             vec![(&timestamp_t2_key, &Hash::new([128; HASH_SIZE]))]
         );
 

--- a/exonum/src/sandbox/consensus/basic.rs
+++ b/exonum/src/sandbox/consensus/basic.rs
@@ -187,7 +187,10 @@ fn test_query_state_hash() {
         let proof = proof_configs.check().unwrap();
         assert_eq!(proof.merkle_root(), state_hash);
         assert_ne!(configs_rh, Hash::zero());
-        assert_eq!(proof.entries().collect::<Vec<_>>(), vec![(&configs_key, &configs_rh)]);
+        assert_eq!(
+            proof.entries().collect::<Vec<_>>(),
+            vec![(&configs_key, &configs_rh)]
+        );
 
         let proof_configs = sandbox.get_proof_to_service_table(TIMESTAMPING_SERVICE, 0);
         let proof = proof_configs.check().unwrap();

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -466,12 +466,10 @@ impl<K, V> MapProof<K, V> {
     /// Existing entries have `Some` value, non-existing have `None`.
     /// This method does not perform any integrity checks of the proof.
     pub fn all_entries_unchecked(&self) -> impl Iterator<Item = (&K, Option<&V>)> {
-        self.entries
-            .iter()
-            .map(|e| match e {
-                OptionalEntry::Missing { ref missing } => (missing, None),
-                OptionalEntry::KV { ref key, ref value } => (key, Some(value)),
-            })
+        self.entries.iter().map(|e| match e {
+            OptionalEntry::Missing { ref missing } => (missing, None),
+            OptionalEntry::KV { ref key, ref value } => (key, Some(value)),
+        })
     }
 }
 
@@ -599,30 +597,24 @@ where
 impl<K, V> CheckedMapProof<K, V> {
     /// Retrieves references to keys that the proof shows as missing from the map.
     pub fn missing_keys(&self) -> impl Iterator<Item = &K> {
-        self.entries
-            .iter()
-            .filter_map(|kv| match *kv {
-                (ref key, None) => Some(key),
-                _ => None,
-            })
+        self.entries.iter().filter_map(|kv| match *kv {
+            (ref key, None) => Some(key),
+            _ => None,
+        })
     }
 
     /// Retrieves references to key-value pairs that the proof shows as present in the map.
     pub fn entries(&self) -> impl Iterator<Item = (&K, &V)> {
-        self.entries
-            .iter()
-            .filter_map(|kv| match *kv {
-                (ref key, Some(ref value)) => Some((key, value)),
-                _ => None,
-            })
+        self.entries.iter().filter_map(|kv| match *kv {
+            (ref key, Some(ref value)) => Some((key, value)),
+            _ => None,
+        })
     }
 
     /// Retrieves references to existing and non-existing entries in the proof.
     /// Existing entries have `Some` value, non-existing have `None`.
     pub fn all_entries(&self) -> impl Iterator<Item = (&K, Option<&V>)> {
-        self.entries
-            .iter()
-            .map(|&(ref k, ref v)| (k, v.as_ref()))
+        self.entries.iter().map(|&(ref k, ref v)| (k, v.as_ref()))
     }
 
     /// Returns a hash of the map that this proof is constructed for.

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -213,8 +213,8 @@ impl<K, V> Into<(K, Option<V>)> for OptionalEntry<K, V> {
 ///
 /// // Check the proof consistency
 /// let checked_proof = proof.check().unwrap();
-/// assert_eq!(checked_proof.entries(), vec![(&h1, &100u32)]);
-/// assert_eq!(checked_proof.missing_keys(), vec![&h3]);
+/// assert_eq!(checked_proof.entries().collect::<Vec<_>>(), vec![(&h1, &100u32)]);
+/// assert_eq!(checked_proof.missing_keys().collect::<Vec<_>>(), vec![&h3]);
 /// assert_eq!(checked_proof.merkle_root(), map.merkle_root());
 /// ```
 ///
@@ -555,7 +555,7 @@ where
     ///
     /// let proof = map.get_proof(h2);
     /// let checked_proof = proof.check().unwrap();
-    /// assert_eq!(checked_proof.entries(), vec![(&h2, &200u32)]);
+    /// assert_eq!(checked_proof.entries().collect::<Vec<_>>(), vec![(&h2, &200u32)]);
     /// assert_eq!(checked_proof.merkle_root(), map.merkle_root());
     /// ```
     ///

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -460,6 +460,20 @@ impl<K, V> MapProof<K, V> {
     pub fn missing_keys_unchecked(&self) -> Vec<&K> {
         self.entries.iter().filter_map(|e| e.as_missing()).collect()
     }
+
+    /// Retrieves references to existing and non-existing entries in the proof.
+    ///
+    /// Existing entries have `Some` value, non-existing have `None`.
+    /// This method does not perform any integrity checks of the proof.
+    pub fn all_entries_unchecked(&self) -> Vec<(&K, Option<&V>)> {
+        self.entries
+            .iter()
+            .map(|e| match e {
+                OptionalEntry::Missing { ref missing } => (missing, None),
+                &OptionalEntry::KV { ref key, ref value } => (key, Some(value)),
+            })
+            .collect()
+    }
 }
 
 impl<K, V> MapProof<K, V>

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -457,22 +457,21 @@ impl<K, V> MapProof<K, V> {
 
     /// Retrieves references to keys that the proof shows as missing from the map.
     /// This method does not perform any integrity checks of the proof.
-    pub fn missing_keys_unchecked(&self) -> Vec<&K> {
-        self.entries.iter().filter_map(|e| e.as_missing()).collect()
+    pub fn missing_keys_unchecked(&self) -> impl Iterator<Item = &K> {
+        self.entries.iter().filter_map(|e| e.as_missing())
     }
 
     /// Retrieves references to existing and non-existing entries in the proof.
     ///
     /// Existing entries have `Some` value, non-existing have `None`.
     /// This method does not perform any integrity checks of the proof.
-    pub fn all_entries_unchecked(&self) -> Vec<(&K, Option<&V>)> {
+    pub fn all_entries_unchecked(&self) -> impl Iterator<Item = (&K, Option<&V>)> {
         self.entries
             .iter()
             .map(|e| match e {
                 OptionalEntry::Missing { ref missing } => (missing, None),
-                &OptionalEntry::KV { ref key, ref value } => (key, Some(value)),
+                OptionalEntry::KV { ref key, ref value } => (key, Some(value)),
             })
-            .collect()
     }
 }
 
@@ -599,34 +598,31 @@ where
 
 impl<K, V> CheckedMapProof<K, V> {
     /// Retrieves references to keys that the proof shows as missing from the map.
-    pub fn missing_keys(&self) -> Vec<&K> {
+    pub fn missing_keys(&self) -> impl Iterator<Item = &K> {
         self.entries
             .iter()
             .filter_map(|kv| match *kv {
                 (ref key, None) => Some(key),
                 _ => None,
             })
-            .collect()
     }
 
     /// Retrieves references to key-value pairs that the proof shows as present in the map.
-    pub fn entries(&self) -> Vec<(&K, &V)> {
+    pub fn entries(&self) -> impl Iterator<Item = (&K, &V)> {
         self.entries
             .iter()
             .filter_map(|kv| match *kv {
                 (ref key, Some(ref value)) => Some((key, value)),
                 _ => None,
             })
-            .collect()
     }
 
     /// Retrieves references to existing and non-existing entries in the proof.
     /// Existing entries have `Some` value, non-existing have `None`.
-    pub fn all_entries(&self) -> Vec<(&K, Option<&V>)> {
+    pub fn all_entries(&self) -> impl Iterator<Item = (&K, Option<&V>)> {
         self.entries
             .iter()
             .map(|&(ref k, ref v)| (k, v.as_ref()))
-            .collect()
     }
 
     /// Returns a hash of the map that this proof is constructed for.

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -336,7 +336,7 @@ fn check_map_proof<K, V>(
 
     let proof = proof.check().unwrap();
     assert_eq!(
-        proof.entries(),
+        proof.entries().collect::<Vec<_>>(),
         entries
             .iter()
             .map(|&(ref k, ref v)| (k, v))
@@ -345,7 +345,7 @@ fn check_map_proof<K, V>(
     assert_eq!(proof.merkle_root(), table.merkle_root());
 
     let deserialized_proof = deserialized_proof.check().unwrap();
-    assert_eq!(deserialized_proof.entries(), proof.entries());
+    assert_eq!(deserialized_proof.entries().collect::<Vec<_>>(), proof.entries().collect::<Vec<_>>());
     assert_eq!(deserialized_proof.merkle_root(), proof.merkle_root());
 }
 
@@ -384,7 +384,7 @@ fn check_map_multiproof<K, V>(
     let proof = proof.check().unwrap();
     assert_eq!(proof.merkle_root(), table.merkle_root());
     assert_eq!(missing_keys.iter().collect::<Vec<&_>>(), {
-        let mut actual_keys = proof.missing_keys();
+        let mut actual_keys = proof.missing_keys().collect::<Vec<_>>();
         actual_keys
             .sort_unstable_by(|&x, &y| ProofPath::new(x).partial_cmp(&ProofPath::new(y)).unwrap());
         actual_keys
@@ -395,7 +395,7 @@ fn check_map_multiproof<K, V>(
             .map(|&(ref k, ref v)| (k, v))
             .collect::<Vec<_>>(),
         {
-            let mut actual_entries = proof.entries();
+            let mut actual_entries = proof.entries().collect::<Vec<_>>();
             actual_entries.sort_unstable_by(|&(x, _), &(y, _)| {
                 ProofPath::new(x).partial_cmp(&ProofPath::new(y)).unwrap()
             });
@@ -1289,7 +1289,7 @@ fn tree_with_hashed_key(db: Box<dyn Database>) {
     );
     let proof = proof.check().unwrap();
     assert_eq!(
-        proof.all_entries(),
+        proof.all_entries().collect::<Vec<_>>(),
         vec![(&Point::new(1, 2), Some(&vec![1, 2, 3]))]
     );
     assert_eq!(proof.merkle_root(), table.merkle_root());

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -345,7 +345,10 @@ fn check_map_proof<K, V>(
     assert_eq!(proof.merkle_root(), table.merkle_root());
 
     let deserialized_proof = deserialized_proof.check().unwrap();
-    assert_eq!(deserialized_proof.entries().collect::<Vec<_>>(), proof.entries().collect::<Vec<_>>());
+    assert_eq!(
+        deserialized_proof.entries().collect::<Vec<_>>(),
+        proof.entries().collect::<Vec<_>>()
+    );
     assert_eq!(deserialized_proof.merkle_root(), proof.merkle_root());
 }
 

--- a/exonum/tests/proof_map_index.rs
+++ b/exonum/tests/proof_map_index.rs
@@ -54,7 +54,7 @@ where
 
     let proof = proof.check().unwrap();
     assert_eq!(
-        proof.entries(),
+        proof.entries().collect::<Vec<_>>(),
         entries
             .iter()
             .map(|&(ref k, ref v)| (k, v))
@@ -70,7 +70,7 @@ fn check_map_multiproof<T, K, V>(
 ) where
     T: AsRef<Snapshot>,
     K: ProofMapKey + Clone + PartialEq + Debug,
-    V: StorageValue + PartialEq + Debug,
+    V: StorageValue + Clone + PartialEq + Debug,
 {
     let (entries, missing_keys) = {
         let mut entries: Vec<(K, V)> = Vec::new();
@@ -96,10 +96,12 @@ fn check_map_multiproof<T, K, V>(
         (entries, missing_keys)
     };
 
+    let unchecked_proof = proof.clone();
     let proof = proof.check().unwrap();
+    assert_eq!(proof.all_entries().collect::<Vec<_>>(), unchecked_proof.all_entries_unchecked().collect::<Vec<_>>());
     assert_eq!(proof.merkle_root(), table.merkle_root());
     assert_eq!(missing_keys.iter().collect::<Vec<&_>>(), {
-        let mut actual_keys = proof.missing_keys();
+        let mut actual_keys = proof.missing_keys().collect::<Vec<_>>();
         actual_keys
             .sort_unstable_by(|&x, &y| ProofPath::new(x).partial_cmp(&ProofPath::new(y)).unwrap());
         actual_keys
@@ -110,7 +112,7 @@ fn check_map_multiproof<T, K, V>(
             .map(|&(ref k, ref v)| (k, v))
             .collect::<Vec<_>>(),
         {
-            let mut actual_entries = proof.entries();
+            let mut actual_entries = proof.entries().collect::<Vec<_>>();
             actual_entries.sort_unstable_by(|&(x, _), &(y, _)| {
                 ProofPath::new(x).partial_cmp(&ProofPath::new(y)).unwrap()
             });

--- a/exonum/tests/proof_map_index.rs
+++ b/exonum/tests/proof_map_index.rs
@@ -98,7 +98,10 @@ fn check_map_multiproof<T, K, V>(
 
     let unchecked_proof = proof.clone();
     let proof = proof.check().unwrap();
-    assert_eq!(proof.all_entries().collect::<Vec<_>>(), unchecked_proof.all_entries_unchecked().collect::<Vec<_>>());
+    assert_eq!(
+        proof.all_entries().collect::<Vec<_>>(),
+        unchecked_proof.all_entries_unchecked().collect::<Vec<_>>()
+    );
     assert_eq!(proof.merkle_root(), table.merkle_root());
     assert_eq!(missing_keys.iter().collect::<Vec<&_>>(), {
         let mut actual_keys = proof.missing_keys().collect::<Vec<_>>();


### PR DESCRIPTION
Tiny but useful change.

# Why?

At EJB, we need to get raw proof data as fast as possible for sending it to the Java side.

# Is it safe from user perspective?

I'm not sure. One of possible solutions would be marking this as `doc(hidden)` or even behind feature gate.
I need to hear your opinions.

UPD: Also includes change from `Vec` to `impl Iterator` for most public methods in `MapProof` API.
