### PR TITLE
Added feature i128 to byteorder crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ rust:
   - 1.31.1
 
 cache:
+  timeout: 1000
   directories:
   - node_modules
   - $HOME/.cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## 0.10.2 - 2019-01-14
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.10.2 - 2019-01-14
 
-### Internal Improvements
+### New Features
 
 #### exonum
 

--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography", "hashing"]
 description = "Cryptography related types, constants, traits and functions."
 
 [dependencies]
-byteorder = "1.2.3"
+byteorder = { version = "1.2.7", features = [ "i128" ] }
 chrono = "=0.4.6"
 hex = "=0.3.2"
 hex-buffer-serde = "=0.1.1"

--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum-crypto"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/examples/cryptocurrency-advanced/backend/Cargo.toml
+++ b/examples/cryptocurrency-advanced/backend/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-exonum = { version = "0.10.1", path = "../../../exonum" }
+exonum = { version = "0.10.2", path = "../../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../../components/derive" }
 exonum-configuration = { version = "0.10.0", path = "../../../services/configuration" }
 serde = "1.0.0"
@@ -24,7 +24,7 @@ failure = "0.1.5"
 protobuf = "2.2.0"
 
 [dev-dependencies]
-exonum-testkit = { version = "0.10.0", path = "../../../testkit" }
+exonum-testkit = { version = "0.10.1", path = "../../../testkit" }
 serde_json = "1.0.0"
 pretty_assertions = "=0.5.1"
 assert_matches = "1.2.0"

--- a/examples/cryptocurrency-advanced/backend/Cargo.toml
+++ b/examples/cryptocurrency-advanced/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum-cryptocurrency-advanced"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"
@@ -17,7 +17,7 @@ circle-ci = { repository = "exonum/exonum" }
 [dependencies]
 exonum = { version = "0.10.2", path = "../../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../../components/derive" }
-exonum-configuration = { version = "0.10.0", path = "../../../services/configuration" }
+exonum-configuration = { version = "0.10.1", path = "../../../services/configuration" }
 serde = "1.0.0"
 serde_derive = "1.0.0"
 failure = "0.1.5"

--- a/examples/cryptocurrency/Cargo.toml
+++ b/examples/cryptocurrency/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-exonum = { version = "0.10.1", path = "../../exonum" }
+exonum = { version = "0.10.2", path = "../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../components/derive" }
 failure = "0.1.5"
 serde = "1.0.0"
@@ -26,7 +26,7 @@ serde_json = "1.0.0"
 protobuf = "2.2.0"
 
 [dev-dependencies]
-exonum-testkit = { version = "0.10.0", path = "../../testkit" }
+exonum-testkit = { version = "0.10.1", path = "../../testkit" }
 rand = "=0.6.4"
 pretty_assertions = "=0.5.1"
 assert_matches = "1.2.0"

--- a/examples/timestamping/backend/Cargo.toml
+++ b/examples/timestamping/backend/Cargo.toml
@@ -14,7 +14,7 @@ circle-ci = { repository = "exonum/exonum" }
 [dependencies]
 exonum = { version = "0.10.2", path = "../../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../../components/derive" }
-exonum-configuration = { version = "0.10.0", path = "../../../services/configuration" }
+exonum-configuration = { version = "0.10.1", path = "../../../services/configuration" }
 exonum-time = { version = "0.10.0", path = "../../../services/time" }
 serde = "1.0.10"
 serde_derive = "1.0.10"

--- a/examples/timestamping/backend/Cargo.toml
+++ b/examples/timestamping/backend/Cargo.toml
@@ -12,7 +12,7 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-exonum = { version = "0.10.1", path = "../../../exonum" }
+exonum = { version = "0.10.2", path = "../../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../../components/derive" }
 exonum-configuration = { version = "0.10.0", path = "../../../services/configuration" }
 exonum-time = { version = "0.10.0", path = "../../../services/time" }
@@ -25,7 +25,7 @@ chrono = { version = "=0.4.6", features = ["serde"] }
 protobuf = "2.2.0"
 
 [dev-dependencies]
