### PR TITLE
ECR-2636 change hashing in ProofListIndex

### DIFF
--- a/exonum/src/sandbox/consensus/block_request.rs
+++ b/exonum/src/sandbox/consensus/block_request.rs
@@ -20,6 +20,7 @@ use crypto::CryptoHash;
 use helpers::{Height, Round, ValidatorId};
 use node::state::{BLOCK_REQUEST_TIMEOUT, TRANSACTIONS_REQUEST_TIMEOUT};
 use sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use storage::proof_list_index::LEAF_TAG;
 
 /// HANDLE block response
 

--- a/exonum/src/sandbox/sandbox_tests_helper.rs
+++ b/exonum/src/sandbox/sandbox_tests_helper.rs
@@ -25,6 +25,7 @@ use helpers::{Height, Milliseconds, Round, ValidatorId};
 use messages::{
     Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed,
 };
+use storage::proof_list_index::root_hash;
 use storage::Database;
 
 pub type TimestampingSandbox = Sandbox;
@@ -207,7 +208,9 @@ pub fn compute_txs_merkle_root(txs: &[Hash]) -> Hash {
     let mut fork = MemoryDB::new().fork();
     let mut hashes = ProofListIndex::new("name", &mut fork);
     hashes.extend(txs.iter().cloned());
-    hashes.merkle_root()
+    hashes.merkle_root();
+
+    root_hash(txs)
 }
 
 pub fn add_round_with_transactions(

--- a/exonum/src/storage/proof_list_index/proof.rs
+++ b/exonum/src/storage/proof_list_index/proof.rs
@@ -15,9 +15,8 @@
 use serde::{de::Error, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{from_value, Error as SerdeJsonError, Value};
 
-use super::{super::StorageValue, hash_one, hash_pair, key::ProofListKey};
+use super::{super::StorageValue, hash_one, hash_pair, hash_leaf, key::ProofListKey};
 use crypto::Hash;
-use storage::proof_list_index::hash_value;
 
 /// An enum that represents a proof of existence for a proof list elements.
 #[derive(Debug, PartialEq, Eq)]
@@ -69,7 +68,7 @@ impl<V: StorageValue + Clone> ListProof<V> {
                     return Err(ListProofError::UnexpectedLeaf);
                 }
                 vec.push((key.index(), value));
-                hash_value(value.clone())
+                hash_leaf(value.clone())
             }
         };
         Ok(hash)

--- a/exonum/src/storage/proof_list_index/proof.rs
+++ b/exonum/src/storage/proof_list_index/proof.rs
@@ -17,6 +17,7 @@ use serde_json::{from_value, Error as SerdeJsonError, Value};
 
 use super::{super::StorageValue, hash_one, hash_pair, key::ProofListKey};
 use crypto::Hash;
+use storage::proof_list_index::hash_value;
 
 /// An enum that represents a proof of existence for a proof list elements.
 #[derive(Debug, PartialEq, Eq)]
@@ -42,7 +43,7 @@ pub enum ListProofError {
     UnmatchedRootHash,
 }
 
-impl<V: StorageValue> ListProof<V> {
+impl<V: StorageValue + Clone> ListProof<V> {
     fn collect<'a>(
         &'a self,
         key: ProofListKey,
@@ -68,7 +69,7 @@ impl<V: StorageValue> ListProof<V> {
                     return Err(ListProofError::UnexpectedLeaf);
                 }
                 vec.push((key.index(), value));
-                value.hash()
+                hash_value(value.clone())
             }
         };
         Ok(hash)

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -822,3 +822,35 @@ mod root_hash_tests {
         assert_root_hash_correct(&hash_list(&[]));
     }
 }
+
+mod ct_hash_tests {
+    use crypto::{self, Hash, hash};
+    use storage::{Database, MemoryDB, proof_list_index::{root_hash_ct, hash_value, NODE_TAG}};
+
+    fn hash_list(bytes: &[&[u8]]) -> Vec<Hash> {
+        bytes.iter().map(|chunk| crypto::hash(chunk)).collect()
+    }
+
+    #[test]
+    fn root_hash_certified_transparency() {
+        let root_hash = root_hash_ct(&hash_list(&[b"1", b"2"]));
+        println!("hash {:?}", root_hash);
+
+        println!("-------------------- manual check --------------------");
+
+        let hash1 = hash_value(hash(b"1").as_ref());
+        let hash2 = hash_value(hash(b"2").as_ref());
+
+        println!("hash1 {:?}", hash1);
+        println!("hash2 {:?}", hash2);
+
+        let mut value_to_hash = vec![NODE_TAG];
+        value_to_hash.extend_from_slice(&hash1.as_ref());
+        value_to_hash.extend_from_slice(&hash2.as_ref());
+
+        let root_hash = hash(&value_to_hash);
+
+        println!("root_hash {:?}", root_hash);
+    }
+
+}

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -21,6 +21,10 @@ use encoding::serialize::{
     json::reexport::{from_str, to_string},
     reexport::Serialize,
 };
