### PR TITLE
Some refactoring to make network.rs more clear

### DIFF
--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -444,7 +444,6 @@ impl Listener {
                 trace!("Received handshake message={:?}", connect);
                 Self::process_incoming_messages(stream, network_tx, connect, address)
             })
-
     }
 
     fn parse_connect_message(raw: Option<RawMessage>) -> Result<Connect, failure::Error> {

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -25,7 +25,9 @@ use tokio_retry::{
     strategy::{jitter, FixedInterval}, Retry,
 };
 
-use std::{cell::RefCell, collections::HashMap, net::SocketAddr, rc::{Rc, Weak}, time::Duration};
+use std::{
+    cell::RefCell, collections::HashMap, net::SocketAddr, rc::{Rc, Weak}, time::Duration,
+};
 
 use super::{
     error::{log_error, result_ok}, to_box,
@@ -319,7 +321,7 @@ impl RequestHandler {
         RequestHandler(to_box(requests_handler))
     }
 
-    #[cfg_attr(feature="cargo-clippy", allow(too_many_arguments))]
+    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     fn handle_send_message(
         peer: SocketAddr,
         msg: RawMessage,

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -385,7 +385,8 @@ impl Listener {
     ) -> Result<Self, failure::Error> {
         // Incoming connections limiter
         let incoming_connections_limit = network_config.max_incoming_connections;
-        let mut incoming_connections_counter = 0;
+        // The reference counter is used to automatically count the number of the open connections.
+        let incoming_connections_counter: Rc<()> = Rc::default();
         // Incoming connections handler
         let listener = TcpListener::bind(&listen_address, &handle)?;
         let network_tx = network_tx.clone();
@@ -393,9 +394,11 @@ impl Listener {
         let server = listener
             .incoming()
             .for_each(move |(sock, address)| {
+                let holder = Rc::downgrade(&incoming_connections_counter);
                 // Check incoming connections count
-                incoming_connections_counter += 1;
-                if incoming_connections_counter > incoming_connections_limit {
+                let connections_count = Rc::weak_count(&incoming_connections_counter);
+                info!("connections_count {}", connections_count);
+                if connections_count > incoming_connections_limit {
                     warn!(
                         "Rejected incoming connection with peer={}, \
                          connections limit reached.",
@@ -412,9 +415,9 @@ impl Listener {
                     .and_then(move |sock| {
                         Self::handle_incoming_connection(sock, address, network_tx)
                     })
-                    .then(move |result| {
-                        incoming_connections_counter -= 1;
-                        result
+                    .map(|_| {
+                        // Ensure that holder lives until the stream ends.
+                        let _holder = holder;
                     })
                     .map_err(|e| {
                         error!("Connection terminated: {}: {}", e, e.find_root_cause());


### PR DESCRIPTION
Moved `and_then` closures to separate messages.