### PR TITLE
Serialize TransactionStatus with protobuf [ECR-2704]

### DIFF
--- a/exonum/src/encoding/protobuf/mod.rs
+++ b/exonum/src/encoding/protobuf/mod.rs
@@ -18,7 +18,7 @@
 #![allow(bare_trait_objects)]
 #![allow(renamed_and_removed_lints)]
 
-pub use self::blockchain::{Block, ConfigReference, TxLocation};
+pub use self::blockchain::{Block, ConfigReference, TransactionResult, TxLocation};
 pub use self::helpers::{BitVec, Hash, PublicKey};
 pub use self::protocol::{
     BlockRequest, BlockResponse, Connect, PeersRequest, Precommit, Prevote, PrevotesRequest,
@@ -176,6 +176,20 @@ impl ProtobufConvert for ValidatorId {
     fn from_pb(pb: Self::ProtoStruct) -> Result<Self, ()> {
         if pb <= u32::from(u16::max_value()) {
             Ok(ValidatorId(pb as u16))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl ProtobufConvert for u16 {
+    type ProtoStruct = u32;
+    fn to_pb(&self) -> Self::ProtoStruct {
+        u32::from(*self)
+    }
+    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, ()> {
+        if pb <= u32::from(u16::max_value()) {
+            Ok(pb as u16)
         } else {
             Err(())
         }

--- a/exonum/src/encoding/protobuf/proto/blockchain.proto
+++ b/exonum/src/encoding/protobuf/proto/blockchain.proto
@@ -36,3 +36,8 @@ message TxLocation {
   uint64 block_height = 1;
   uint64 position_in_block = 2;
 }
+
+message TransactionResult {
+  uint32 status = 1;
+  string description = 2;
+}


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here 
  and list any open questions you might have. -->

Now TransactionStatus is serialized with protobuf.

change: empty string description == no description

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
