### PR TITLE
Add Blockchain::broadcast_raw_transaction method [ECR-2401]

### DIFF
--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -289,6 +289,12 @@ impl Blockchain {
     #[doc(hidden)]
     pub fn broadcast_raw_transaction(&self, tx: RawTransaction) -> Result<(), failure::Error> {
         let service_id = tx.service_id();
+        if !self.service_map.contains_key(&service_id) {
+            return format_err!(
+                "Unable to broadcast transaction: no service with ID={} found",
+                service_id
+            );
+        }
         let msg = Message::sign_transaction(
             tx.service_transaction(),
             service_id,

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -290,10 +290,10 @@ impl Blockchain {
     pub fn broadcast_raw_transaction(&self, tx: RawTransaction) -> Result<(), failure::Error> {
         let service_id = tx.service_id();
         if !self.service_map.contains_key(&service_id) {
-            return format_err!(
+            return Err(format_err!(
                 "Unable to broadcast transaction: no service with ID={} found",
                 service_id
-            );
+            ));
         }
         let msg = Message::sign_transaction(
             tx.service_transaction(),

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -286,6 +286,19 @@ impl Blockchain {
         crypto::hash(&vec)
     }
 
+    #[doc(hidden)]
+    pub fn broadcast_raw_transaction(&self, tx: RawTransaction) -> Result<(), failure::Error> {
+        let service_id = tx.service_id();
+        let msg = Message::sign_transaction(
+            tx.service_transaction(),
+            service_id,
+            self.service_keypair.0,
+            &self.service_keypair.1,
+        );
+
+        self.api_sender.broadcast_transaction(msg)
+    }
+
     /// Executes the given transactions from the pool.
     /// Then collects the resulting changes from the current storage state and returns them
     /// with the hash of the resulting block.

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -221,7 +221,8 @@ pub struct TransactionContext<'a> {
 }
 
 impl<'a> TransactionContext<'a> {
-    pub(crate) fn new(fork: &'a mut Fork, raw_message: &Signed<RawTransaction>) -> Self {
+    #[doc(hidden)]
+    pub fn new(fork: &'a mut Fork, raw_message: &Signed<RawTransaction>) -> Self {
         TransactionContext {
             fork,
             service_id: raw_message.service_id(),


### PR DESCRIPTION
## Overview

This method will be used for broadcasting transactions by Java Bindings.
Any ideas about nicer interface are welcome

Additionally, `TransactionContext::new` method made public.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-2401
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [X] There are no TODOs left in the merged code
- [X] Change is covered by automated tests
- [X] Benchmark results are attached (if applicable)
- [X] The [coding guidelines] are followed
- [X] Public API has proper documentation
- [X] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
