### PR TITLE
Remove Transaction::verify method [ECR-2721]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `Transaction::execute` now accepts `TransactionContext` as the second
    parameter. `TransactionContext` provides the public key of transaction
-   author, ID of current service, and transaction hash (#943)
+   author, ID of current service, and transaction hash. (#943)
 
-- `Transaction::verify` method has been removed. (#???)
+- `Transaction::verify` method has been removed. (#1085)
 
 - Every transaction that contains the public key of the author was refactored
    to use the author indicated in `TransactionContext`. (#984 #980 #979 #975 #971)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
    parameter. `TransactionContext` provides the public key of transaction
    author, ID of current service, and transaction hash (#943)
 
+- `Transaction::verify` method has been removed. (#???)
+
 - Every transaction that contains the public key of the author was refactored
    to use the author indicated in `TransactionContext`. (#984 #980 #979 #975 #971)
 

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -187,10 +187,6 @@ mod timestamping {
     }
 
     impl Transaction for PanickingTx {
-        fn verify(&self) -> bool {
-            unimplemented!("never used in benchmark")
-        }
-
         fn execute(&self, _: TransactionContext) -> ExecutionResult {
             panic!("panic text");
         }

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -181,12 +181,6 @@ mod timestamping {
     }
 
     impl Transaction for Tx {
-        fn verify(&self) -> bool {
-            // We don't verify transactions within the benchmark, so in this
-            // and following transaction types the verification code is trivial.
-            unimplemented!("never used in benchmark")
-        }
-
         fn execute(&self, _: TransactionContext) -> ExecutionResult {
             Ok(())
         }
@@ -337,10 +331,6 @@ mod cryptocurrency {
     }
 
     impl Transaction for Tx {
-        fn verify(&self) -> bool {
-            unimplemented!("never used in benchmark")
-        }
-
         fn execute(&self, mut context: TransactionContext) -> ExecutionResult {
             let from = context.author();
             let mut index = ProofMapIndex::new("provable_balances", context.fork());
@@ -355,10 +345,6 @@ mod cryptocurrency {
     }
 
     impl Transaction for SimpleTx {
-        fn verify(&self) -> bool {
-            unimplemented!("never used in benchmark")
-        }
-
         fn execute(&self, mut context: TransactionContext) -> ExecutionResult {
             let from = context.author();
 
@@ -374,10 +360,6 @@ mod cryptocurrency {
     }
 
     impl Transaction for RollbackTx {
-        fn verify(&self) -> bool {
-            unimplemented!("never used in benchmark")
-        }
-
         fn execute(&self, mut context: TransactionContext) -> ExecutionResult {
             let from = context.author();
 

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -120,47 +120,6 @@ impl ::serde::Serialize for dyn Transaction {
 ///
 /// [doc:transactions]: https://exonum.com/doc/architecture/transactions/
 pub trait Transaction: ::std::fmt::Debug + Send + 'static + ::erased_serde::Serialize {
-    /// Verifies the internal consistency of the transaction. `verify` should include
-    /// only invariant checking. The message signature is checked internally.
-    /// `verify` has no access to the blockchain state;
-    /// checks involving the blockchain state must be preformed in [`execute`](#tymethod.execute).
-    ///
-    /// If a transaction fails `verify`, it is considered incorrect and cannot be included into
-    /// any correct block proposal. Incorrect transactions are never included into the blockchain.
-    ///
-    /// *This method should not use external data, that is, it must be a pure function.*
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[macro_use] extern crate exonum;
-    /// # #[macro_use] extern crate serde_derive;
-    /// #
-    /// use exonum::blockchain::{Transaction, TransactionContext};
-    /// use exonum::crypto::PublicKey;
-    /// use exonum::messages::Signed;
-    /// # use exonum::blockchain::ExecutionResult;
-    ///
-    /// transactions! {
-    ///     MyTransactions {
-    ///
-    ///         struct MyTransaction {
-    ///             // Transaction definition...
-    ///             public_key: &PublicKey,
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// impl Transaction for MyTransaction {
-    ///     // Other methods...
-    ///     // ...
-    /// #   fn execute(&self, _: TransactionContext) -> ExecutionResult { Ok(()) }
-    /// }
-    /// # fn main() {}
-    fn verify(&self) -> bool {
-        true
-    }
-
     /// Receives a `TransactionContext` witch contain fork
     /// of the current blockchain state and can modify it depending on the contents
     /// of the transaction.


### PR DESCRIPTION
## Overview

`Transaction::verify` is no more useful (and no more used) in Exonum 0.10

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-2721
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