-exonum-testkit = { version = "0.10.0", path = "../../../testkit" }
+exonum-testkit = { version = "0.10.1", path = "../../../testkit" }
 pretty_assertions = "=0.5.1"
 
 [build-dependencies]

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -56,7 +56,7 @@ ctrlc = "3.1.1"
 
 exonum_rocksdb = "0.7.4"
 exonum_sodiumoxide = { version = "0.0.20", optional = true }
-exonum-crypto = { version = "0.10.2", path = "../components/crypto" }
+exonum-crypto = { version = "0.10.3", path = "../components/crypto" }
 exonum-derive = { version = "0.10.0", path = "../components/derive" }
 
 [dev-dependencies]

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -22,7 +22,7 @@ actix = "=0.7.9"
 actix-net = "=0.2.6"
 actix-web = { version = "=0.7.17", default-features = false }
 log = "=0.4.6"
-byteorder = "1.2.3"
+byteorder = { version = "1.2.7", features = [ "i128" ] }
 hex = "=0.3.2"
 bit-vec = "=0.5.0"
 rand = "=0.6.4"

--- a/services/configuration/Cargo.toml
+++ b/services/configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum-configuration"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/doc/advanced/configuration-updater/"
 repository = "https://github.com/exonum/exonum"

--- a/services/configuration/Cargo.toml
+++ b/services/configuration/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "exonum/exonum" }
 [dependencies]
 clap = "2.30.0"
 env_logger = "=0.6.0"
-exonum = { version = "0.10.1", path = "../../exonum" }
+exonum = { version = "0.10.2", path = "../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../components/derive" }
 failure = "0.1.5"
 lazy_static = "1.0.0"
@@ -31,7 +31,7 @@ toml = "=0.4.10"
 protobuf = "2.2.0"
 
 [dev-dependencies]
-exonum-testkit = { version = "0.10.0", path = "../../testkit" }
+exonum-testkit = { version = "0.10.1", path = "../../testkit" }
 pretty_assertions = "=0.5.1"
 assert_matches = "1.2.0"
 

--- a/services/time/Cargo.toml
+++ b/services/time/Cargo.toml
@@ -17,7 +17,7 @@ circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
 chrono = { version = "=0.4.6", features = ["serde"] }
-exonum = { version = "0.10.1", path = "../../exonum" }
+exonum = { version = "0.10.2", path = "../../exonum" }
 exonum-derive = { version = "0.10.0", path = "../../components/derive" }
 failure = "0.1.5"
 serde = "1.0.10"
@@ -26,7 +26,7 @@ serde_json = "1.0.2"
 protobuf = "2.2.0"
 
 [dev-dependencies]
-exonum-testkit = { version = "0.10.0", path = "../../testkit" }
+exonum-testkit = { version = "0.10.1", path = "../../testkit" }
 pretty_assertions = "=0.5.1"
 
 [build-dependencies]

--- a/services/time/Cargo.toml
+++ b/services/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum-time"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exonum-testkit"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"
@@ -20,7 +20,7 @@ circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
 actix-web = { version = "=0.7.17", default-features = false }
-exonum = { version = "0.10.1", path = "../exonum" }
+exonum = { version = "0.10.2", path = "../exonum" }
 failure = "0.1.5"
 futures = "=0.1.25"
 reqwest = "=0.9.5"

--- a/testkit/server/Cargo.toml
+++ b/testkit/server/Cargo.toml
@@ -17,6 +17,6 @@ travis-ci = { repository = "exonum/exonum" }
 circle-ci = { repository = "exonum/exonum" }
 
 [dependencies]
-exonum = { version = "0.10.1", path = "../../exonum" }
-exonum-testkit = { version = "0.10.0", path = ".." }
+exonum = { version = "0.10.2", path = "../../exonum" }
+exonum-testkit = { version = "0.10.1", path = ".." }
 exonum-cryptocurrency = { version = "0.0.0", path = "../../examples/cryptocurrency" }


### PR DESCRIPTION
## Overview

Added feature `i128` to `byteorder` crate to include `LittleEndian::write_i128` and  `LittleEndian::write_u128` functions.

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions