### PR TITLE
Add ?Sized bound to the index_id attribute of new_in_family(..) 

### DIFF
--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -105,12 +105,17 @@ where
     ///
     /// [`&Snapshot`]: ../trait.Snapshot.html
     /// [`&mut Fork`]: ../struct.Fork.html
-    pub fn new_in_family<S: AsRef<str>, P: StorageKey>(
+    pub fn new_in_family<S, P>(
         family_name: S,
         index_id: &P,
         index_type: IndexType,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            P: StorageKey,
+            P: ?Sized,
+            S: AsRef<str>,
+    {
         assert_valid_name(&family_name);
 
         let is_family = true;

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -85,11 +85,16 @@ where
     /// let snapshot = db.snapshot();
     /// let index: Entry<_, u8> = Entry::new_in_family(name, &index_id, &snapshot);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::Entry, view),
             _v: PhantomData,

--- a/exonum/src/storage/key_set_index.rs
+++ b/exonum/src/storage/key_set_index.rs
@@ -103,11 +103,16 @@ where
     /// let index_id = vec![123];
     /// let index: KeySetIndex<_, u8> = KeySetIndex::new_in_family(name, &index_id, &snapshot);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::KeySet, view),
             _k: PhantomData,

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -107,11 +107,16 @@ where
     /// let snapshot = db.snapshot();
     /// let index: ListIndex<_, u8> = ListIndex::new_in_family(name, &index_id, &snapshot);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::List, view),
             length: Cell::new(None),

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -134,11 +134,16 @@ where
     /// let snapshot = db.snapshot();
     /// let index: MapIndex<_, u8, u8> = MapIndex::new_in_family(name, &index_id, &snapshot);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::Map, view),
             _k: PhantomData,

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -133,11 +133,16 @@ where
     /// let mut mut_index : ProofListIndex<_, u8> =
     ///                                 ProofListIndex::new_in_family(name, &index_id, &mut fork);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::ProofList, view),
             length: Cell::new(None),

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -178,11 +178,16 @@ where
     ///     &mut fork,
     ///  );
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::ProofMap, view),
             _k: PhantomData,

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -185,11 +185,16 @@ where
     ///     &snapshot,
     ///  );
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::SparseList, view),
             size: Cell::new(None),

--- a/exonum/src/storage/tests.rs
+++ b/exonum/src/storage/tests.rs
@@ -14,8 +14,8 @@
 
 use super::super::crypto::Hash;
 use super::{
-    Database, Fork, KeySetIndex, ListIndex, MapIndex, ProofListIndex, ProofMapIndex, Snapshot,
-    SparseListIndex, ValueSetIndex,
+    Database, Entry, Fork, KeySetIndex, ListIndex, MapIndex, ProofListIndex, ProofMapIndex,
+    Snapshot, SparseListIndex, ValueSetIndex,
 };
 
 const IDX_NAME: &'static str = "idx_name";
@@ -269,6 +269,7 @@ mod rocksdb_tests {
 #[allow(unreachable_code, unused_variables)]
 fn should_compile() {
     let mut fork: Fork = unimplemented!();
+    let _: Entry<_, ()> = Entry::new_in_family("", "", &mut fork);
     let _: KeySetIndex<_, Hash> = KeySetIndex::new_in_family("", "", &mut fork);
     let _: ListIndex<_, ()> = ListIndex::new_in_family("", "", &mut fork);
     let _: MapIndex<_, Hash, ()> = MapIndex::new_in_family("", "", &mut fork);

--- a/exonum/src/storage/tests.rs
+++ b/exonum/src/storage/tests.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{Database, Fork, Snapshot};
+use super::super::crypto::Hash;
+use super::{
+    Database, Fork, KeySetIndex, ListIndex, MapIndex, ProofListIndex, ProofMapIndex, Snapshot,
+    SparseListIndex, ValueSetIndex,
+};
 
 const IDX_NAME: &'static str = "idx_name";
 
@@ -258,4 +262,18 @@ mod rocksdb_tests {
         let iter = index.iter();
         assert_eq!(index.len() as usize, iter.count());
     }
+}
+
+#[test]
+#[ignore]
+#[allow(unreachable_code, unused_variables)]
+fn should_compile() {
+    let mut fork: Fork = unimplemented!();
+    let _: KeySetIndex<_, Hash> = KeySetIndex::new_in_family("", "", &mut fork);
+    let _: ListIndex<_, ()> = ListIndex::new_in_family("", "", &mut fork);
+    let _: MapIndex<_, Hash, ()> = MapIndex::new_in_family("", "", &mut fork);
+    let _: ProofListIndex<_, ()> = ProofListIndex::new_in_family("", "", &mut fork);
+    let _: ProofMapIndex<_, Hash, ()> = ProofMapIndex::new_in_family("", "", &mut fork);
+    let _: SparseListIndex<_, ()> = SparseListIndex::new_in_family("", "", &mut fork);
+    let _: ValueSetIndex<_, ()> = ValueSetIndex::new_in_family("", "", &mut fork);
 }

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -117,11 +117,16 @@ where
     /// let index_id = vec![123];
     /// let index: ValueSetIndex<_, u8> = ValueSetIndex::new_in_family(name, &index_id, &snapshot);
     /// ```
-    pub fn new_in_family<S: AsRef<str>, I: StorageKey>(
+    pub fn new_in_family<S, I>(
         family_name: S,
         index_id: &I,
         view: T,
-    ) -> Self {
+    ) -> Self
+        where
+            I: StorageKey,
+            I: ?Sized,
+            S: AsRef<str>,
+    {
         Self {
             base: BaseIndex::new_in_family(family_name, index_id, IndexType::ValueSet, view),
             _v: PhantomData,


### PR DESCRIPTION
The motivation is to allow this:

```rust
let _ = ProofMapIndex::new_in_family("foo", "bar", &mut fork);
                                         // ^---^ Error is triggered here at the moment
                                         // because str is not Sized
```

The reason is that signature of `new_in_family` have only `StorageKey` bound on `index_id` attribute but `StorageKey` is also implemented for `str` and `[u8]` which is unsized.

Note that this PR only address the `new_in_family` and this issue still may exists for other functions with similar bounds.