### PR TITLE
Fix Signed<T> deserialization [ECR-2689]

### DIFF
--- a/exonum/src/encoding/spec.rs
+++ b/exonum/src/encoding/spec.rs
@@ -255,7 +255,7 @@ macro_rules! encoding_struct {
                 use $crate::encoding::serialize::json::ExonumJson;
                 self.serialize_field()
                     .map_err(|_| S::Error::custom(
-                                concat!("Can not serialize structure: ", stringify!($name))))?
+                                concat!("Cannot serialize structure: ", stringify!($name))))?
                     .serialize(serializer)
             }
         }

--- a/exonum/src/messages/authorization.rs
+++ b/exonum/src/messages/authorization.rs
@@ -144,7 +144,7 @@ impl SignedMessage {
         public_key: &PublicKey,
     ) -> Result<(), Error> {
         if !crypto::verify(signature, &full_buffer, &public_key) {
-            bail!("Can not verify message.");
+            bail!("Cannot verify message.");
         }
         Ok(())
     }

--- a/exonum/src/messages/authorization.rs
+++ b/exonum/src/messages/authorization.rs
@@ -144,7 +144,7 @@ impl SignedMessage {
         public_key: &PublicKey,
     ) -> Result<(), Error> {
         if !crypto::verify(signature, &full_buffer, &public_key) {
-            bail!("Can't verify message.");
+            bail!("Can not verify message.");
         }
         Ok(())
     }

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -34,6 +34,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use failure::Error;
 use hex::{FromHex, ToHex};
+use serde::de::{self, Deserialize, Deserializer};
 
 use std::{borrow::Cow, cmp::PartialEq, fmt, mem, ops::Deref};
 
@@ -164,10 +165,10 @@ impl BinaryForm for ServiceTransaction {
 /// payload may have different binary representation (thus invalidating the message signature).
 ///
 /// So we use `Signed` to keep the original byte buffer around with the parsed `Payload`.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Signed<T> {
     // TODO: inner T duplicate data in SignedMessage, we can use owning_ref,
-    //if our serialization format allows us (ECR-2315).
+    // if our serialization format allows us (ECR-2315).
     payload: T,
     #[serde(with = "HexStringRepresentation")]
     message: SignedMessage,
@@ -282,5 +283,38 @@ impl<T: ProtocolMessage> CryptoHash for Signed<T> {
 impl PartialEq<Signed<RawTransaction>> for SignedMessage {
     fn eq(&self, other: &Signed<RawTransaction>) -> bool {
         self.eq(other.signed_message())
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Signed<T>
+where
+    T: ProtocolMessage + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct SignedLayout<P> {
+            payload: P,
+            #[serde(with = "HexStringRepresentation")]
+            message: SignedMessage,
+        };
+
+        let inner: SignedLayout<T> = SignedLayout::deserialize(deserializer)?;
+        // Checks that signed message correspond to the payload.
+        let encoded_payload = inner
+            .payload
+            .encode()
+            .map_err(|e| de::Error::custom(format!("Unable to encode payload: {}", e)))?;
+        if encoded_payload != inner.message.payload() {
+            return Err(de::Error::custom(
+                "Payload does not correspond to the signed message",
+            ));
+        }
+        Ok(Signed {
+            payload: inner.payload,
+            message: inner.message,
+        })
     }
 }

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -307,8 +307,11 @@ where
         Message::deserialize(signed_message)
             .map_err(|e| de::Error::custom(format!("Unable to deserialize signed message: {}", e)))
             .and_then(|msg| {
-                T::try_from(msg).map_err(|_| {
-                    de::Error::custom(format!("Unable to decode signed message into payload",))
+                T::try_from(msg).map_err(|e| {
+                    de::Error::custom(format!(
+                        "Unable to decode signed message into payload: {:?}",
+                        e
+                    ))
                 })
             })
     }

--- a/exonum/src/messages/protocol.rs
+++ b/exonum/src/messages/protocol.rs
@@ -947,8 +947,8 @@ impl Precommit {
 #[doc(hidden)]
 pub trait ProtocolMessage: Debug + Clone + BinaryForm {
     fn message_type() -> (u8, u8);
-    ///Trying to convert `Message` to concrete message,
-    ///if ok returns message `Signed<Self>` if fails, returns `Message` back.
+    /// Trying to convert `Message` to concrete message,
+    /// if ok returns message `Signed<Self>` if fails, returns `Message` back.
     fn try_from(p: Message) -> Result<Signed<Self>, Message>;
 
     fn into_protocol(this: Signed<Self>) -> Message;

--- a/exonum/src/messages/tests.rs
+++ b/exonum/src/messages/tests.rs
@@ -181,7 +181,7 @@ fn test_precommit_serde_correct() {
 }
 
 #[test]
-#[should_panic(expected = "Can not verify message.")]
+#[should_panic(expected = "Cannot verify message.")]
 fn test_precommit_serde_wrong_signature() {
     use crypto::SIGNATURE_LENGTH;
 

--- a/exonum/src/messages/tests.rs
+++ b/exonum/src/messages/tests.rs
@@ -181,7 +181,7 @@ fn test_precommit_serde_correct() {
 }
 
 #[test]
-#[should_panic(expected = "Can\'t verify message.")]
+#[should_panic(expected = "Can not verify message.")]
 fn test_precommit_serde_wrong_signature() {
     let (pub_key, secret_key) = gen_keypair();
     let ts = Utc::now();
@@ -201,39 +201,6 @@ fn test_precommit_serde_wrong_signature() {
     // Break signature.
     let raw_len = precommit.message.raw.len();
     precommit.message.raw[raw_len - 2] /= 2 + 1;
-
-    let precommit_json = serde_json::to_string(&precommit).unwrap();
-    let precommit2: Signed<Precommit> = serde_json::from_str(&precommit_json).unwrap();
-    assert_eq!(precommit2, precommit);
-}
-
-#[test]
-#[should_panic(expected = "Payload does not correspond to the signed message")]
-fn test_precommit_serde_not_correspond_payload() {
-    let (pub_key, secret_key) = gen_keypair();
-    let ts = Utc::now();
-
-    let mut precommit = Message::concrete(
-        Precommit::new(
-            ValidatorId(123),
-            Height(15),
-            Round(25),
-            &hash(&[1, 2, 3]),
-            &hash(&[3, 2, 1]),
-            ts,
-        ),
-        pub_key,
-        &secret_key,
-    );
-    // Modify payload.
-    precommit.payload = Precommit::new(
-        ValidatorId(124),
-        Height(15),
-        Round(25),
-        &hash(&[1, 2, 3]),
-        &hash(&[3, 2, 1]),
-        ts,
-    );
 
     let precommit_json = serde_json::to_string(&precommit).unwrap();
     let precommit2: Signed<Precommit> = serde_json::from_str(&precommit_json).unwrap();


### PR DESCRIPTION
`Signed<T>` serialization contains a bug, that omit payload verification.