### PR TITLE
Do not run PowerShell test scripts on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,6 @@ jobs:
       apt:
         sources:
         - sourceline: 'ppa:giskou/librocksdb'
-        - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main'
-          key_url: https://packages.microsoft.com/keys/microsoft.asc
         packages:
         - gcc
         - g++
@@ -116,7 +114,6 @@ jobs:
         - libiberty-dev
         - libsnappy-dev
         - librocksdb
-        - powershell
     install:
     - nvm install 8 && nvm use 8
     - cd $TRAVIS_BUILD_DIR/testkit/server/src && npm install && cd $TRAVIS_BUILD_DIR
@@ -127,7 +124,6 @@ jobs:
     - cargo run -p exonum-testkit --example configuration_change
     - cargo run -p exonum-time --example simple_service
     - cd $TRAVIS_BUILD_DIR/examples/cryptocurrency/examples && ./test.sh
-    - cd $TRAVIS_BUILD_DIR/examples/cryptocurrency/examples && ./test.ps1
     - cd $TRAVIS_BUILD_DIR/testkit/server/src && npm run test:unix
 
   # Benchmarks (compilation only)


### PR DESCRIPTION
Travis CI currently has issues with installing APT Addons with custom GPG keys via key_url. Because of this issue we are not able to install PowerShell package necessary to run PowerShell test scripts. For some reason Travis insists on downloading and adding [a key from its server][1] instead of using [the correct one specified by the key_url][2]. Here are examples of [successful][3] and [failing][4] builds.

[1]: https://build.travis-ci.org/files/gpg/travis-security.asc
[2]: https://packages.microsoft.com/keys/microsoft.asc
[3]: https://travis-ci.org/exonum/exonum/jobs/422083025
[4]: https://travis-ci.org/exonum/exonum/jobs/422510434

Implement a final solution to the PowerShell problem and drop it from the build script altogether. We'll keep the script around as we may want to run it during Windows builds on AppVeyor. But do not run it in Travis CI environment on Linux.