### PR TITLE
tx_pool_capacity parameter has been removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Removed obsolete `enable_blockchain_explorer` option from `NodeApiConfig`. (#891)
 
+- `tx_pool_capacity` parameter has been removed from `MemoryPoolConfig`. (#1036)
+
 #### exonum
 
 - Trait `TransactionSend` was removed.

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -220,8 +220,6 @@ impl Default for EventsPoolCapacity {
 /// Memory pool configuration parameters.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MemoryPoolConfig {
-    /// Maximum number of uncommitted transactions.
-    pub tx_pool_capacity: usize,
     /// Sets the maximum number of messages that can be buffered on the event loop's
     /// notification channel before a send will fail.
     pub events_pool_capacity: EventsPoolCapacity,
@@ -230,7 +228,6 @@ pub struct MemoryPoolConfig {
 impl Default for MemoryPoolConfig {
     fn default() -> Self {
         Self {
-            tx_pool_capacity: 100_000,
             events_pool_capacity: EventsPoolCapacity::default(),
         }
     }
@@ -429,7 +426,6 @@ impl NodeHandler {
             config.listener.consensus_secret_key,
             config.service.service_public_key,
             config.service.service_secret_key,
-            config.mempool.tx_pool_capacity,
             connect_list,
             stored,
             connect,

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -63,7 +63,6 @@ pub struct State {
 
     config: StoredConfiguration,
     connect_list: SharedConnectList,
-    tx_pool_capacity: usize,
 
     peers: HashMap<PublicKey, Signed<Connect>>,
     connections: HashMap<PublicKey, ConnectedPeerAddr>,
@@ -441,7 +440,6 @@ impl State {
         consensus_secret_key: SecretKey,
         service_public_key: PublicKey,
         service_secret_key: SecretKey,
-        tx_pool_capacity: usize,
         connect_list: ConnectList,
         stored: StoredConfiguration,
         connect: Signed<Connect>,
@@ -456,7 +454,6 @@ impl State {
             consensus_secret_key,
             service_public_key,
             service_secret_key,
-            tx_pool_capacity,
             connect_list: SharedConnectList::from_connect_list(connect_list),
             peers,
             connections: HashMap::new(),

--- a/exonum/tests/testdata/config/config01.toml
+++ b/exonum/tests/testdata/config/config01.toml
@@ -22,7 +22,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config02.toml
+++ b/exonum/tests/testdata/config/config02.toml
@@ -25,7 +25,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config03.toml
+++ b/exonum/tests/testdata/config/config03.toml
@@ -28,7 +28,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config04.toml
+++ b/exonum/tests/testdata/config/config04.toml
@@ -31,7 +31,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config12.toml
+++ b/exonum/tests/testdata/config/config12.toml
@@ -25,7 +25,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config13.toml
+++ b/exonum/tests/testdata/config/config13.toml
@@ -28,7 +28,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config14.toml
+++ b/exonum/tests/testdata/config/config14.toml
@@ -31,7 +31,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config23.toml
+++ b/exonum/tests/testdata/config/config23.toml
@@ -28,7 +28,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config24.toml
+++ b/exonum/tests/testdata/config/config24.toml
@@ -31,7 +31,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024

--- a/exonum/tests/testdata/config/config34.toml
+++ b/exonum/tests/testdata/config/config34.toml
@@ -31,7 +31,6 @@ max_propose_timeout = 200
 propose_timeout_threshold = 500
 
 [mempool]
-tx_pool_capacity = 100000
 
 [mempool.events_pool_capacity]
 api_requests_capacity = 1024


### PR DESCRIPTION
This parameter hasn't been used, so it is OK to remove it completely.