### PR TITLE
Store secret keys in separate files [ECR-2518]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum
 
+- Node secret keys are now stored in separate files in a secure way.
+  CLI for generating node configs and starting nodes has been extended
+  in order to reflect these changes.
+
 - Trait `TransactionSend` was removed.
   `ApiSender` now contains `broadcast_transaction` method. (#943)
 
@@ -109,7 +113,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 #### exonum-crypto
 
-- Added `utils` module with functions `create_keys_file` for creating
+- Added `utils` module with functions `generate_keys_file` for creating
   and `read_keys_from_file` for reading files that contain a
   public key and encrypted secret key. (#1056)
 

--- a/examples/cryptocurrency-advanced/backend/consensus.toml
+++ b/examples/cryptocurrency-advanced/backend/consensus.toml
@@ -1,0 +1,15 @@
+public_key = '230056351d29b4fc61c4f6073ea26f2e90551870e0addcbf24243f04d995ec41'
+
+[secret_key]
+ciphertext = '62f9ab47112f8b3cdbc2ee46fe6f7974f59e1d24e707384e583ca3eab992dd7a'
+mac = '553b31354f7aef2bbafdd6db993e540b'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = 'c801c0939746ea03d079b40e1c76068a7a55da7bd55b3b972bd8ebb276516ce6'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '22bd3b1085846389db88d30b2fa00293f9b1bded946a8f24'

--- a/examples/cryptocurrency-advanced/backend/service.toml
+++ b/examples/cryptocurrency-advanced/backend/service.toml
@@ -1,0 +1,15 @@
+public_key = 'baa12227b844bcc5564ee0c6e68c27b0358690a3e34d745b8a093605b4375848'
+
+[secret_key]
+ciphertext = '0670edae151250a79035df55596c770e7494341af8edcc5ed00eb89b8a2390d0'
+mac = '0aab30a974c6261ec67e14a1ac9f47e8'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '0a2c408a6b2dbfecbaae1209ce53a61185e7dc7fcdecf02cdb2d7bec707ca65f'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '239135ab3bc56705ceb6a97ef8b3154ee41a621630df9871'

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -104,6 +104,7 @@ protos
 pubkey
 pubkeys
 pwbox
+quux
 readonly
 rebasing
 reddit
@@ -116,6 +117,7 @@ roadmap
 rocksdb
 roughtime
 roundtrip
+rpassword
 rtype
 runtimes
 rustfmt

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { version = "=0.7.1", features = ["serde"] }
 snow = "=0.4.0"
 rust_decimal = "=0.10.2"
 protobuf = { version = "2.2.0", features = ["with-serde"] }
+rpassword = "2.0.0"
 
 exonum-crypto = { version = "0.9.0", path = "../crypto" }
 exonum_rocksdb = "0.7.4"

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -53,7 +53,7 @@ uuid = { version = "=0.7.1", features = ["serde"] }
 snow = "=0.4.0"
 rust_decimal = "=0.10.2"
 protobuf = { version = "2.2.0", features = ["with-serde"] }
-rpassword = "2.0.0"
+rpassword = "=2.1.0"
 
 exonum-crypto = { version = "0.9.0", path = "../crypto" }
 exonum_rocksdb = "0.7.4"

--- a/exonum/src/helpers/config.rs
+++ b/exonum/src/helpers/config.rs
@@ -22,7 +22,7 @@ use std::{
     fs::{self, File},
     io::{Read, Write},
     mem::drop,
-    path::Path,
+    path::{Path, PathBuf},
     sync::mpsc,
     thread,
 };
@@ -136,7 +136,7 @@ impl ConfigManager {
     where
         P: AsRef<Path>,
     {
-        let mut current_config: NodeConfig = ConfigFile::load(path)?;
+        let mut current_config: NodeConfig<PathBuf> = ConfigFile::load(path)?;
         current_config.connect_list = connect_list;
         ConfigFile::save(&current_config, path)?;
 

--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -95,7 +95,9 @@ impl ClapBackend {
                         if let Some(short) = detail.short_name {
                             clap_arg = clap_arg.short(short);
                         }
-                        clap_arg.multiple(detail.multiple).takes_value(true)
+                        clap_arg
+                            .multiple(detail.multiple)
+                            .takes_value(arg.takes_value)
                     }
                 };
                 clap_arg.help(arg.help).required(arg.required)

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -425,7 +425,7 @@ impl GenerateNodeConfig {
         loop {
             write!(&mut writer, "Enter passphrase (empty for no passphrase): ")?;
             let password = rpassword::read_password_with_reader(Some(&mut reader))?;
-            write!(&mut writer, "Enter same passphrase again: ").unwrap();
+            write!(&mut writer, "Enter same passphrase again: ")?;
             if password == rpassword::read_password_with_reader(Some(&mut reader))? {
                 return Ok(password);
             }

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -474,7 +474,7 @@ impl Command for GenerateNodeConfig {
             Argument::new_named(
                 CONSENSUS_KEY_PATH,
                 false,
-                "Path to the pem file storing consensus private key (default: ./consensus.toml)",
+                "Path to the file storing consensus private key (default: ./consensus.toml)",
                 "c",
                 "consensus-path",
                 false,
@@ -482,7 +482,7 @@ impl Command for GenerateNodeConfig {
             Argument::new_named(
                 SERVICE_KEY_PATH,
                 false,
-                "Path to the pem file storing service private key (default: ./service.toml)",
+                "Path to the file storing service private key (default: ./service.toml)",
                 "s",
                 "service-path",
                 false,

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -429,7 +429,7 @@ impl GenerateNodeConfig {
             if password == rpassword::read_password_with_reader(Some(&mut reader))? {
                 return Ok(password);
             }
-            writeln!(&mut writer, "Passphrases do not match.  Try again.").unwrap();
+            writeln!(&mut writer, "Passphrases do not match. Try again.")?;
         }
     }
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -423,7 +423,7 @@ impl GenerateNodeConfig {
 
     fn prompt_passphrase<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> io::Result<String> {
         loop {
-            write!(&mut writer, "Enter passphrase (empty for no passphrase): ").unwrap();
+            write!(&mut writer, "Enter passphrase (empty for no passphrase): ")?;
             let password = rpassword::read_password_with_reader(Some(&mut reader))?;
             write!(&mut writer, "Enter same passphrase again: ").unwrap();
             if password == rpassword::read_password_with_reader(Some(&mut reader))? {

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -84,7 +84,7 @@ pub struct Argument {
 }
 
 impl Argument {
-    /// Creates a new falg with `long` and optionally `short` names.
+    /// Creates a new flag with `long` and optionally `short` names.
     pub fn new_flag<T>(
         name: &'static str,
         help: &'static str,

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -16,10 +16,10 @@
 
 use toml;
 
-use std::{collections::BTreeMap, net::SocketAddr};
+use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf};
 
 use blockchain::config::{ConsensusConfig, ValidatorKeys};
-use crypto::{PublicKey, SecretKey};
+use crypto::PublicKey;
 
 /// Abstract configuration.
 pub type AbstractConfig = BTreeMap<String, toml::Value>;
@@ -78,12 +78,12 @@ pub struct NodePrivateConfig {
     pub external_address: String,
     /// Consensus public key.
     pub consensus_public_key: PublicKey,
-    /// Consensus secret key.
-    pub consensus_secret_key: SecretKey,
+    /// Path to the consensus secret key file.
+    pub consensus_secret_key: PathBuf,
     /// Service public key.
     pub service_public_key: PublicKey,
-    /// Service secret key.
-    pub service_secret_key: SecretKey,
+    /// Path to the service secret key file.
+    pub service_secret_key: PathBuf,
     /// Additional service secret config.
     #[serde(default)]
     pub services_secret_configs: AbstractConfig,

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -25,6 +25,8 @@ use crypto::gen_keypair;
 use env_logger::Builder;
 use log::SetLoggerError;
 
+use std::path::{Component, Path, PathBuf};
+
 use blockchain::{GenesisConfig, ValidatorKeys};
 use node::{ConnectListConfig, NodeConfig};
 
@@ -76,4 +78,63 @@ pub fn generate_testnet_config(count: u16, start_port: u16) -> Vec<NodeConfig> {
             database: Default::default(),
             thread_pool_size: Default::default(),
         }).collect::<Vec<_>>()
+}
+
+/// This routine is adapted from the *old* Path's `path_relative_from`
+/// function, which works differently from the new `relative_from` function.
+/// In particular, this handles the case on unix where both paths are
+/// absolute but with only the root as the common directory.
+///
+/// @see https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158
+pub fn path_relative_from(path: impl AsRef<Path>, base: impl AsRef<Path>) -> Option<PathBuf> {
+    let path = path.as_ref();
+    let base = base.as_ref();
+
+    if path.is_absolute() != base.is_absolute() {
+        if path.is_absolute() {
+            Some(PathBuf::from(path))
+        } else {
+            None
+        }
+    } else {
+        let mut ita = path.components();
+        let mut itb = base.components();
+        let mut comps: Vec<Component> = vec![];
+        loop {
+            match (ita.next(), itb.next()) {
+                (None, None) => break,
+                (Some(a), None) => {
+                    comps.push(a);
+                    comps.extend(ita.by_ref());
+                    break;
+                }
+                (None, _) => comps.push(Component::ParentDir),
+                (Some(a), Some(b)) if comps.is_empty() && a == b => (),
+                (Some(a), Some(b)) if b == Component::CurDir => comps.push(a),
+                (Some(_), Some(b)) if b == Component::ParentDir => return None,
+                (Some(a), Some(_)) => {
+                    comps.push(Component::ParentDir);
+                    for _ in itb {
+                        comps.push(Component::ParentDir);
+                    }
+                    comps.push(a);
+                    comps.extend(ita.by_ref());
+                    break;
+                }
+            }
+        }
+        Some(comps.iter().map(|c| c.as_os_str()).collect())
+    }
+}
+
+#[test]
+fn test_path_relative_from() {
+    let baz: PathBuf = "/foo/bar/baz".into();
+    let bar: PathBuf = "/foo/bar".into();
+    let quux: PathBuf = "/foo/bar/quux".into();
+    assert_eq!(path_relative_from(&bar, &baz), Some("../".into()));
+    assert_eq!(path_relative_from(&baz, &bar), Some("baz".into()));
+    assert_eq!(path_relative_from(&quux, &baz), Some("../quux".into()));
+    assert_eq!(path_relative_from(&baz, &quux), Some("../baz".into()));
+    assert_eq!(path_relative_from(&bar, &quux), Some("../".into()));
 }

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -73,6 +73,7 @@ extern crate log;
 extern crate os_info;
 extern crate rand;
 extern crate rand_xorshift;
+extern crate rpassword;
 extern crate rust_decimal;
 extern crate serde;
 #[macro_use]

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -32,13 +32,16 @@ use exonum::{
 use toml::Value;
 
 use std::{
+    env,
     ffi::OsString,
-    fs,
-    fs::{File, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::{Read, Write},
     panic,
-    path::Path,
+    path::{Path, PathBuf},
 };
+
+const EXONUM_CONSENSUS_PASS: &str = "EXONUM_CONSENSUS_PASS";
+const EXONUM_SERVICE_PASS: &str = "EXONUM_SERVICE_PASS";
 
 const CONFIG_TMP_FOLDER: &str = "/tmp/";
 const CONFIG_TESTDATA_FOLDER: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testdata/config/");
@@ -79,7 +82,7 @@ fn touch(path: &str) {
         .unwrap();
 }
 
-fn compare_files(filename: &str, folder: &str) {
+fn compare_configs(filename: &str, folder: &str) {
     let source = full_testdata_name(filename);
     let destination = full_tmp_name(filename, folder);
 
@@ -136,25 +139,37 @@ fn generate_config(folder: &str, i: usize, mode: IpMode) {
         &full_tmp_name(SEC_CONFIG[i], folder),
         "-a",
         ip,
+        "--consensus-path",
+        &full_tmp_name(&format!("consensus{}.toml", i), folder),
+        "--service-path",
+        &full_tmp_name(&format!("service{}.toml", i), folder),
+        "--no-password",
     ]));
 }
 
-fn finalize_config(folder: &str, config: &str, i: usize, count: usize) {
-    let mut variables = vec![
+fn finalize_config(folder: &str, config: &str, sec_config: &str, pub_configs: &[&str]) {
+    let pub_config_paths = pub_configs.iter().map(|conf| {
+        override_validators_count(conf, pub_configs.len(), folder);
+        full_tmp_name(conf, folder)
+    });
+
+    let variables = vec![
         "exonum-config-test".to_owned(),
         "finalize".to_owned(),
-        full_testdata_name(SEC_CONFIG[i]),
+        full_testdata_name(sec_config),
         full_tmp_name(config, folder),
         "-p".to_owned(),
-    ];
+    ].iter()
+    .cloned()
+    .chain(pub_config_paths)
+    .collect::<Vec<_>>();
 
-    fs::create_dir_all(full_tmp_name("", folder)).expect("Can't create temp folder");
-
-    for &conf in PUB_CONFIG.iter().take(count) {
-        override_validators_count(conf, count, folder);
-        variables.push(full_tmp_name(conf, folder));
-    }
     assert!(!default_run_with_matches(variables));
+}
+
+fn finalize_config_with_validators_count(folder: &str, config: &str, i: usize, count: usize) {
+    let pub_configs = PUB_CONFIG.iter().cloned().take(count).collect::<Vec<_>>();
+    finalize_config(folder, config, SEC_CONFIG[i], pub_configs.as_slice());
 }
 
 fn override_validators_count(config: &str, n: usize, folder: &str) {
@@ -186,6 +201,10 @@ fn override_validators_count(config: &str, n: usize, folder: &str) {
         .expect("Create temp config file is failed");
 }
 
+fn copy_file_to_temp(file: &str, folder: &str) {
+    fs::copy(&full_testdata_name(file), &full_tmp_name(file, folder)).unwrap();
+}
+
 fn run_node(config: &str, folder: &str) {
     assert!(default_run_with_matches(vec![
         "exonum-config-test",
@@ -212,7 +231,7 @@ fn test_generate_template() {
 
     let result = panic::catch_unwind(|| {
         generate_template(command);
-        compare_files(GENERATED_TEMPLATE, command);
+        compare_configs(GENERATED_TEMPLATE, command);
     });
 
     fs::remove_dir_all(full_tmp_folder(command)).unwrap();
@@ -256,13 +275,16 @@ fn test_generate_config_ipv6() {
 fn test_generate_full_config_run() {
     let command = "finalize";
     let result = panic::catch_unwind(|| {
+        fs::create_dir_all(full_tmp_name("", command)).expect("Can't create temp folder");
         for i in 0..PUB_CONFIG.len() {
+            copy_file_to_temp(&format!("consensus{}.toml", i), command);
+            copy_file_to_temp(&format!("service{}.toml", i), command);
             for n in 0..PUB_CONFIG.len() + 1 {
                 println!("{} {}", i, n);
                 let config = format!("config{}{}.toml", i, n);
                 let result = panic::catch_unwind(|| {
-                    finalize_config(command, &config, i, n);
-                    compare_files(&config, command);
+                    finalize_config_with_validators_count(command, &config, i, n);
+                    compare_configs(&config, command);
                     run_node(&config, command);
                 });
 
@@ -275,8 +297,29 @@ fn test_generate_full_config_run() {
                 }
             }
         }
+
+        // Test with password.
+        // Can't move to a separate test because of environment variables race condition.
+        env::set_var(EXONUM_CONSENSUS_PASS, "some passphrase");
+        env::set_var(EXONUM_SERVICE_PASS, "another passphrase");
+
+        fs::create_dir_all(full_tmp_name("", command)).expect("Can't create temp folder");
+        copy_file_to_temp("consensus_with_password.toml", command);
+        copy_file_to_temp("service_with_password.toml", command);
+
+        let config = "config_with_password.toml";
+        finalize_config(
+            command,
+            config,
+            "config_with_password_sec.toml",
+            &["config_with_password_pub.toml"],
+        );
+        compare_configs(config, command);
+        run_node(&config, command);
     });
 
+    env::remove_var(EXONUM_CONSENSUS_PASS);
+    env::remove_var(EXONUM_SERVICE_PASS);
     fs::remove_dir_all(full_tmp_folder(command)).unwrap();
 
     if let Err(err) = result {
@@ -286,16 +329,16 @@ fn test_generate_full_config_run() {
 
 #[test]
 fn test_run_dev() {
-    let artifacts_dir = ".exonum";
+    let artifacts_dir = "run-dev";
     let db_dir = format!("{}/{}", artifacts_dir, "db");
     let full_db_dir = full_tmp_folder(&db_dir);
 
     // Mock existence of old DB files that are supposed to be cleaned up.
-    fs::create_dir_all(Path::new(&full_db_dir)).expect("Expected db temp folder to be created.");
+    fs::create_dir_all(Path::new(&full_db_dir)).expect("Expected db temp folder to be created");
     let old_db_file = full_tmp_name("1", &db_dir);
-    touch(&old_db_file);
 
     let result = panic::catch_unwind(|| {
+        touch(&old_db_file);
         run_dev(artifacts_dir);
 
         // Test cleaning up.
@@ -357,7 +400,7 @@ fn test_update_config() {
 
     ConfigManager::update_connect_list(connect_list.clone(), &config_path)
         .expect("Unable to update connect list");
-    let config: NodeConfig =
+    let config: NodeConfig<PathBuf> =
         ConfigFile::load(config_path.clone()).expect("Can't load node config file");
 
     let new_connect_list = config.connect_list;

--- a/exonum/tests/testdata/config/config02.toml
+++ b/exonum/tests/testdata/config/config02.toml
@@ -1,18 +1,18 @@
-consensus_public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-consensus_secret_key = "2a751e6595af66f7644bd33cf7710b6226cf8d0de4b3d18bc8fc2d80f19325a716ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+consensus_public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+consensus_secret_key = "consensus0.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
-service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+service_public_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
+service_secret_key = "service0.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -46,4 +46,4 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"

--- a/exonum/tests/testdata/config/config03.toml
+++ b/exonum/tests/testdata/config/config03.toml
@@ -1,21 +1,21 @@
-consensus_public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-consensus_secret_key = "2a751e6595af66f7644bd33cf7710b6226cf8d0de4b3d18bc8fc2d80f19325a716ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+consensus_public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+consensus_secret_key = "consensus0.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
-service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+service_public_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
+service_secret_key = "service0.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -49,8 +49,8 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"

--- a/exonum/tests/testdata/config/config04.toml
+++ b/exonum/tests/testdata/config/config04.toml
@@ -1,24 +1,24 @@
-consensus_public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-consensus_secret_key = "2a751e6595af66f7644bd33cf7710b6226cf8d0de4b3d18bc8fc2d80f19325a716ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+consensus_public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+consensus_secret_key = "consensus0.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
-service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+service_public_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
+service_secret_key = "service0.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+service_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
 [[genesis.validator_keys]]
-consensus_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-service_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -52,12 +52,12 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+public_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"

--- a/exonum/tests/testdata/config/config0_pub.toml
+++ b/exonum/tests/testdata/config/config0_pub.toml
@@ -19,5 +19,5 @@ address = "127.0.0.1:6333"
 [node.services_public_configs]
 
 [node.validator_keys]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"

--- a/exonum/tests/testdata/config/config0_sec.toml
+++ b/exonum/tests/testdata/config/config0_sec.toml
@@ -1,8 +1,8 @@
-consensus_public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-consensus_secret_key = "2a751e6595af66f7644bd33cf7710b6226cf8d0de4b3d18bc8fc2d80f19325a716ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+consensus_public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+consensus_secret_key = "consensus0.toml"
 listen_address = "0.0.0.0:6333"
 external_address = "127.0.0.1:6333"
-service_public_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
-service_secret_key = "18544ebbf3ceeeebca847fe6b4e6ce88f83fc92b6b0e24d5466f3cd08aea37bb523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+service_public_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
+service_secret_key = "service0.toml"
 
 [services_secret_configs]

--- a/exonum/tests/testdata/config/config12.toml
+++ b/exonum/tests/testdata/config/config12.toml
@@ -1,18 +1,18 @@
-consensus_public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-consensus_secret_key = "44ea40ec4dd4cf8baa3c2cc0d3537fd33d03880816964f049e4db16bded17d11924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+consensus_public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+consensus_secret_key = "consensus1.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
-service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+service_public_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
+service_secret_key = "service1.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -46,4 +46,4 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"

--- a/exonum/tests/testdata/config/config13.toml
+++ b/exonum/tests/testdata/config/config13.toml
@@ -1,21 +1,21 @@
-consensus_public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-consensus_secret_key = "44ea40ec4dd4cf8baa3c2cc0d3537fd33d03880816964f049e4db16bded17d11924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+consensus_public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+consensus_secret_key = "consensus1.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
-service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+service_public_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
+service_secret_key = "service1.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -49,8 +49,8 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"

--- a/exonum/tests/testdata/config/config14.toml
+++ b/exonum/tests/testdata/config/config14.toml
@@ -1,24 +1,24 @@
-consensus_public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-consensus_secret_key = "44ea40ec4dd4cf8baa3c2cc0d3537fd33d03880816964f049e4db16bded17d11924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+consensus_public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+consensus_secret_key = "consensus1.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
-service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+service_public_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
+service_secret_key = "service1.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+service_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
 [[genesis.validator_keys]]
-consensus_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-service_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -52,12 +52,12 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"

--- a/exonum/tests/testdata/config/config1_pub.toml
+++ b/exonum/tests/testdata/config/config1_pub.toml
@@ -19,5 +19,5 @@ address = "127.0.0.1:6333"
 [node.services_public_configs]
 
 [node.validator_keys]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"

--- a/exonum/tests/testdata/config/config1_sec.toml
+++ b/exonum/tests/testdata/config/config1_sec.toml
@@ -1,8 +1,8 @@
-consensus_public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-consensus_secret_key = "44ea40ec4dd4cf8baa3c2cc0d3537fd33d03880816964f049e4db16bded17d11924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+consensus_public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+consensus_secret_key = "consensus1.toml"
 listen_address = "0.0.0.0:6333"
 external_address = "127.0.0.1:6333"
-service_public_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
-service_secret_key = "4897e0ce97c47514a29bf37606622bbcb30550bbbd469ab059606865418456b27413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+service_public_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
+service_secret_key = "service1.toml"
 
 [services_secret_configs]

--- a/exonum/tests/testdata/config/config23.toml
+++ b/exonum/tests/testdata/config/config23.toml
@@ -1,21 +1,21 @@
-consensus_public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-consensus_secret_key = "56eec2297d556110623c77a83f449d1fde376af69e50d3316a0da87e15a45ef5648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+consensus_public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+consensus_secret_key = "consensus2.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
-service_secret_key = "6e9a000213c7e3698f50e8e9bef4773a89d39b2d940925e7b3a82280a58c68a6ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+service_public_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
+service_secret_key = "service2.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -49,8 +49,8 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"

--- a/exonum/tests/testdata/config/config24.toml
+++ b/exonum/tests/testdata/config/config24.toml
@@ -1,24 +1,24 @@
-consensus_public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-consensus_secret_key = "56eec2297d556110623c77a83f449d1fde376af69e50d3316a0da87e15a45ef5648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+consensus_public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+consensus_secret_key = "consensus2.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
-service_secret_key = "6e9a000213c7e3698f50e8e9bef4773a89d39b2d940925e7b3a82280a58c68a6ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+service_public_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
+service_secret_key = "service2.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+service_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
 [[genesis.validator_keys]]
-consensus_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-service_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -52,12 +52,12 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"

--- a/exonum/tests/testdata/config/config2_pub.toml
+++ b/exonum/tests/testdata/config/config2_pub.toml
@@ -19,5 +19,5 @@ address = "127.0.0.1:6333"
 [node.services_public_configs]
 
 [node.validator_keys]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"

--- a/exonum/tests/testdata/config/config2_sec.toml
+++ b/exonum/tests/testdata/config/config2_sec.toml
@@ -1,8 +1,8 @@
-consensus_public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-consensus_secret_key = "56eec2297d556110623c77a83f449d1fde376af69e50d3316a0da87e15a45ef5648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+consensus_public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+consensus_secret_key = "consensus2.toml"
 listen_address = "0.0.0.0:6333"
 external_address = "127.0.0.1:6333"
-service_public_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
-service_secret_key = "6e9a000213c7e3698f50e8e9bef4773a89d39b2d940925e7b3a82280a58c68a6ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+service_public_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
+service_secret_key = "service2.toml"
 
 [services_secret_configs]

--- a/exonum/tests/testdata/config/config34.toml
+++ b/exonum/tests/testdata/config/config34.toml
@@ -1,24 +1,24 @@
-consensus_public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-consensus_secret_key = "2ee145b26b65df4c8441f035bc3ae6ac3950e76c7f3e48d11a00b2c0ca26d75d41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+consensus_public_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+consensus_secret_key = "consensus3.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
-service_secret_key = "422acb782a4430c7dd982f73b88c29f03440248a010119410c7f522871919110066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+service_public_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
+service_secret_key = "service3.toml"
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
-service_key = "523ead8ea8457de570e165a512dd5d1b6688cb5757c3d744e03d1173f3e3e237"
+consensus_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+service_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
 [[genesis.validator_keys]]
-consensus_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-service_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
+service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
 [[genesis.validator_keys]]
-consensus_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
-service_key = "ed0c18a99cf373b0436376449da688e8150a93083d7b7ecdda3372e7bf70b80a"
+consensus_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
+service_key = "48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f"
 [[genesis.validator_keys]]
-consensus_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
-service_key = "7413a596e4fa0953cf22b120bd1ee0ba233bd1c619f10b21e6854b6b3cc9a6e9"
+consensus_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
+service_key = "b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa"
 
 [genesis.consensus]
 max_message_len = 1048576
@@ -52,12 +52,12 @@ create_if_missing = true
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"
 
 [[connect_list.peers]]
 address = "127.0.0.1:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"

--- a/exonum/tests/testdata/config/config3_sec.toml
+++ b/exonum/tests/testdata/config/config3_sec.toml
@@ -1,8 +1,8 @@
-consensus_public_key = "41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
-consensus_secret_key = "2ee145b26b65df4c8441f035bc3ae6ac3950e76c7f3e48d11a00b2c0ca26d75d41dd7940903ca3102c041222a4c51f9f7978499b082833c733c3b15165202f80"
+consensus_public_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
+consensus_secret_key = "consensus3.toml"
 listen_address = "0.0.0.0:6333"
 external_address = "127.0.0.1:6333"
-service_public_key = "066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
-service_secret_key = "422acb782a4430c7dd982f73b88c29f03440248a010119410c7f522871919110066f9874c7b32fca4c1ad4dacbe9bc9aa0de38b480d8c71ea05e5b3c70422152"
+service_public_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
+service_secret_key = "service3.toml"
 
 [services_secret_configs]

--- a/exonum/tests/testdata/config/config_domain.toml
+++ b/exonum/tests/testdata/config/config_domain.toml
@@ -1,11 +1,11 @@
 [[peers]]
 address = "127.0.0.1:6333"
-public_key = "16ef83ca4b231404daec6d07b24beb84d89c25944285d2e32a2dcf8f0f3eda72"
+public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
 
 [[peers]]
 address = "localhost:6333"
-public_key = "648e98a2405a40325d946bf8de6937795fe5c22ab095bca765a8b218e49ff5a3"
+public_key = "ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b"
 
 [[peers]]
 address = "exonum.com:6333"
-public_key = "924625eb77b9ad21e76713e7ada715945fbf0a926698832e121484c797fcc58e"
+public_key = "8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b"

--- a/exonum/tests/testdata/config/config_with_password.toml
+++ b/exonum/tests/testdata/config/config_with_password.toml
@@ -1,15 +1,16 @@
-consensus_public_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
-consensus_secret_key = "consensus0.toml"
+consensus_public_key = "36ffd90ed85f84b42be2377e5c01625f4e2644cdafd6cff5807853ace5a3734c"
+consensus_secret_key = "consensus_with_password.toml"
 external_address = "127.0.0.1:6333"
 listen_address = "0.0.0.0:6333"
-service_public_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
-service_secret_key = "service0.toml"
+service_public_key = "e1cf09efc8f275a04b69978bb721a40838253a2515eb1e8911c96379932be479"
+service_secret_key = "service_with_password.toml"
+
 
 [api]
 state_update_timeout = 10000
 [[genesis.validator_keys]]
-consensus_key = "72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d"
-service_key = "d2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c"
+consensus_key = "36ffd90ed85f84b42be2377e5c01625f4e2644cdafd6cff5807853ace5a3734c"
+service_key = "e1cf09efc8f275a04b69978bb721a40838253a2515eb1e8911c96379932be479"
 
 [genesis.consensus]
 max_message_len = 1048576

--- a/exonum/tests/testdata/config/config_with_password_pub.toml
+++ b/exonum/tests/testdata/config/config_with_password_pub.toml
@@ -19,5 +19,5 @@ address = "127.0.0.1:6333"
 [node.services_public_configs]
 
 [node.validator_keys]
-consensus_key = "620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188"
-service_key = "1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9"
+consensus_key = "36ffd90ed85f84b42be2377e5c01625f4e2644cdafd6cff5807853ace5a3734c"
+service_key = "e1cf09efc8f275a04b69978bb721a40838253a2515eb1e8911c96379932be479"

--- a/exonum/tests/testdata/config/config_with_password_sec.toml
+++ b/exonum/tests/testdata/config/config_with_password_sec.toml
@@ -1,0 +1,8 @@
+consensus_public_key = "36ffd90ed85f84b42be2377e5c01625f4e2644cdafd6cff5807853ace5a3734c"
+consensus_secret_key = "consensus_with_password.toml"
+listen_address = "0.0.0.0:6333"
+external_address = "127.0.0.1:6333"
+service_public_key = "e1cf09efc8f275a04b69978bb721a40838253a2515eb1e8911c96379932be479"
+service_secret_key = "service_with_password.toml"
+
+[services_secret_configs]

--- a/exonum/tests/testdata/config/consensus0.toml
+++ b/exonum/tests/testdata/config/consensus0.toml
@@ -1,0 +1,15 @@
+public_key = '72e49d4be54e29cfe89a98318a501be452a1daaf3e7b6cdd4f6c7006cc5d406d'
+
+[secret_key]
+ciphertext = 'd58ee12dc7c918b3ec89e84ec98865fd70442225592aa662a1ebad5b2763e5fe'
+mac = '481ff7f46b2fdefcabd708c116f3c4c0'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '4b78a943560b71b7173de5262bb313713cb70353b019ccf48b2970d184eed838'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '2d59b7fd16161136931fca254fb61811764bae5c08dc7d59'

--- a/exonum/tests/testdata/config/consensus1.toml
+++ b/exonum/tests/testdata/config/consensus1.toml
@@ -1,0 +1,15 @@
+public_key = '8b284e3a0c749d6fc69c995add66128b1bc9a319d5d2db42ba0049a2a1955b1b'
+
+[secret_key]
+ciphertext = '19dca8de47a047933d7085093a1dcfe6864831287e4ef8ba0ac4f0a22c21ff8d'
+mac = 'a4b7f561fd062bcd46ce004a0e9ec261'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '1baaff92c342f80ee4669b934ea6734a7ceb63a98ca7c22feeacd7cd820a4a9a'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '5b4f134aaadc52107cfcfa00b21acb0c5e5170d4b778f46b'

--- a/exonum/tests/testdata/config/consensus2.toml
+++ b/exonum/tests/testdata/config/consensus2.toml
@@ -1,0 +1,15 @@
+public_key = 'ac1276c51963c1c3e42d2ea88e062fe69fb5cd27225a01003c0edc2f749d5d0b'
+
+[secret_key]
+ciphertext = '8815da2a8127c7c4c33a31a5d42481739500b2dc0fc8b4c756468c303fd0486f'
+mac = '4d318c4b2231c9a0798839abe07b12b3'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '88368defd0aa0dacd86c05a5cfa7cdd52e708444a82e66288960b323b794d881'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'f75d6f3e3399b70eeb8dd0361b52747d2202586f1835a0a8'

--- a/exonum/tests/testdata/config/consensus3.toml
+++ b/exonum/tests/testdata/config/consensus3.toml
@@ -1,0 +1,15 @@
+public_key = '620fff1d2fb6d32af8d63e63c0891283da2fecb0b36cc60686f34778e71af188'
+
+[secret_key]
+ciphertext = '358455d319b44eec682e1f67fca9058d78c9cdb468c95b97848b3ddbb28cfbbd'
+mac = '37aa3ff02e4a70a55acd728546cd463b'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '6e4332b04333dd8c32ce59f0e72088715978480af3179a8dc987c373ae9d6b67'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'e0474569347bf3a1aff9c36b09b607185d87dbff924c48ca'

--- a/exonum/tests/testdata/config/consensus_with_password.toml
+++ b/exonum/tests/testdata/config/consensus_with_password.toml
@@ -1,0 +1,15 @@
+public_key = '36ffd90ed85f84b42be2377e5c01625f4e2644cdafd6cff5807853ace5a3734c'
+
+[secret_key]
+ciphertext = '3a0ce42cdd2e1cdc35c94eb1b533ed347fa000dea86160e0eb5aeea9e436c7c6'
+mac = '5e67a64e4eab59ced1f871250d9b211e'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = 'a36d1b80ad9c2949f27f640a0978fba590f2b667db85244d257c35a1a298086d'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'e83c0116b3e3d4b9e5e77a95cebeefea6ebc87228ef4c7b0'

--- a/exonum/tests/testdata/config/service0.toml
+++ b/exonum/tests/testdata/config/service0.toml
@@ -1,0 +1,15 @@
+public_key = 'd2688e531673818c3f6aad90115a1a604ea52861dbc97582573756a9f8720c2c'
+
+[secret_key]
+ciphertext = '0713b2efbaa172e064a434daff2d6426a462ad6dcf350fec2b080a25fac6cb9c'
+mac = 'ce746be75f9d3b13380b2c1fc4b299d8'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '198896a8c864953261f56368019a2349e0d574d7a90b3fd531a5500eb4beeb94'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'de7ef9cec9c1a2bb3b2fec390a62aa0d850c273b26db549d'

--- a/exonum/tests/testdata/config/service1.toml
+++ b/exonum/tests/testdata/config/service1.toml
@@ -1,0 +1,15 @@
+public_key = '48799487c3acdb515608b42966803f64b7eef7b3c0260b1c8cf20bcd3fcd6b1f'
+
+[secret_key]
+ciphertext = '4cf6d96ae67f7398ae4ea98029c4843bcd0a8f263928f3825a59e171c564d196'
+mac = 'd534881ff3394fc00aaf924023f5390b'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '27f8317db43e2f06492feb868712cd35bc48ec8a15223cc927b0cc2213d71f76'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'f6994f033515fb41d85155d8ab5d3b01f4d2d105da9e8560'

--- a/exonum/tests/testdata/config/service2.toml
+++ b/exonum/tests/testdata/config/service2.toml
@@ -1,0 +1,15 @@
+public_key = 'b70aa38520ce0ca60fcade9446f3e884a297b187b07eafc1226f0876aba004fa'
+
+[secret_key]
+ciphertext = '8ee20cbdfac22a6a3f140220f9f3d2e59bf9f125ba11649db5ad67d1c26f476b'
+mac = '5eef55e409a49a46315e923a5492e3e6'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '21b9001a964c20a82fea3bcb53632dd174fa3d7e44d64e4536d52122cdfd3485'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '1bb04ebf4131e1b62779d83a26282d5fc8ee1077e7c84681'

--- a/exonum/tests/testdata/config/service3.toml
+++ b/exonum/tests/testdata/config/service3.toml
@@ -1,0 +1,15 @@
+public_key = '1d42b689ed938bfd31d20f0b8c5d79219df10babb61fe837708979534dcaa4b9'
+
+[secret_key]
+ciphertext = 'a37f7cf6e1c92045a811eb1f0f80f6d032efb0496ba39dc3b21f1a47e57476fc'
+mac = '549bc62bd7bf1a4125fc69028a9c6374'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = '4028a2aff9560728f6f6d9a781cd024659b32b9929cc26c2b1f8b7eda52124b1'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = '3d33d4f0bccb7b1b034e68483c72c2e583b0529381244bf6'

--- a/exonum/tests/testdata/config/service_with_password.toml
+++ b/exonum/tests/testdata/config/service_with_password.toml
@@ -1,0 +1,15 @@
+public_key = 'e1cf09efc8f275a04b69978bb721a40838253a2515eb1e8911c96379932be479'
+
+[secret_key]
+ciphertext = 'd451b5dabcc1ee080e5a781c68b6c873751b0b1dd5cc95cf38231862def947ff'
+mac = '42590a125b0175140e8ee16d047420c6'
+kdf = 'scrypt-nacl'
+cipher = 'xsalsa20-poly1305'
+
+[secret_key.kdfparams]
+salt = 'f7277164f73a22e51f09d61fbc9c5a86ba51fc29e5f18ed9cfa57365bdff3ab7'
+memlimit = 16777216
+opslimit = 524288
+
+[secret_key.cipherparams]
+iv = 'a7d082db34298b275e36961f878e18c6db4ab0e199cd999b'

--- a/services/configuration/src/cmd.rs
+++ b/services/configuration/src/cmd.rs
@@ -82,7 +82,7 @@ impl CommandExtension for Finalize {
     }
 
     fn execute(&self, mut context: Context) -> Result<Context, failure::Error> {
-        let mut node_config: NodeConfig = context.get(keys::NODE_CONFIG).unwrap();
+        let mut node_config = context.get(keys::NODE_CONFIG).unwrap();
         let common_config = context.get(keys::COMMON_CONFIG).unwrap();
 
         // Local config section


### PR DESCRIPTION
## Overview

This PR changes the way we store secret keys for our nodes. CLI has been updated for these changes as well.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See:
- https://jira.bf.local/browse/ECR-2518
- https://jira.bf.local/browse/ECR-2519
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
