### PR TITLE
Update actix-web to 0.7.5, remove workarounds [ECR-2149]

### DIFF
--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
 actix = "=0.7.4"
-actix-web = "=0.7.3"
+actix-web = "=0.7.5"
 log = "=0.4.5"
 byteorder = "1.2.3"
 hex = "=0.3.2"

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -21,7 +21,7 @@ pub use actix_web::middleware::cors::Cors;
 
 use actix::{Addr, System};
 use actix_web::{
-    self, error::ResponseError, server::{HttpServer, IntoHttpHandler, StopServer}, AsyncResponder,
+    self, error::ResponseError, server::{HttpServer, Server, StopServer}, AsyncResponder,
     FromRequest, HttpMessage, HttpResponse, Query,
 };
 use failure;
@@ -49,9 +49,6 @@ pub type RawHandler = dyn Fn(HttpRequest) -> FutureResponse + 'static + Send + S
 pub type App = actix_web::App<ServiceApiState>;
 /// Type alias for the `actix-web::App` configuration.
 pub type AppConfig = Arc<dyn Fn(App) -> App + 'static + Send + Sync>;
-
-/// Type alias for the `actix-web` HTTP server runtime address.
-type HttpServerAddr = Addr<HttpServer<<App as IntoHttpHandler>::Handler>>;
 
 /// Raw `actix-web` backend requests handler.
 #[derive(Clone)]
@@ -312,7 +309,7 @@ pub struct SystemRuntimeConfig {
 pub struct SystemRuntime {
     system_thread: JoinHandle<result::Result<(), failure::Error>>,
     system: System,
-    api_runtime_addresses: Vec<HttpServerAddr>,
+    api_runtime_addresses: Vec<Addr<Server>>,
 }
 
 impl SystemRuntimeConfig {

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -88,7 +88,7 @@ impl ServiceApiBackend for ApiBuilder {
     type Backend = actix_web::Scope<ServiceApiState>;
 
     fn raw_handler(&mut self, handler: Self::Handler) -> &mut Self {
-        self.handlers.push(sanitize(handler));
+        self.handlers.push(handler);
         self
     }
 
@@ -101,14 +101,6 @@ impl ServiceApiBackend for ApiBuilder {
         }
         output
     }
-}
-
-// TODO: remove this workaround for a regression in actix-web 0.7.3 (ECR-2149)
-fn sanitize(mut handler: RequestHandler) -> RequestHandler {
-    if !handler.name.starts_with('/') {
-        handler.name.insert(0, '/');
-    }
-    handler
 }
 
 impl ExtendApiBackend for actix_web::Scope<ServiceApiState> {

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-actix-web = "=0.7.3"
+actix-web = "=0.7.5"
 exonum = { version = "0.9.0", path = "../exonum" }
 failure = "0.1.2"
 futures = "=0.1.23"


### PR DESCRIPTION
A straightforward update, but not without regressions. This was not mentioned in the changelog or migration guide, but it turned out that [`HttpServer::start()`](https://github.com/ilammy/exonum/blob/9ac19c7763a5999f5e5a8f7577a2cba2aa350dc2/exonum/src/api/backends/actix.rs#L335-L338) now returns `Server`, not `HttpServer`. `Addr<HttpServer>` is no longer a valid type, we should use the correct one instead. Remove the type alias altogether as it's used in only one place and it's not that hard to spell out.

Furthermore, our current version of actix-web 0.7.3 contained a regression bug which is fixed in 0.7.5. Remove now unnecessary workaround for this regression.

Supersedes #908, #923.