### PR TITLE
Removed a build stage in CI by 1.27.2 version of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,12 +184,6 @@ jobs:
     script:
     - RUST_LOG=off cargo bench --verbose --manifest-path exonum/Cargo.toml --features long_benchmarks --no-run
 
-  # Compatibility check with the older rust version. Should be synced with readme badges.
-  - name: rust_1_27_2_compatibility
-    rust: 1.27.2
-    script:
-    - cargo build
-
 notifications:
   slack:
     secure: ufnH5/ilJ/GkfzU28GguFgQzL1Jb7gGGVaBytCi1VW9cvME7wHC/Pf3ZDM9cVv7t8Cq6K423J8pSkT8vErB7GzHLGRJK8EsBkuGxiAJiHJIVNf/a20gjyqtS2wSyoVDDFz1LRtCNvQanSy2psSWyJcWtnAllluwRNHKXZWYFOpU6uqt2XIi1s3vuMyVw177alNyQkUJ6mhnt9ZDGoMXfcwXIvZ1bt3GPwAbuvAiHsShIrtVGJYTbIBDBsFsGgc1313xdz670xa1JrvZpIl0ZF91Z/0rxtQZjYos859ARnP+v5TfMpsOZbhVHtLI81/o/dOu/Dnrv2xo4VgLaHCTPfhO7LE7kGZ1OyEFqzsadL+k97JQnfkyyFRA84FrVNvgn5NStJtNRJu593v0zuI1OpmY5Xcu/XG2X3dpYZJGciKywoI8gFCc18taIqWY8P3uL/KdxX3VLikMkmYX+cXxHwhH/RvNLbfxD+hTepz+sGWBnLg/dFNpy3WdzJrSNKE9OAH3Gy53z32fT7XiGF8+juN3RB7MmoLA+sOKnGnjal+o44Ga7KDxHe9lOjRVWAQFH6lIEVNwpdEp+2zqu2QAyCIbYcyEdxo8oKXMwAOPFeIqFGshAYGSQAYbT9V75J2Hfcpqb+EXhiBluCSjoaacg4Yhsc/tFhqI7B5+tq7Z5KVU=

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -52,7 +52,6 @@ uuid = { version = "=0.7.1", features = ["serde"] }
 snow = "=0.4.0"
 rust_decimal = "=0.10.2"
 protobuf = "=2.1.4"
-ring = "=0.13.2"
 
 exonum-crypto = { version = "0.9.0", path = "../crypto" }
 exonum_rocksdb = "0.7.4"


### PR DESCRIPTION
The stage became not actual because too many dependencies became not compatible with 1.27.2 and therefore this stage always is failed.