### PR TITLE
Fix `clear` in indexes belonging to a family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Endpoint `v1/peers` now returns `ConnectInfo` in incoming connections instead
   of single IP-addresses. (#959)
 
+- `Fork::remove_by_prefix()` method now specifies prefix as `Option<&[u8]>` instead
+  of `Option<&Vec<u8>>`. (#1042)
+
 #### exonum-configuration
 
 - The `Vote` and `VoteAgainst` now save the transaction hash instead of
@@ -121,6 +124,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Bug with incorrect EOF handling while decoding network messages has been
   fixed. (#917)
+
+- Bug leading to deletion of excessive data when `clear`ing an index belonging
+  to an index family has been fixed. (#1042)
 
 ### API Improvements
 

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -269,8 +269,8 @@ impl<'a> BaseIndex<&'a mut Fork> {
     /// in the index.
     pub fn clear(&mut self) {
         self.set_index_type();
-        self.view
-            .remove_by_prefix(&self.name, self.index_id.as_ref());
+        let prefix = self.index_id.as_ref().map(Vec::as_slice);
+        self.view.remove_by_prefix(&self.name, prefix);
     }
 }
 

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -449,7 +449,7 @@ impl Fork {
 
     /// Removes all keys starting with the specified prefix from the column family
     /// with the given `name`.
-    pub fn remove_by_prefix(&mut self, name: &str, prefix: Option<&Vec<u8>>) {
+    pub fn remove_by_prefix(&mut self, name: &str, prefix: Option<&[u8]>) {
         let changes = self
             .patch
             .changes_entry(name.to_string())
@@ -458,7 +458,7 @@ impl Fork {
         if let Some(prefix) = prefix {
             let keys = changes
                 .data
-                .range::<Vec<u8>, _>((Included(prefix), Unbounded))
+                .range::<[u8], _>((Included(prefix), Unbounded))
                 .map(|(k, _)| k.to_vec())
                 .take_while(|k| k.starts_with(prefix))
                 .collect::<Vec<_>>();
@@ -470,10 +470,10 @@ impl Fork {
         }
 
         // Remove keys from storage.
-        let prefix_as_slice = prefix.map_or(&[] as &[u8], |k| k.as_slice());
-        let mut iter = self.snapshot.iter(name, prefix_as_slice);
+        let prefix_or_empty_slice = prefix.unwrap_or_default();
+        let mut iter = self.snapshot.iter(name, prefix_or_empty_slice);
         while let Some((k, ..)) = iter.next() {
-            if !k.starts_with(prefix_as_slice) {
+            if !k.starts_with(prefix_or_empty_slice) {
                 break;
             }
 

--- a/exonum/src/storage/db.rs
+++ b/exonum/src/storage/db.rs
@@ -468,11 +468,15 @@ impl Fork {
         } else {
             changes.data.clear();
         }
-        // Remove from storage
-        let mut iter = self
-            .snapshot
-            .iter(name, prefix.map_or(&[], |k| k.as_slice()));
+
+        // Remove keys from storage.
+        let prefix_as_slice = prefix.map_or(&[] as &[u8], |k| k.as_slice());
+        let mut iter = self.snapshot.iter(name, prefix_as_slice);
         while let Some((k, ..)) = iter.next() {
+            if !k.starts_with(prefix_as_slice) {
+                break;
+            }
+
             let change = changes.data.insert(k.to_vec(), Change::Delete);
             if self.logged {
                 self.changelog.push((name.to_string(), k.to_vec(), change));

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -589,6 +589,10 @@ mod tests {
         );
     }
 
+    // Parameters for the `list_index_clear_in_family` test.
+    const FAMILY_CLEAR_PARAMS: &[(u32, u32, bool)] =
+        &[(0, 5, false), (5, 0, false), (1, 7, true), (7, 1, true)];
+
     mod memorydb_tests {
         use std::path::Path;
         use storage::{Database, ListIndex, MemoryDB};
@@ -642,14 +646,7 @@ mod tests {
 
         #[test]
         fn list_index_clear_in_family() {
-            const PARAMS: &[(u32, u32, bool)] = &[
-                (0_u32, 5_u32, false),
-                (5_u32, 0_u32, false),
-                (1_u32, 7_u32, true),
-                (7_u32, 1_u32, true),
-            ] as &[(u32, u32, bool)];
-
-            for &(x, y, merge_before_clear) in PARAMS {
+            for &(x, y, merge_before_clear) in super::FAMILY_CLEAR_PARAMS {
                 let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
                 let path = dir.path();
                 let db = create_database(path);
@@ -712,14 +709,7 @@ mod tests {
 
         #[test]
         fn list_index_clear_in_family() {
-            const PARAMS: &[(u32, u32, bool)] = &[
-                (0_u32, 5_u32, false),
-                (5_u32, 0_u32, false),
-                (1_u32, 7_u32, true),
-                (7_u32, 1_u32, true),
-            ] as &[(u32, u32, bool)];
-
-            for &(x, y, merge_before_clear) in PARAMS {
+            for &(x, y, merge_before_clear) in super::FAMILY_CLEAR_PARAMS {
                 let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
                 let path = dir.path();
                 let db = create_database(path);

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -468,8 +468,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Fork, ListIndex};
+    use super::{Fork, ListIndex, Snapshot};
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
+    use storage::Database;
 
     fn gen_tempdir_name() -> String {
         thread_rng().sample_iter(&Alphanumeric).take(10).collect()
@@ -531,6 +532,63 @@ mod tests {
         );
     }
 
+    fn list_index_clear_in_family(db: Box<dyn Database>, x: u32, y: u32, merge_before_clear: bool) {
+        assert_ne!(x, y);
+        let mut fork = db.fork();
+
+        fn list<T>(index: u32, view: T) -> ListIndex<T, String>
+        where
+            T: AsRef<dyn Snapshot>,
+        {
+            ListIndex::new_in_family("family", &index, view)
+        }
+
+        // Write data to both indexes.
+        {
+            let mut index = list(x, &mut fork);
+            index.push("foo".to_owned());
+            index.push("bar".to_owned());
+        }
+        {
+            let mut index = list(y, &mut fork);
+            index.push("baz".to_owned());
+            index.push("qux".to_owned());
+        }
+
+        if merge_before_clear {
+            db.merge_sync(fork.into_patch()).expect("merge");
+            fork = db.fork();
+        }
+
+        // Clear the index with the lower family key.
+        {
+            let mut index = list(x, &mut fork);
+            index.clear();
+        }
+
+        // The other index should be unaffected.
+        {
+            let index = list(x, &fork);
+            assert!(index.is_empty());
+            let index = list(y, &fork);
+            assert_eq!(
+                index.iter().collect::<Vec<_>>(),
+                vec!["baz".to_owned(), "qux".to_owned()]
+            );
+        }
+
+        // ...even after fork merge.
+        db.merge_sync(fork.into_patch()).expect("merge");
+        let snapshot = db.snapshot();
+        let index = list(x, &snapshot);
+        assert!(index.is_empty());
+        let index = list(y, &snapshot);
+        assert_eq!(
+            index.iter().collect::<Vec<_>>(),
+            vec!["baz".to_owned(), "qux".to_owned()]
+        );
+    }
+
     mod memorydb_tests {
         use std::path::Path;
         use storage::{Database, ListIndex, MemoryDB};
@@ -580,6 +638,23 @@ mod tests {
             let mut fork = db.fork();
             let mut list_index = ListIndex::new_in_family(IDX_NAME, &vec![01], &mut fork);
             super::list_index_iter(&mut list_index);
+        }
+
+        #[test]
+        fn list_index_clear_in_family() {
+            const PARAMS: &[(u32, u32, bool)] = &[
+                (0_u32, 5_u32, false),
+                (5_u32, 0_u32, false),
+                (1_u32, 7_u32, true),
+                (7_u32, 1_u32, true),
+            ] as &[(u32, u32, bool)];
+
+            for &(x, y, merge_before_clear) in PARAMS {
+                let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
+                let path = dir.path();
+                let db = create_database(path);
+                super::list_index_clear_in_family(db, x, y, merge_before_clear);
+            }
         }
     }
 
@@ -633,6 +708,23 @@ mod tests {
             let mut fork = db.fork();
             let mut list_index = ListIndex::new_in_family(IDX_NAME, &vec![01], &mut fork);
             super::list_index_iter(&mut list_index);
+        }
+
+        #[test]
+        fn list_index_clear_in_family() {
+            const PARAMS: &[(u32, u32, bool)] = &[
+                (0_u32, 5_u32, false),
+                (5_u32, 0_u32, false),
+                (1_u32, 7_u32, true),
+                (7_u32, 1_u32, true),
+            ] as &[(u32, u32, bool)];
+
+            for &(x, y, merge_before_clear) in PARAMS {
+                let dir = TempDir::new(super::gen_tempdir_name().as_str()).unwrap();
+                let path = dir.path();
+                let db = create_database(path);
+                super::list_index_clear_in_family(db, x, y, merge_before_clear);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes incorrect behavior of the `clear()` method in indexes belonging to the same family. Before the fix, in certain situations the method cleared all indexes with the prefixes lexicographically greater than the one the method was invoked for. The explanatory test for `ListIndex` is supplied with the PR.