### PR TITLE
Backport DNS resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## 0.9.2 - 2018-09-10
 
+- Config parameter `external_address` is now a required value. (#826)
+
+### New features
+
+- Added possibility to use domain names instead of IP addresses as a peer's
+  addresses. In config file domain names can be used in `ConnectList`
+  configuration and addresses will be resolved once on startup. (#826)
+
 ### Internal Improvements
 
 #### exonum
@@ -12,17 +20,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Added a possibility to create `ServiceApiBuilder` with blockchain. (#929)
 
 ## 0.9.1 - 2018-08-02
-- `NodePrivateConfig` fields have been renamed: `listen_addr` to `listen_address`
-  and `external_addr` to `external_address`. (#809)
-  
-- `NodePublicConfig` `addr` field has been renamed to `address`. (#809)
-
-- Config parameter `external_address` is now a required value. (#826)
-
-### New features
-
-- Added possibility to use domain names instead of IP addresses as a peer's
-  addresses. (#826)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Added a possibility to create `ServiceApiBuilder` with blockchain. (#929)
 
 ## 0.9.1 - 2018-08-02
+- `NodePrivateConfig` fields have been renamed: `listen_addr` to `listen_address`
+  and `external_addr` to `external_address`. (#809)
+  
+- `NodePublicConfig` `addr` field has been renamed to `address`. (#809)
+
+- Config parameter `external_address` is now a required value. (#826)
+
+### New features
+
+- Added possibility to use domain names instead of IP addresses as a peer's
+  addresses. (#826)
 
 ### Bug Fixes
 

--- a/examples/cryptocurrency/examples/demo.rs
+++ b/examples/cryptocurrency/examples/demo.rs
@@ -46,7 +46,7 @@ fn node_config() -> NodeConfig {
         consensus_public_key,
         consensus_secret_key,
         genesis,
-        external_address: None,
+        external_address: peer_address,
         network: Default::default(),
         connect_list: Default::default(),
         api: api_cfg,

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -609,7 +609,7 @@ impl Command for Finalize {
         let config = {
             NodeConfig {
                 listen_address: secret_config.listen_addr,
-                external_address: Some(secret_config.external_addr),
+                external_address: secret_config.external_addr,
                 network: Default::default(),
                 consensus_public_key: secret_config.consensus_public_key,
                 consensus_secret_key: secret_config.consensus_secret_key,

--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -114,9 +114,10 @@ impl Command for Maintenance {
             .arg::<String>(MAINTENANCE_ACTION_PATH)
             .unwrap_or_else(|_| panic!("{} not found.", MAINTENANCE_ACTION_PATH));
 
-        match action.as_ref() {
-            "clear-cache" => Self::clear_cache(&context),
-            _ => println!("Unsupported maintenance action: {}", action),
+        if action == "clear-cache" {
+            Self::clear_cache(&context);
+        } else {
+            println!("Unsupported maintenance action: {}", action);
         }
 
         Feedback::None

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -80,7 +80,7 @@ pub fn generate_testnet_config(count: u8, start_port: u16) -> Vec<NodeConfig> {
         .enumerate()
         .map(|(idx, (validator, service))| NodeConfig {
             listen_address: peers[idx],
-            external_address: Some(peers[idx]),
+            external_address: peers[idx],
             network: Default::default(),
             consensus_public_key: validator.0,
             consensus_secret_key: validator.1,

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -34,9 +34,11 @@ use tokio_core::reactor::Core;
 use toml::Value;
 
 use std::{
-    collections::{BTreeMap, HashSet}, fmt, io, net::SocketAddr, sync::Arc, thread,
+    collections::{BTreeMap, HashSet}, fmt, io, net::{SocketAddr, ToSocketAddrs}, sync::Arc, thread,
     time::{Duration, SystemTime},
 };
+
+use serde::de::{self, Deserialize, Deserializer};
 
 use blockchain::{
     Blockchain, GenesisConfig, Schema, Service, SharedNodeState, Transaction, ValidatorKeys,
@@ -234,7 +236,8 @@ pub struct NodeConfig {
     /// Network listening address.
     pub listen_address: SocketAddr,
     /// Remote Network address used by this node.
-    pub external_address: Option<SocketAddr>,
+    #[serde(deserialize_with = "deserialize_socket_address")]
+    pub external_address: SocketAddr,
     /// Network configuration.
     pub network: NetworkConfiguration,
     /// Consensus public key.
@@ -760,10 +763,28 @@ impl fmt::Debug for ApiSender {
     }
 }
 
+fn deserialize_socket_address<'de, D>(value: D) -> Result<SocketAddr, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let address_str: String = Deserialize::deserialize(value)?;
+    address_str
+        .to_socket_addrs()
+        .map_err(de::Error::custom)?
+        .next()
+        .ok_or_else(|| {
+            de::Error::custom(&format!(
+                "no one ip belongs to the hostname: {}",
+                address_str
+            ))
+        })
+}
+
 /// Data needed to add peer into `ConnectList`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct ConnectInfo {
     /// Peer address.
+    #[serde(deserialize_with = "deserialize_socket_address")]
     pub address: SocketAddr,
     /// Peer public key.
     pub public_key: PublicKey,
@@ -880,18 +901,12 @@ impl Node {
             peer_discovery: peers,
         };
 
-        let external_address = if let Some(v) = node_cfg.external_address {
-            v
-        } else {
-            warn!("Could not find 'external_address' in the config, using 'listen_address'");
-            node_cfg.listen_address
-        };
         let api_state = SharedNodeState::new(node_cfg.api.state_update_timeout as u64);
         let system_state = Box::new(DefaultSystemState(node_cfg.listen_address));
         let network_config = config.network;
         let handler = NodeHandler::new(
             blockchain,
-            external_address,
+            node_cfg.external_address,
             channel.node_sender(),
             system_state,
             config,

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -21,7 +21,7 @@ extern crate serde_derive;
 extern crate toml;
 
 use exonum::{
-    api::backends::actix::AllowOrigin, crypto::PublicKey,
+    api::backends::actix::AllowOrigin, crypto::PublicKey, encoding::serialize::FromHex,
     helpers::{
         config::{ConfigFile, ConfigManager}, fabric::NodeBuilder,
     },
@@ -359,4 +359,37 @@ fn test_update_config() {
 
     // Cleanup.
     fs::remove_dir_all(Path::new(&full_test_dir)).unwrap();
+}
+
+#[test]
+fn test_domain_name_peer() {
+    const TEST_CONFIG_FILE: &str = "config_domain.toml";
+    let testdata_path = full_testdata_name(TEST_CONFIG_FILE);
+    let config: ConnectListConfig =
+        ConfigFile::load(testdata_path).expect("Can't load node config file");
+
+    let connect_list = ConnectListConfig {
+        peers: vec![
+            ConnectInfo {
+                address: "127.0.0.1:6333".parse().unwrap(),
+                public_key: PublicKey::from_hex(
+                    "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72",
+                ).unwrap(),
+            },
+            ConnectInfo {
+                address: "127.0.0.1:6333".parse().unwrap(),
+                public_key: PublicKey::from_hex(
+                    "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3",
+                ).unwrap(),
+            },
+            ConnectInfo {
+                address: "94.130.16.228:6333".parse().unwrap(),
+                public_key: PublicKey::from_hex(
+                    "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e",
+                ).unwrap(),
+            },
+        ],
+    };
+
+    assert_eq!(config.peers, connect_list.peers);
 }

--- a/exonum/tests/testdata/config/config_domain.toml
+++ b/exonum/tests/testdata/config/config_domain.toml
@@ -1,0 +1,11 @@
+[[peers]]
+address = "127.0.0.1:6333"
+public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+
+[[peers]]
+address = "localhost:6333"
+public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+
+[[peers]]
+address = "exonum.com:6333"
+public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"


### PR DESCRIPTION
I propose to port this version of resolve by @aleksuss if it is enough.
How it will work:
you can use hostname:port in ConnectList in node's config file, but hostname will be resolved only on startup(which should cover almost all practical cases).