+use storage::proof_list_index::hash_value;
+use storage::proof_list_index::hash_with_prefix;
+use storage::proof_list_index::LEAF_TAG;
+use storage::proof_list_index::NODE_TAG;
 use storage::Database;
 
 const IDX_NAME: &'static str = "idx_name";
@@ -121,9 +125,9 @@ fn list_index_proof(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
 
-    let h0 = 2u64.hash();
-    let h1 = 4u64.hash();
-    let h2 = 6u64.hash();
+    let h0 = hash_value(2u64);
+    let h1 = hash_value(4u64);
+    let h2 = hash_value(6u64);
     let h01 = hash_pair(&h0, &h1);
     let h22 = hash_one(&h2);
     let h012 = hash_pair(&h01, &h22);
@@ -299,42 +303,50 @@ fn randomly_generate_proofs(db: Box<dyn Database>) {
     }
 }
 
+fn hash_leaf(value: &[u8]) -> Hash {
+    hash_with_prefix(LEAF_TAG, value)
+}
+
+fn hash_node(value: &[u8]) -> Hash {
+    hash_with_prefix(NODE_TAG, value)
+}
+
 fn index_and_proof_roots(db: Box<dyn Database>) {
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
     assert_eq!(index.merkle_root(), Hash::zero());
 
-    let h1 = hash(&[1, 2]);
-    let h2 = hash(&[2, 3]);
-    let h3 = hash(&[3, 4]);
-    let h4 = hash(&[4, 5]);
-    let h5 = hash(&[5, 6]);
-    let h6 = hash(&[6, 7]);
-    let h7 = hash(&[7, 8]);
-    let h8 = hash(&[8, 9]);
+    let h1 = hash_leaf(&[1, 2]);
+    let h2 = hash_leaf(&[2, 3]);
+    let h3 = hash_leaf(&[3, 4]);
+    let h4 = hash_leaf(&[4, 5]);
+    let h5 = hash_leaf(&[5, 6]);
+    let h6 = hash_leaf(&[6, 7]);
+    let h7 = hash_leaf(&[7, 8]);
+    let h8 = hash_leaf(&[8, 9]);
 
-    let h12 = hash(&[h1.as_ref(), h2.as_ref()].concat());
-    let h3up = hash(h3.as_ref());
-    let h123 = hash(&[h12.as_ref(), h3up.as_ref()].concat());
+    let h12 = hash_node(&[h1.as_ref(), h2.as_ref()].concat());
+    let h3up = hash_node(h3.as_ref());
+    let h123 = hash_node(&[h12.as_ref(), h3up.as_ref()].concat());
 
-    let h34 = hash(&[h3.as_ref(), h4.as_ref()].concat());
-    let h1234 = hash(&[h12.as_ref(), h34.as_ref()].concat());
+    let h34 = hash_node(&[h3.as_ref(), h4.as_ref()].concat());
+    let h1234 = hash_node(&[h12.as_ref(), h34.as_ref()].concat());
 
-    let h5up = hash(h5.as_ref());
-    let h5upup = hash(h5up.as_ref());
-    let h12345 = hash(&[h1234.as_ref(), h5upup.as_ref()].concat());
+    let h5up = hash_node(h5.as_ref());
+    let h5upup = hash_node(h5up.as_ref());
+    let h12345 = hash_node(&[h1234.as_ref(), h5upup.as_ref()].concat());
 
-    let h56 = hash(&[h5.as_ref(), h6.as_ref()].concat());
-    let h56up = hash(h56.as_ref());
-    let h123456 = hash(&[h1234.as_ref(), h56up.as_ref()].concat());
+    let h56 = hash_node(&[h5.as_ref(), h6.as_ref()].concat());
+    let h56up = hash_node(h56.as_ref());
+    let h123456 = hash_node(&[h1234.as_ref(), h56up.as_ref()].concat());
 
-    let h7up = hash(h7.as_ref());
-    let h567 = hash(&[h56.as_ref(), h7up.as_ref()].concat());
-    let h1234567 = hash(&[h1234.as_ref(), h567.as_ref()].concat());
+    let h7up = hash_node(h7.as_ref());
+    let h567 = hash_node(&[h56.as_ref(), h7up.as_ref()].concat());
+    let h1234567 = hash_node(&[h1234.as_ref(), h567.as_ref()].concat());
 
-    let h78 = hash(&[h7.as_ref(), h8.as_ref()].concat());
-    let h5678 = hash(&[h56.as_ref(), h78.as_ref()].concat());
-    let h12345678 = hash(&[h1234.as_ref(), h5678.as_ref()].concat());
+    let h78 = hash_node(&[h7.as_ref(), h8.as_ref()].concat());
+    let h5678 = hash_node(&[h56.as_ref(), h78.as_ref()].concat());
+    let h12345678 = hash_node(&[h1234.as_ref(), h5678.as_ref()].concat());
 
     let expected_hash_comb: Vec<(Vec<u8>, Hash, u64)> = vec![
         (vec![1, 2], h1, 0),
@@ -459,17 +471,17 @@ fn proof_structure(db: Box<dyn Database>) {
 
     // spell-checker:ignore upup
 
-    let h1 = hash(&vec![0, 1, 2]);
-    let h2 = hash(&vec![1, 2, 3]);
-    let h3 = hash(&vec![2, 3, 4]);
-    let h4 = hash(&vec![3, 4, 5]);
-    let h5 = hash(&vec![4, 5, 6]);
-    let h12 = hash(&[h1.as_ref(), h2.as_ref()].concat());
-    let h34 = hash(&[h3.as_ref(), h4.as_ref()].concat());
-    let h1234 = hash(&[h12.as_ref(), h34.as_ref()].concat());
-    let h5up = hash(h5.as_ref());
-    let h5upup = hash(h5up.as_ref());
-    let h12345 = hash(&[h1234.as_ref(), h5upup.as_ref()].concat());
+    let h1 = hash_leaf(&vec![0, 1, 2]);
+    let h2 = hash_leaf(&vec![1, 2, 3]);
+    let h3 = hash_leaf(&vec![2, 3, 4]);
+    let h4 = hash_leaf(&vec![3, 4, 5]);
+    let h5 = hash_leaf(&vec![4, 5, 6]);
+    let h12 = hash_node(&[h1.as_ref(), h2.as_ref()].concat());
+    let h34 = hash_node(&[h3.as_ref(), h4.as_ref()].concat());
+    let h1234 = hash_node(&[h12.as_ref(), h34.as_ref()].concat());
+    let h5up = hash_node(h5.as_ref());
+    let h5upup = hash_node(h5up.as_ref());
+    let h12345 = hash_node(&[h1234.as_ref(), h5upup.as_ref()].concat());
 
     for i in 0_u8..5 {
         index.push(vec![i, i + 1, i + 2]);
@@ -507,8 +519,8 @@ fn proof_structure(db: Box<dyn Database>) {
 }
 
 fn simple_merkle_root(db: Box<dyn Database>) {
-    let h1 = hash(&[1]);
-    let h2 = hash(&[2]);
+    let h1 = hash(&[0x0, 1]);
+    let h2 = hash(&[0x0, 2]);
 
     let mut fork = db.fork();
     let mut index = ProofListIndex::new(IDX_NAME, &mut fork);
@@ -824,8 +836,11 @@ mod root_hash_tests {
 }
 
 mod ct_hash_tests {
-    use crypto::{self, Hash, hash};
-    use storage::{Database, MemoryDB, proof_list_index::{root_hash_ct, hash_value, NODE_TAG}};
+    use crypto::{self, hash, Hash};
+    use storage::{
+        proof_list_index::{hash_value, root_hash_ct, NODE_TAG},
+        Database, MemoryDB,
+    };
 
     fn hash_list(bytes: &[&[u8]]) -> Vec<Hash> {
         bytes.iter().map(|chunk| crypto::hash(chunk)).collect()
@@ -833,24 +848,24 @@ mod ct_hash_tests {
 
     #[test]
     fn root_hash_certified_transparency() {
-        let root_hash = root_hash_ct(&hash_list(&[b"1", b"2"]));
-        println!("hash {:?}", root_hash);
+        //        let root_hash = root_hash_ct(&hash_list(&[b"1", b"2"]));
+        //        println!("hash {:?}", root_hash);
 
         println!("-------------------- manual check --------------------");
 
-        let hash1 = hash_value(hash(b"1").as_ref());
-        let hash2 = hash_value(hash(b"2").as_ref());
-
-        println!("hash1 {:?}", hash1);
-        println!("hash2 {:?}", hash2);
-
-        let mut value_to_hash = vec![NODE_TAG];
-        value_to_hash.extend_from_slice(&hash1.as_ref());
-        value_to_hash.extend_from_slice(&hash2.as_ref());
-
-        let root_hash = hash(&value_to_hash);
-
-        println!("root_hash {:?}", root_hash);
+        //        let hash1 = hash_value(hash(b"1").as_ref());
+        //        let hash2 = hash_value(hash(b"2").as_ref());
+        //
+        //        println!("hash1 {:?}", hash1);
+        //        println!("hash2 {:?}", hash2);
+        //
+        //        let mut value_to_hash = vec![NODE_TAG];
+        //        value_to_hash.extend_from_slice(&hash1.as_ref());
+        //        value_to_hash.extend_from_slice(&hash2.as_ref());
+        //
+        //        let root_hash = hash(&value_to_hash);
+        //
+        //        println!("root_hash {:?}", root_hash);
     }
 
 }


### PR DESCRIPTION
Use separate hashing for leaf nodes and branch nodes according to [certificate transparency ](https://tools.ietf.org/html/rfc6962#section-2.1) specification. Leaf nodes hashes with 0x0 prefix, branch nodes with 0x1.

- [ ] Change hash tree structure(?)
- [ ] Add tests.
- [ ] Fix sanbox tests.

