### PR TITLE
Remove ring dependency(fix lazy_static)

### DIFF
--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -20,7 +20,7 @@ circle-ci = { repository = "exonum/exonum" }
 [dependencies]
 actix = "=0.7.9"
 actix-net = "=0.2.6"
-actix-web = "=0.7.17"
+actix-web = { version = "=0.7.17", default-features = false }
 log = "=0.4.6"
 byteorder = "1.2.3"
 hex = "=0.3.2"

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-actix-web = "=0.7.17"
+actix-web = { version = "=0.7.17", default-features = false }
 exonum = { version = "0.10.1", path = "../exonum" }
 failure = "0.1.5"
 futures = "=0.1.25"


### PR DESCRIPTION
## Overview

Criterion and ring dependency are not compatible(because of their lazy_static). 
We depend on ring through actix-web default feature.
This PR removes actix-web default features.

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
