### PR TITLE
Use PUBLIC_KEY_LENGTH constant instead of hardcoded integer

### DIFF
--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -21,7 +21,8 @@ extern crate serde_derive;
 extern crate toml;
 
 use exonum::{
-    api::backends::actix::AllowOrigin, crypto::PublicKey, encoding::serialize::FromHex,
+    api::backends::actix::AllowOrigin, crypto::{PublicKey, PUBLIC_KEY_LENGTH},
+    encoding::serialize::FromHex,
     helpers::{
         config::{ConfigFile, ConfigManager}, fabric::NodeBuilder,
     },
@@ -344,7 +345,7 @@ fn test_update_config() {
     // Test config update.
     let peer = ConnectInfo {
         address: SocketAddr::from_str("0.0.0.1:8080").unwrap(),
-        public_key: PublicKey::new([1; 32]),
+        public_key: PublicKey::new([1; PUBLIC_KEY_LENGTH]),
     };
 
     let connect_list = ConnectListConfig { peers: vec![peer] };


### PR DESCRIPTION
This PR removes hardcoded length of a public key from `exonum/tests/config.rs`.