### PR TITLE
Update to Rust 2018 edition [ECR-2816]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Internal improvements
 
 - All Exonum crates have been updated to Rust 2018 edition. This means that
-  we require at least Rust 1.31 for compilation. (#1230)
+  it is required to use Rust 1.31 or newer for compilation. (#1230)
 
 #### exonum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Internal improvements
 
+- All Exonum crates have been updated to Rust 2018 edition. This means that
+  we require at least Rust 1.31 for compilation. (#1230)
+
 #### exonum
 
 - Added `allow-origin` for `localhost` for public and private api in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ but we have several additional conventions:
 
 - Use [Rust 2018 edition].
 
-  * Avoid `extern crate` unless it is required.
+  - Avoid `extern crate` unless it is required.
 
-  * Avoid `mod.rs` files, simply use directories for nested modules.
+  - Avoid `mod.rs` files, simply use directories for nested modules.
 
 - Prefer [nested imports] whenever possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Notice that the repository uses a set of linters for static analysis:
 - [clippy]
 - [cargo audit]
 - [cargo-deadlinks]
-- [rustfmt 0.9.0]
+- [rustfmt]
 - [cspell]
 - [markdownlint-cli]
 
@@ -105,7 +105,7 @@ but we have several additional conventions:
 [clippy]: https://github.com/rust-lang-nursery/rust-clippy
 [cargo audit]: https://github.com/RustSec/cargo-audit
 [cargo-deadlinks]: https://github.com/deadlinks/cargo-deadlinks
-[rustfmt 0.9.0]: https://github.com/rust-lang-nursery/rustfmt
+[rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 [cspell]: https://github.com/Jason3S/cspell
 [markdownlint-cli]: https://github.com/igorshubovych/markdownlint-cli
 [Travis script]: .travis.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,20 @@ but we have several additional conventions:
   Public method should be documented, but meaningful parameter names are also
   helpful for better understanding.
 
+- Use [Rust 2018 edition].
+
+  * Avoid `extern crate` unless it is required.
+
+  * Avoid `mod.rs` files, simply use directories for nested modules.
+
 - Prefer [nested imports] whenever possible.
 
 - Don't try to minimize imports scope (for example don't put it inside a
   function), place them at the beginning of the file.
 
-- Avoid leading `::` in the type names (for example `::std::path::Path`),
-  instead import a type and use a shorter form:
+- Prefer importing a type name instead of using fully-qualified names.
+  For example, avoid writing `std::path::Path` in code, instead import
+  a type and use a shorter form:
 
   ```rust
   // Import type:
@@ -78,7 +85,7 @@ but we have several additional conventions:
 
 - Modules and imports (`use`) should be in the following order:
 
-  - `extern crate`s.
+  - `extern crate`s (if you really need them).
   - Reexporting (`pub use`).
   - Public modules (`pub mod`).
   - Imports (`use`):
@@ -103,3 +110,4 @@ but we have several additional conventions:
 [markdownlint-cli]: https://github.com/igorshubovych/markdownlint-cli
 [Travis script]: .travis.yml
 [nested imports]: http://rust-lang.github.io/rfcs/2128-use-nested-groups.html
+[Rust 2018 edition]: https://rust-lang-nursery.github.io/edition-guide/rust-2018/index.html

--- a/components/build/Cargo.toml
+++ b/components/build/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-build"
 version = "0.10.0"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/components/build/src/lib.rs
+++ b/components/build/src/lib.rs
@@ -16,9 +16,6 @@
 
 //! This crate simplifies writing build.rs for exonum and exonum services.
 
-extern crate protoc_rust;
-extern crate walkdir;
-
 use protoc_rust::Customize;
 use walkdir::WalkDir;
 

--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-crypto"
 version = "0.10.3"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/components/crypto/src/crypto_lib/sodiumoxide/mod.rs
+++ b/components/crypto/src/crypto_lib/sodiumoxide/mod.rs
@@ -29,7 +29,7 @@
 
 // spell-checker:ignore DIGESTBYTES, PUBLICKEYBYTES, SECRETKEYBYTES, SEEDBYTES, SIGNATUREBYTES
 
-extern crate exonum_sodiumoxide as sodiumoxide;
+use exonum_sodiumoxide as sodiumoxide;
 
 /// Digest type for sodiumoxide-based implementation.
 pub use self::sha256::Digest as Hash;

--- a/components/crypto/src/crypto_lib/sodiumoxide/x25519.rs
+++ b/components/crypto/src/crypto_lib/sodiumoxide/x25519.rs
@@ -29,9 +29,7 @@ use super::sodiumoxide::crypto::{
         PublicKey as PublicKeySodium, SecretKey as SecretKeySodium,
     },
 };
-use write_short_hex;
-use PublicKey as crypto_PublicKey;
-use SecretKey as crypto_SecretKey;
+use crate::{write_short_hex, PublicKey as crypto_PublicKey, SecretKey as crypto_SecretKey};
 
 /// Length of the public Curve25519 key.
 pub const PUBLIC_KEY_LENGTH: usize = 32;

--- a/components/crypto/src/lib.rs
+++ b/components/crypto/src/lib.rs
@@ -20,19 +20,8 @@
 //! cryptography applied in the system and add abstractions best
 //! suited for Exonum.
 
-extern crate byteorder;
-extern crate chrono;
-extern crate hex;
-extern crate hex_buffer_serde;
-extern crate pwbox;
-extern crate rand;
-extern crate rust_decimal;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
-extern crate toml;
-extern crate uuid;
 
 #[doc(inline)]
 pub use self::crypto_impl::{
@@ -687,7 +676,6 @@ mod tests {
     use super::*;
 
     use serde::de::DeserializeOwned;
-    use serde_json;
 
     use hex::FromHex;
 

--- a/components/crypto/src/utils.rs
+++ b/components/crypto/src/utils.rs
@@ -26,7 +26,6 @@ use std::{
     io::{Error, ErrorKind, Read, Write},
     path::Path,
 };
-use toml;
 
 /// Creates a TOML file that contains encrypted `SecretKey` and returns `PublicKey` for the secret key.
 pub fn generate_keys_file<P: AsRef<Path>, W: AsRef<[u8]>>(
@@ -141,11 +140,8 @@ impl EncryptedKeys {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
-
-    use self::tempdir::TempDir;
     use super::*;
-    use toml;
+    use tempdir::TempDir;
 
     #[test]
     fn test_create_and_read_keys_file() {

--- a/components/derive/Cargo.toml
+++ b/components/derive/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-derive"
 version = "0.10.0"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -15,16 +15,12 @@
 #![recursion_limit = "256"]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-
-extern crate syn;
-#[macro_use]
-extern crate quote;
 
 mod pb_convert;
 mod tx_set;
 
 use proc_macro::TokenStream;
+use quote::quote;
 use syn::{Attribute, Lit, Meta, MetaList, MetaNameValue, NestedMeta, Path};
 
 // Exonum derive attribute names, used as

--- a/components/derive/src/pb_convert.rs
+++ b/components/derive/src/pb_convert.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use proc_macro::TokenStream;
-use proc_macro2::{self, Ident, Span};
+use proc_macro2::{Ident, Span};
+use quote::quote;
 use syn::{Attribute, Data, DeriveInput, Lit, Path};
 
 use super::{
@@ -96,7 +97,7 @@ fn implement_protobuf_convert_trait(
     }
 }
 
-fn implement_binary_form(name: &Ident, cr: &quote::ToTokens) -> impl quote::ToTokens {
+fn implement_binary_form(name: &Ident, cr: &dyn quote::ToTokens) -> impl quote::ToTokens {
     quote! {
         impl #cr::messages::BinaryForm for #name {
 
@@ -113,7 +114,7 @@ fn implement_binary_form(name: &Ident, cr: &quote::ToTokens) -> impl quote::ToTo
     }
 }
 
-fn implement_storage_traits(name: &Ident, cr: &quote::ToTokens) -> impl quote::ToTokens {
+fn implement_storage_traits(name: &Ident, cr: &dyn quote::ToTokens) -> impl quote::ToTokens {
     quote! {
         impl #cr::crypto::CryptoHash for #name {
             fn hash(&self) -> #cr::crypto::Hash {

--- a/components/derive/src/tx_set.rs
+++ b/components/derive/src/tx_set.rs
@@ -14,6 +14,7 @@
 
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
+use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Fields, Type};
 
 struct Variant {
@@ -51,7 +52,7 @@ fn get_tx_variants(data: &DataEnum) -> Vec<Variant> {
 fn implement_conversions_for_transactions(
     name: &Ident,
     variants: &[Variant],
-    cr: &quote::ToTokens,
+    cr: &dyn quote::ToTokens,
 ) -> impl quote::ToTokens {
     let conversions = variants.iter().map(|Variant { ident, typ, .. }| {
         quote! {
@@ -78,7 +79,7 @@ fn implement_conversions_for_transactions(
 fn implement_into_service_tx(
     name: &Ident,
     variants: &[Variant],
-    cr: &quote::ToTokens,
+    cr: &dyn quote::ToTokens,
 ) -> impl quote::ToTokens {
     let tx_set_impl = variants.iter().map(|Variant { id, ident, .. }| {
         quote! {
@@ -101,7 +102,7 @@ fn implement_into_service_tx(
 fn implement_transaction_set_trait(
     name: &Ident,
     variants: &[Variant],
-    cr: &quote::ToTokens,
+    cr: &dyn quote::ToTokens,
 ) -> impl quote::ToTokens {
     let tx_set_impl = variants.iter().map(|Variant { id, ident, typ }| {
         quote! {
@@ -127,7 +128,7 @@ fn implement_transaction_set_trait(
 fn implement_into_boxed_tx(
     name: &Ident,
     variants: &[Variant],
-    cr: &quote::ToTokens,
+    cr: &dyn quote::ToTokens,
 ) -> impl quote::ToTokens {
     let tx_set_impl = variants.iter().map(|Variant { ident, .. }| {
         quote! {

--- a/examples/cryptocurrency-advanced/backend/Cargo.toml
+++ b/examples/cryptocurrency-advanced/backend/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-cryptocurrency-advanced"
 version = "0.10.1"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/examples/cryptocurrency-advanced/backend/build.rs
+++ b/examples/cryptocurrency-advanced/backend/build.rs
@@ -1,5 +1,3 @@
-extern crate exonum_build;
-
 use exonum_build::{get_exonum_protobuf_files_path, protobuf_generate};
 
 fn main() {

--- a/examples/cryptocurrency-advanced/backend/src/api.rs
+++ b/examples/cryptocurrency-advanced/backend/src/api.rs
@@ -23,8 +23,7 @@ use exonum::{
     storage::{ListProof, MapProof},
 };
 
-use wallet::Wallet;
-use {Schema, CRYPTOCURRENCY_SERVICE_ID};
+use crate::{wallet::Wallet, Schema, CRYPTOCURRENCY_SERVICE_ID};
 
 /// Describes the query parameters for the `get_wallet` endpoint.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/examples/cryptocurrency-advanced/backend/src/lib.rs
+++ b/examples/cryptocurrency-advanced/backend/src/lib.rs
@@ -21,17 +21,14 @@
     bare_trait_objects
 )]
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
-extern crate protobuf;
 #[macro_use]
 extern crate failure;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-pub use schema::Schema;
+pub use crate::schema::Schema;
 
 pub mod api;
 pub mod proto;
@@ -48,7 +45,7 @@ use exonum::{
     storage::Snapshot,
 };
 
-use transactions::WalletTransactions;
+use crate::transactions::WalletTransactions;
 
 /// Unique service ID.
 const CRYPTOCURRENCY_SERVICE_ID: u16 = 128;

--- a/examples/cryptocurrency-advanced/backend/src/main.rs
+++ b/examples/cryptocurrency-advanced/backend/src/main.rs
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_configuration;
-extern crate exonum_cryptocurrency_advanced;
-
-use exonum::helpers::{self, fabric::NodeBuilder};
+use exonum::helpers::fabric::NodeBuilder;
 use exonum_configuration as configuration;
 use exonum_cryptocurrency_advanced as cryptocurrency;
 
 fn main() {
     exonum::crypto::init();
-    helpers::init_logger().unwrap();
+    exonum::helpers::init_logger().unwrap();
 
     let node = NodeBuilder::new()
         .with_service(Box::new(configuration::ServiceFactory))

--- a/examples/cryptocurrency-advanced/backend/src/schema.rs
+++ b/examples/cryptocurrency-advanced/backend/src/schema.rs
@@ -19,8 +19,7 @@ use exonum::{
     storage::{Fork, ProofListIndex, ProofMapIndex, Snapshot},
 };
 
-use wallet::Wallet;
-use INITIAL_BALANCE;
+use crate::{wallet::Wallet, INITIAL_BALANCE};
 
 /// Database schema for the cryptocurrency.
 #[derive(Debug)]

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -25,8 +25,7 @@ use exonum::{
 };
 
 use super::proto;
-use schema::Schema;
-use CRYPTOCURRENCY_SERVICE_ID;
+use crate::{schema::Schema, CRYPTOCURRENCY_SERVICE_ID};
 
 const ERROR_SENDER_SAME_AS_RECEIVER: u8 = 0;
 

--- a/examples/cryptocurrency-advanced/backend/tests/api.rs
+++ b/examples/cryptocurrency-advanced/backend/tests/api.rs
@@ -18,9 +18,6 @@
 //! Note how API tests predominantly use `TestKitApi` to send transactions and make assertions
 //! about the storage state.
 
-extern crate exonum;
-extern crate exonum_cryptocurrency_advanced as cryptocurrency;
-extern crate exonum_testkit;
 #[macro_use]
 extern crate serde_json;
 
@@ -32,7 +29,7 @@ use exonum::{
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.
-use cryptocurrency::{
+use exonum_cryptocurrency_advanced::{
     api::{WalletInfo, WalletQuery},
     transactions::{CreateWallet, Transfer},
     wallet::Wallet,
@@ -40,7 +37,7 @@ use cryptocurrency::{
 };
 
 // Imports shared test constants.
-use constants::{ALICE_NAME, BOB_NAME};
+use crate::constants::{ALICE_NAME, BOB_NAME};
 
 mod constants;
 

--- a/examples/cryptocurrency/Cargo.toml
+++ b/examples/cryptocurrency/Cargo.toml
@@ -2,6 +2,7 @@
 name = "exonum-cryptocurrency"
 publish = false
 version = "0.0.0"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/examples/cryptocurrency/examples/demo.rs
+++ b/examples/cryptocurrency/examples/demo.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_cryptocurrency as cryptocurrency;
-
-use exonum::blockchain::{GenesisConfig, ValidatorKeys};
-use exonum::node::{Node, NodeApiConfig, NodeConfig};
-use exonum::storage::MemoryDB;
-
-use cryptocurrency::service::CurrencyService;
+use exonum::{
+    blockchain::{GenesisConfig, ValidatorKeys},
+    node::{Node, NodeApiConfig, NodeConfig},
+    storage::MemoryDB,
+};
+use exonum_cryptocurrency::service::CurrencyService;
 
 fn node_config() -> NodeConfig {
     let (consensus_public_key, consensus_secret_key) = exonum::crypto::gen_keypair();

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -30,16 +30,12 @@
     bare_trait_objects
 )]
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
 extern crate failure;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate protobuf;
-extern crate serde_json;
 
 pub mod proto;
 
@@ -268,9 +264,11 @@ pub mod errors {
 pub mod contracts {
     use exonum::blockchain::{ExecutionResult, Transaction, TransactionContext};
 
-    use errors::Error;
-    use schema::{CurrencySchema, Wallet};
-    use transactions::{TxCreateWallet, TxTransfer};
+    use crate::{
+        errors::Error,
+        schema::{CurrencySchema, Wallet},
+        transactions::{TxCreateWallet, TxTransfer},
+    };
 
     /// Initial balance of a newly created wallet.
     const INIT_BALANCE: u64 = 100;
@@ -344,7 +342,7 @@ pub mod api {
         crypto::PublicKey,
     };
 
-    use schema::{CurrencySchema, Wallet};
+    use crate::schema::{CurrencySchema, Wallet};
 
     /// Public service API description.
     #[derive(Debug, Clone)]
@@ -398,8 +396,7 @@ pub mod service {
         storage::Snapshot,
     };
 
-    use api::CryptocurrencyApi;
-    use transactions::CurrencyTransactions;
+    use crate::{api::CryptocurrencyApi, transactions::CurrencyTransactions};
 
     /// Service ID for the `Service` trait.
     pub const SERVICE_ID: u16 = 1;

--- a/examples/cryptocurrency/tests/api.rs
+++ b/examples/cryptocurrency/tests/api.rs
@@ -20,9 +20,6 @@
 
 #[macro_use]
 extern crate assert_matches;
-extern crate exonum;
-extern crate exonum_cryptocurrency as cryptocurrency;
-extern crate exonum_testkit;
 #[macro_use]
 extern crate serde_json;
 
@@ -34,13 +31,15 @@ use exonum::{
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.
-use cryptocurrency::api::WalletQuery;
-use cryptocurrency::schema::Wallet;
-use cryptocurrency::service::CurrencyService;
-use cryptocurrency::transactions::{TxCreateWallet, TxTransfer};
+use exonum_cryptocurrency::{
+    api::WalletQuery,
+    schema::Wallet,
+    service::CurrencyService,
+    transactions::{TxCreateWallet, TxTransfer},
+};
 
 // Imports shared test constants.
-use constants::{ALICE_NAME, BOB_NAME};
+use crate::constants::{ALICE_NAME, BOB_NAME};
 
 mod constants;
 

--- a/examples/cryptocurrency/tests/tx_logic.rs
+++ b/examples/cryptocurrency/tests/tx_logic.rs
@@ -18,11 +18,8 @@
 //! Note how business logic tests use `TestKit::create_block*` methods to send transactions,
 //! the service schema to make assertions about the storage state.
 
-extern crate exonum;
-extern crate exonum_cryptocurrency as cryptocurrency;
 #[macro_use]
 extern crate exonum_testkit;
-extern crate rand;
 
 use exonum::{
     crypto::{self, PublicKey, SecretKey},
@@ -31,14 +28,14 @@ use exonum::{
 use exonum_testkit::{TestKit, TestKitBuilder};
 
 // Import data types used in tests from the crate where the service is defined.
-use cryptocurrency::{
+use exonum_cryptocurrency::{
     schema::{CurrencySchema, Wallet},
     service::CurrencyService,
     transactions::{TxCreateWallet, TxTransfer},
 };
 
 // Imports shared test constants.
-use constants::{ALICE_NAME, BOB_NAME};
+use crate::constants::{ALICE_NAME, BOB_NAME};
 
 mod constants;
 

--- a/examples/timestamping/backend/Cargo.toml
+++ b/examples/timestamping/backend/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-timestamping"
 version = "0.0.0"
+edition = "2018"
 publish = false
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 repository = "https://github.com/exonum/exonum"

--- a/examples/timestamping/backend/src/api.rs
+++ b/examples/timestamping/backend/src/api.rs
@@ -21,8 +21,10 @@ use exonum::{
     storage::MapProof,
 };
 
-use schema::{Schema, TimestampEntry};
-use TIMESTAMPING_SERVICE;
+use crate::{
+    schema::{Schema, TimestampEntry},
+    TIMESTAMPING_SERVICE,
+};
 
 /// Describes query parameters for `handle_timestamp` and `handle_timestamp_proof` endpoints.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/examples/timestamping/backend/src/lib.rs
+++ b/examples/timestamping/backend/src/lib.rs
@@ -23,20 +23,14 @@
     bare_trait_objects
 )]
 
-extern crate chrono;
-extern crate exonum;
-extern crate exonum_time;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate log;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate protobuf;
-extern crate serde_json;
 
 pub mod api;
 pub mod proto;
@@ -52,9 +46,7 @@ use exonum::{
     storage::Snapshot,
 };
 
-use api::PublicApi;
-use schema::Schema;
-use transactions::TimeTransactions;
+use crate::{api::PublicApi, schema::Schema, transactions::TimeTransactions};
 
 const TIMESTAMPING_SERVICE: u16 = 130;
 const SERVICE_NAME: &str = "timestamping";

--- a/examples/timestamping/backend/src/main.rs
+++ b/examples/timestamping/backend/src/main.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_configuration;
-extern crate exonum_time;
-
-extern crate exonum_timestamping;
-
 use exonum::helpers::fabric::NodeBuilder;
 
 fn main() {

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -26,8 +26,10 @@ use exonum::{
 use exonum_time::schema::TimeSchema;
 
 use super::proto;
-use schema::{Schema, Timestamp, TimestampEntry};
-use TIMESTAMPING_SERVICE;
+use crate::{
+    schema::{Schema, Timestamp, TimestampEntry},
+    TIMESTAMPING_SERVICE,
+};
 
 /// Error codes emitted by wallet transactions during execution.
 #[derive(Debug, Fail)]

--- a/examples/timestamping/backend/tests/api.rs
+++ b/examples/timestamping/backend/tests/api.rs
@@ -14,13 +14,8 @@
 
 #[macro_use]
 extern crate serde_json;
-
 #[macro_use]
 extern crate exonum_testkit;
-
-extern crate exonum;
-extern crate exonum_time;
-extern crate exonum_timestamping;
 
 use exonum::{
     api::node::public::explorer::{TransactionQuery, TransactionResponse},

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum"
 version = "0.10.2"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -77,7 +77,7 @@ fn create_rocksdb(tempdir: &TempDir) -> RocksDB {
     RocksDB::open(tempdir.path(), &options).unwrap()
 }
 
-fn create_blockchain(db: impl Database, services: Vec<Box<Service>>) -> Blockchain {
+fn create_blockchain(db: impl Database, services: Vec<Box<dyn Service>>) -> Blockchain {
     use exonum::{
         blockchain::{GenesisConfig, ValidatorKeys},
         crypto,
@@ -132,7 +132,7 @@ mod timestamping {
             "timestamping"
         }
 
-        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
             Vec::new()
         }
 
@@ -237,7 +237,7 @@ mod cryptocurrency {
             "cryptocurrency"
         }
 
-        fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+        fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
             Vec::new()
         }
 
@@ -532,7 +532,7 @@ fn execute_block_rocksdb(
 }
 
 pub fn bench_block(criterion: &mut Criterion) {
-    use log::{self, LevelFilter};
+    use log::LevelFilter;
     use std::panic;
 
     log::set_max_level(LevelFilter::Off);

--- a/exonum/benches/criterion/lib.rs
+++ b/exonum/benches/criterion/lib.rs
@@ -14,25 +14,15 @@
 
 #[macro_use]
 extern crate criterion;
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
 extern crate serde_derive;
-extern crate futures;
-extern crate log;
-extern crate num;
-extern crate protobuf;
-extern crate rand;
-extern crate rand_xorshift;
-extern crate tempdir;
-extern crate tokio_core;
-extern crate tokio_threadpool;
 
-use block::bench_block;
-use crypto::bench_crypto;
-use storage::bench_storage;
-use transactions::bench_verify_transactions;
+use crate::block::bench_block;
+use crate::crypto::bench_crypto;
+use crate::storage::bench_storage;
+use crate::transactions::bench_verify_transactions;
 
 mod block;
 mod crypto;

--- a/exonum/examples/explorer.rs
+++ b/exonum/examples/explorer.rs
@@ -14,14 +14,12 @@
 
 //! Examples of usage of a blockchain explorer.
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
-extern crate protobuf;
 
 use exonum::{
     blockchain::{Blockchain, Schema, Transaction, TransactionError},
@@ -31,7 +29,7 @@ use exonum::{
     messages::{Message, RawTransaction, Signed},
 };
 
-use blockchain::{
+use crate::blockchain::{
     consensus_keys, create_block, create_blockchain, CreateWallet, Transfer, SERVICE_ID,
 };
 

--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -22,12 +22,10 @@ pub use actix_web::middleware::cors::Cors;
 use actix::{Addr, System};
 use actix_net::server::Server;
 use actix_web::{
-    self,
     error::ResponseError,
     server::{HttpServer, StopServer},
     AsyncResponder, FromRequest, HttpMessage, HttpResponse, Query,
 };
-use failure;
 use futures::{Future, IntoFuture};
 use serde::{
     de::{self, DeserializeOwned},
@@ -43,7 +41,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use api::{
+use crate::api::{
     error::Error as ApiError, ApiAccess, ApiAggregator, ExtendApiBackend, FutureResult, Immutable,
     Mutable, NamedWith, Result, ServiceApiBackend, ServiceApiScope, ServiceApiState,
 };
@@ -117,7 +115,7 @@ impl ExtendApiBackend for actix_web::Scope<ServiceApiState> {
     where
         I: IntoIterator<Item = (&'a str, &'a ServiceApiScope)>,
     {
-        for mut item in items {
+        for item in items {
             self = self.nested(&item.0, move |scope| item.1.actix_backend.wire(scope))
         }
         self

--- a/exonum/src/api/error.rs
+++ b/exonum/src/api/error.rs
@@ -18,10 +18,9 @@
 
 //! The set of errors for the Exonum API module.
 
-use failure;
 use std::io;
 
-use storage;
+use crate::storage;
 
 /// List of possible API errors.
 #[derive(Fail, Debug)]

--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -24,9 +24,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::BTreeMap, fmt};
 
 use self::{backends::actix, node::public::ExplorerApi};
-use blockchain::{Blockchain, SharedNodeState};
-use crypto::PublicKey;
-use node::ApiSender;
+use crate::blockchain::{Blockchain, SharedNodeState};
+use crate::crypto::PublicKey;
+use crate::node::ApiSender;
 
 pub mod backends;
 pub mod error;

--- a/exonum/src/api/node/private/mod.rs
+++ b/exonum/src/api/node/private/mod.rs
@@ -19,11 +19,11 @@
 
 use std::{collections::HashMap, net::SocketAddr};
 
-use api::{Error as ApiError, ServiceApiScope, ServiceApiState};
-use blockchain::{Service, SharedNodeState};
-use crypto::PublicKey;
-use messages::PROTOCOL_MAJOR_VERSION;
-use node::{ConnectInfo, ExternalMessage};
+use crate::api::{Error as ApiError, ServiceApiScope, ServiceApiState};
+use crate::blockchain::{Service, SharedNodeState};
+use crate::crypto::PublicKey;
+use crate::messages::PROTOCOL_MAJOR_VERSION;
+use crate::node::{ConnectInfo, ExternalMessage};
 
 /// Short information about the service.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -14,9 +14,9 @@
 
 //! Public system API.
 
-use api::{ServiceApiScope, ServiceApiState};
-use blockchain::{Schema, SharedNodeState};
-use helpers::user_agent;
+use crate::api::{ServiceApiScope, ServiceApiState};
+use crate::blockchain::{Schema, SharedNodeState};
+use crate::helpers::user_agent;
 
 /// Information about the current state of the node memory pool.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/exonum/src/api/state.rs
+++ b/exonum/src/api/state.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use blockchain::Blockchain;
-use crypto::{PublicKey, SecretKey};
-use node::ApiSender;
-use storage::Snapshot;
+use crate::blockchain::Blockchain;
+use crate::crypto::{PublicKey, SecretKey};
+use crate::node::ApiSender;
+use crate::storage::Snapshot;
 
 /// Provides the current blockchain state to API handlers.
 ///

--- a/exonum/src/api/websocket.rs
+++ b/exonum/src/api/websocket.rs
@@ -16,15 +16,14 @@
 
 use actix::*;
 use actix_web::ws;
-use serde_json;
 
-use rand::{self, rngs::ThreadRng, Rng};
+use rand::{rngs::ThreadRng, Rng};
 
 use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
-use api::ServiceApiState;
-use blockchain::Schema;
-use crypto::Hash;
+use crate::api::ServiceApiState;
+use crate::blockchain::Schema;
+use crate::crypto::Hash;
 
 /// WebSocket message for communication between clients(`Session`) and server(`Server`).
 #[derive(Message, Debug)]

--- a/exonum/src/blockchain/block.rs
+++ b/exonum/src/blockchain/block.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crypto::Hash;
-use helpers::{Height, ValidatorId};
-use messages::{Precommit, Signed};
-use proto;
+use crate::crypto::Hash;
+use crate::helpers::{Height, ValidatorId};
+use crate::messages::{Precommit, Signed};
+use crate::proto;
 
 /// Exonum block header data structure.
 ///
@@ -107,7 +107,7 @@ pub struct BlockProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crypto::hash;
+    use crate::crypto::hash;
 
     #[test]
     fn test_block() {

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -22,14 +22,14 @@
 //! etc.
 
 use serde::de::Error;
-use serde_json::{self, Error as JsonError};
+use serde_json::Error as JsonError;
 
 use std::collections::{BTreeMap, HashSet};
 
-use crypto::{hash, CryptoHash, Hash, PublicKey};
-use helpers::{Height, Milliseconds};
-use messages::EMPTY_SIGNED_MESSAGE_SIZE;
-use storage::StorageValue;
+use crate::crypto::{hash, CryptoHash, Hash, PublicKey};
+use crate::helpers::{Height, Milliseconds};
+use crate::messages::EMPTY_SIGNED_MESSAGE_SIZE;
+use crate::storage::StorageValue;
 
 /// Public keys of a validator. Each validator has two public keys: the
 /// `consensus_key` is used for internal operations in the consensus process,
@@ -264,10 +264,8 @@ impl StorageValue for StoredConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use toml;
-
     use super::*;
-    use crypto::{gen_keypair_from_seed, Seed, SEED_LENGTH};
+    use crate::crypto::{gen_keypair_from_seed, Seed, SEED_LENGTH};
 
     // TOML doesn't support all rust types, but `StoredConfiguration` must be able to save as TOML.
     #[test]

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -46,7 +46,6 @@ pub use self::{
 pub mod config;
 
 use byteorder::{ByteOrder, LittleEndian};
-use failure;
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -54,11 +53,11 @@ use std::{
     sync::Arc,
 };
 
-use crypto::{self, CryptoHash, Hash, PublicKey, SecretKey};
-use helpers::{Height, Round, ValidatorId};
-use messages::{Connect, Message, Precommit, ProtocolMessage, RawTransaction, Signed};
-use node::ApiSender;
-use storage::{self, Database, Error, Fork, Patch, Snapshot};
+use crate::crypto::{self, CryptoHash, Hash, PublicKey, SecretKey};
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::{Connect, Message, Precommit, ProtocolMessage, RawTransaction, Signed};
+use crate::node::ApiSender;
+use crate::storage::{self, Database, Error, Fork, Patch, Snapshot};
 
 mod block;
 mod genesis;

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 use super::{config::StoredConfiguration, Block, BlockProof, Blockchain, TransactionResult};
-use crypto::{CryptoHash, Hash, PublicKey};
-use helpers::{Height, Round};
-use messages::{Connect, Message, Precommit, RawTransaction, Signed};
-use proto;
-use storage::{
-    Entry, Fork, KeySetIndex, ListIndex, MapIndex, MapProof, ProofListIndex, ProofMapIndex,
-    Snapshot,
+use crate::{
+    crypto::{CryptoHash, Hash, PublicKey},
+    helpers::{Height, Round},
+    messages::{Connect, Message, Precommit, RawTransaction, Signed},
+    proto,
+    storage::{
+        Entry, Fork, KeySetIndex, ListIndex, MapIndex, MapProof, ProofListIndex, ProofMapIndex,
+        Snapshot,
+    },
 };
 
 /// Defines `&str` constants with given name and value.

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -26,14 +26,14 @@ use std::{
 };
 
 use super::transaction::Transaction;
-use api::{websocket, ServiceApiBuilder};
-use blockchain::{ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys};
-use crypto::{Hash, PublicKey, SecretKey};
-use events::network::ConnectedPeerAddr;
-use helpers::{Height, Milliseconds, ValidatorId};
-use messages::{Message, RawTransaction, ServiceTransaction, Signed};
-use node::{ApiSender, ConnectInfo, NodeRole, State};
-use storage::{Fork, Snapshot};
+use crate::api::{websocket, ServiceApiBuilder};
+use crate::blockchain::{ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys};
+use crate::crypto::{Hash, PublicKey, SecretKey};
+use crate::events::network::ConnectedPeerAddr;
+use crate::helpers::{Height, Milliseconds, ValidatorId};
+use crate::messages::{Message, RawTransaction, ServiceTransaction, Signed};
+use crate::node::{ApiSender, ConnectInfo, NodeRole, State};
+use crate::storage::{Fork, Snapshot};
 
 /// A trait that describes the business logic of a certain service.
 ///

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -16,14 +16,14 @@
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-use blockchain::{
+use crate::blockchain::{
     Blockchain, ExecutionResult, Schema, Service, Transaction, TransactionContext, TransactionSet,
 };
-use crypto::{gen_keypair, Hash};
-use helpers::{Height, ValidatorId};
-use messages::{Message, RawTransaction};
-use proto;
-use storage::{Database, Error, Fork, ListIndex, Snapshot};
+use crate::crypto::{gen_keypair, Hash};
+use crate::helpers::{Height, ValidatorId};
+use crate::messages::{Message, RawTransaction};
+use crate::proto;
+use crate::storage::{Database, Error, Fork, ListIndex, Snapshot};
 
 const IDX_NAME: &'static str = "idx_name";
 const TEST_SERVICE_ID: u16 = 255;
@@ -163,12 +163,10 @@ fn handling_tx_panic_storage_error(blockchain: &mut Blockchain) {
 
 mod transactions_tests {
     use super::TEST_SERVICE_ID;
-    use blockchain::{ExecutionResult, Transaction, TransactionContext};
-    use crypto::gen_keypair;
-    use messages::Message;
-    use serde_json;
-
-    use proto::schema::tests::{BlockchainTestTxA, BlockchainTestTxB};
+    use crate::blockchain::{ExecutionResult, Transaction, TransactionContext, TransactionSet};
+    use crate::crypto::gen_keypair;
+    use crate::messages::Message;
+    use crate::proto::schema::tests::{BlockchainTestTxA, BlockchainTestTxB};
 
     #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert)]
     #[exonum(pb = "BlockchainTestTxA", crate = "crate")]
@@ -251,8 +249,6 @@ mod transactions_tests {
 
     #[test]
     fn deserialize_from_raw() {
-        use blockchain::TransactionSet;
-
         fn round_trip<T: Into<MyTransactions>>(t: T) {
             let (pk, sec_key) = gen_keypair();
             use std::ops::Deref;
@@ -364,11 +360,12 @@ fn assert_service_execute_panic(blockchain: &Blockchain, db: &mut Box<dyn Databa
 }
 
 mod memorydb_tests {
-    use blockchain::{Blockchain, Service};
-    use crypto::gen_keypair;
     use futures::sync::mpsc;
-    use node::ApiSender;
-    use storage::{Database, MemoryDB};
+
+    use crate::blockchain::{Blockchain, Service};
+    use crate::crypto::gen_keypair;
+    use crate::node::ApiSender;
+    use crate::storage::{Database, MemoryDB};
 
     use super::{ServiceGood, ServicePanic, ServicePanicStorageError};
 
@@ -437,13 +434,15 @@ mod memorydb_tests {
 }
 
 mod rocksdb_tests {
-    use blockchain::{Blockchain, Service};
-    use crypto::gen_keypair;
     use futures::sync::mpsc;
-    use node::ApiSender;
-    use std::path::Path;
-    use storage::{Database, DbOptions, RocksDB};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use crate::blockchain::{Blockchain, Service};
+    use crate::crypto::gen_keypair;
+    use crate::node::ApiSender;
+    use crate::storage::{Database, DbOptions, RocksDB};
 
     use super::{ServiceGood, ServicePanic, ServicePanicStorageError};
 

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -14,17 +14,16 @@
 
 //! `Transaction` related types.
 
-use failure;
+use hex::ToHex;
 use protobuf::Message;
 use serde::{de::DeserializeOwned, Serialize};
 
 use std::{any::Any, borrow::Cow, convert::Into, error::Error, fmt, u8};
 
-use crypto::{CryptoHash, Hash, PublicKey};
-use hex::ToHex;
-use messages::{HexStringRepresentation, RawTransaction, Signed, SignedMessage};
-use proto::{self, ProtobufConvert};
-use storage::{Fork, StorageValue};
+use crate::crypto::{CryptoHash, Hash, PublicKey};
+use crate::messages::{HexStringRepresentation, RawTransaction, Signed, SignedMessage};
+use crate::proto::{self, ProtobufConvert};
+use crate::storage::{Fork, StorageValue};
 
 //  User-defined error codes (`TransactionErrorType::Code(u8)`) have a `0...255` range.
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
@@ -402,7 +401,7 @@ impl ProtobufConvert for TransactionResult {
         };
 
         Ok(TransactionResult(match status_code {
-            value @ 0...MAX_ERROR_CODE => Err(TransactionError::code(value as u8, description)),
+            value @ 0..=MAX_ERROR_CODE => Err(TransactionError::code(value as u8, description)),
             TRANSACTION_STATUS_OK => Ok(()),
             TRANSACTION_STATUS_PANIC => Err(TransactionError::panic(description)),
             value => bail!("Invalid TransactionResult value: {}", value),
@@ -468,13 +467,13 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use blockchain::{Blockchain, Schema, Service};
-    use crypto;
-    use helpers::{Height, ValidatorId};
-    use messages::Message;
-    use node::ApiSender;
-    use proto;
-    use storage::{Database, Entry, MemoryDB, Snapshot};
+    use crate::blockchain::{Blockchain, Schema, Service};
+    use crate::crypto;
+    use crate::helpers::{Height, ValidatorId};
+    use crate::messages::Message;
+    use crate::node::ApiSender;
+    use crate::proto;
+    use crate::storage::{Database, Entry, MemoryDB, Snapshot};
 
     const TX_RESULT_SERVICE_ID: u16 = 255;
 

--- a/exonum/src/events/codec.rs
+++ b/exonum/src/events/codec.rs
@@ -14,12 +14,11 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::BytesMut;
-use failure;
 use std::mem;
 use tokio_io::codec::{Decoder, Encoder};
 
-use events::noise::{NoiseWrapper, HEADER_LENGTH as NOISE_HEADER_LENGTH};
-use messages::{SignedMessage, EMPTY_SIGNED_MESSAGE_SIZE};
+use crate::events::noise::{NoiseWrapper, HEADER_LENGTH as NOISE_HEADER_LENGTH};
+use crate::messages::{SignedMessage, EMPTY_SIGNED_MESSAGE_SIZE};
 
 #[derive(Debug)]
 pub struct MessagesCodec {
@@ -89,12 +88,11 @@ impl Encoder for MessagesCodec {
 #[cfg(test)]
 mod test {
     use bytes::BytesMut;
-    use failure;
     use tokio_io::codec::{Decoder, Encoder};
 
     use super::MessagesCodec;
-    use events::noise::{HandshakeParams, NoiseWrapper};
-    use messages::{SignedMessage, EMPTY_SIGNED_MESSAGE_SIZE};
+    use crate::events::noise::{HandshakeParams, NoiseWrapper};
+    use crate::messages::{SignedMessage, EMPTY_SIGNED_MESSAGE_SIZE};
 
     pub fn raw_message(val: Vec<u8>) -> SignedMessage {
         SignedMessage::from_vec_unchecked(val)

--- a/exonum/src/events/internal.rs
+++ b/exonum/src/events/internal.rs
@@ -23,7 +23,7 @@ use tokio_core::reactor::{Handle, Timeout};
 use std::time::{Duration, SystemTime};
 
 use super::{InternalEvent, InternalRequest, TimeoutRequest};
-use messages::{Message, SignedMessage};
+use crate::messages::{Message, SignedMessage};
 
 #[derive(Debug)]
 pub struct InternalPart {
@@ -116,7 +116,7 @@ mod tests {
     use std::thread;
 
     use super::*;
-    use crypto::{gen_keypair, Signature};
+    use crate::crypto::{gen_keypair, Signature};
 
     fn verify_message(msg: Vec<u8>) -> Option<InternalEvent> {
         let (internal_tx, internal_rx) = mpsc::channel(16);

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -31,9 +31,9 @@ use futures::{
 
 use std::{cmp::Ordering, time::SystemTime};
 
-use helpers::{Height, Round};
-use messages::Message;
-use node::{ExternalMessage, NodeTimeout};
+use crate::helpers::{Height, Round};
+use crate::messages::Message;
+use crate::node::{ExternalMessage, NodeTimeout};
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use failure;
 use futures::{
     future::{self, err, Either},
     stream::{SplitSink, SplitStream},
@@ -23,7 +22,6 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_codec::Framed;
 use tokio_core::reactor::Handle;
 
-use tokio_dns;
 use tokio_retry::{
     strategy::{jitter, FixedInterval},
     Retry,
@@ -32,15 +30,17 @@ use tokio_retry::{
 use std::{cell::RefCell, collections::HashMap, net::SocketAddr, rc::Rc, time::Duration};
 
 use super::{error::log_error, to_box};
-use crypto::PublicKey;
-use events::{
-    codec::MessagesCodec,
-    error::into_failure,
-    noise::{Handshake, HandshakeParams, NoiseHandshake},
+use crate::{
+    crypto::PublicKey,
+    events::{
+        codec::MessagesCodec,
+        error::into_failure,
+        noise::{Handshake, HandshakeParams, NoiseHandshake},
+    },
+    helpers::Milliseconds,
+    messages::{Connect, Message, Service, Signed, SignedMessage},
+    node::state::SharedConnectList,
 };
-use helpers::Milliseconds;
-use messages::{Connect, Message, Service, Signed, SignedMessage};
-use node::state::SharedConnectList;
 
 const OUTGOING_CHANNEL_SIZE: usize = 10;
 

--- a/exonum/src/events/noise/mod.rs
+++ b/exonum/src/events/noise/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // spell-checker:ignore uint
-use failure;
 
 #[cfg(feature = "sodiumoxide-crypto")]
 #[doc(inline)]
@@ -33,7 +32,7 @@ use tokio_io::{
     AsyncRead, AsyncWrite,
 };
 
-use events::{codec::MessagesCodec, error::into_failure};
+use crate::events::{codec::MessagesCodec, error::into_failure};
 
 pub mod error;
 pub mod wrappers;

--- a/exonum/src/events/noise/tests.rs
+++ b/exonum/src/events/noise/tests.rs
@@ -14,7 +14,6 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::BytesMut;
-use failure;
 use futures::{
     future::Either,
     sync::{mpsc, mpsc::Sender},
@@ -29,8 +28,8 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use std::{net::SocketAddr, thread, time::Duration};
 
-use crypto::{gen_keypair_from_seed, Seed, PUBLIC_KEY_LENGTH, SEED_LENGTH};
-use events::{
+use crate::crypto::{gen_keypair_from_seed, Seed, PUBLIC_KEY_LENGTH, SEED_LENGTH};
+use crate::events::{
     error::into_failure,
     noise::{
         wrappers::sodium_wrapper::resolver::SodiumDh25519, Handshake, HandshakeParams,
@@ -43,7 +42,7 @@ use events::{
 #[test]
 #[cfg(feature = "sodiumoxide-crypto")]
 fn noise_convert_ed_to_curve_dh() {
-    use crypto::{gen_keypair, x25519::into_x25519_keypair};
+    use crate::crypto::{gen_keypair, x25519::into_x25519_keypair};
 
     // Generate Ed25519 keys for initiator and responder.
     let (public_key_i, secret_key_i) = gen_keypair();
@@ -70,7 +69,7 @@ fn noise_convert_ed_to_curve_dh() {
 #[test]
 #[cfg(feature = "sodiumoxide-crypto")]
 fn noise_converted_keys_handshake() {
-    use crypto::{gen_keypair, x25519::into_x25519_keypair};
+    use crate::crypto::{gen_keypair, x25519::into_x25519_keypair};
 
     const MSG_SIZE: usize = 4096;
     static PATTERN: &'static str = "Noise_XK_25519_ChaChaPoly_SHA256";

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/handshake.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/handshake.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use failure;
 use futures::future::{done, Future};
 use tokio_codec::{Decoder, Framed};
 use tokio_io::{AsyncRead, AsyncWrite};
@@ -20,17 +19,19 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use std::net::SocketAddr;
 
 use super::wrapper::NoiseWrapper;
-use crypto::{
-    x25519::{self, into_x25519_keypair, into_x25519_public_key},
-    PublicKey, SecretKey,
+use crate::{
+    crypto::{
+        x25519::{self, into_x25519_keypair, into_x25519_public_key},
+        PublicKey, SecretKey,
+    },
+    events::{
+        codec::MessagesCodec,
+        noise::{Handshake, HandshakeRawMessage, HandshakeResult},
+    },
+    messages::{Connect, Signed},
+    node::state::SharedConnectList,
+    storage::StorageValue,
 };
-use events::{
-    codec::MessagesCodec,
-    noise::{Handshake, HandshakeRawMessage, HandshakeResult},
-};
-use messages::{Connect, Signed};
-use node::state::SharedConnectList;
-use storage::StorageValue;
 
 /// Params needed to establish secured connection using Noise Protocol.
 #[derive(Debug, Clone)]

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
@@ -22,11 +22,11 @@ use snow::{
     types::{Cipher, Dh, Hash, Random},
 };
 
-use crypto::{
+use crate::crypto::{
     x25519, PUBLIC_KEY_LENGTH as SHA256_PUBLIC_KEY_LENGTH,
     SECRET_KEY_LENGTH as SHA256_SECRET_KEY_LENGTH,
 };
-use sodiumoxide::crypto::{
+use crate::sodiumoxide::crypto::{
     aead::chacha20poly1305_ietf as sodium_chacha20poly1305, hash::sha256 as sodium_sha256,
 };
 

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/wrapper.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/wrapper.rs
@@ -18,13 +18,12 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::BytesMut;
-use failure;
 use snow::{Builder, Session};
 
 use std::fmt::{self, Error, Formatter};
 
 use super::{handshake::HandshakeParams, resolver::SodiumResolver};
-use events::noise::{error::NoiseError, HEADER_LENGTH, MAX_MESSAGE_LENGTH, TAG_LENGTH};
+use crate::events::noise::{error::NoiseError, HEADER_LENGTH, MAX_MESSAGE_LENGTH, TAG_LENGTH};
 
 // Maximum allowed handshake message length is 65535,
 // therefore HANDSHAKE_HEADER_LENGTH cannot exceed 2.

--- a/exonum/src/events/tests.rs
+++ b/exonum/src/events/tests.rs
@@ -22,18 +22,19 @@ use std::{
     time::{self, Duration, SystemTime},
 };
 
-use blockchain::ConsensusConfig;
-use crypto::{gen_keypair, gen_keypair_from_seed, PublicKey, SecretKey, Seed, SEED_LENGTH};
-use env_logger;
-use events::{
+use crate::blockchain::ConsensusConfig;
+use crate::crypto::{gen_keypair, gen_keypair_from_seed, PublicKey, SecretKey, Seed, SEED_LENGTH};
+use crate::events::{
     error::log_error,
     network::{NetworkConfiguration, NetworkPart},
     noise::HandshakeParams,
     NetworkEvent, NetworkRequest,
 };
-use helpers::user_agent;
-use messages::{Connect, Message, Signed, SignedMessage};
-use node::{state::SharedConnectList, ConnectInfo, ConnectList, EventsPoolCapacity, NodeChannel};
+use crate::helpers::user_agent;
+use crate::messages::{Connect, Message, Signed, SignedMessage};
+use crate::node::{
+    state::SharedConnectList, ConnectInfo, ConnectList, EventsPoolCapacity, NodeChannel,
+};
 
 #[derive(Debug)]
 pub struct TestHandler {

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -27,14 +27,14 @@ use std::{
     slice,
 };
 
-use blockchain::{
+use crate::blockchain::{
     Block, Blockchain, Schema, TransactionError, TransactionErrorType, TransactionMessage,
     TransactionResult, TxLocation,
 };
-use crypto::{CryptoHash, Hash};
-use helpers::Height;
-use messages::{Precommit, RawTransaction, Signed};
-use storage::{ListProof, Snapshot};
+use crate::crypto::{CryptoHash, Hash};
+use crate::helpers::Height;
+use crate::messages::{Precommit, RawTransaction, Signed};
+use crate::storage::{ListProof, Snapshot};
 
 /// Transaction parsing result.
 type ParseResult = Result<TransactionMessage, failure::Error>;

--- a/exonum/src/helpers/config.rs
+++ b/exonum/src/helpers/config.rs
@@ -16,7 +16,6 @@
 
 use failure::{Error, ResultExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use toml;
 
 use std::{
     fs::{self, File},
@@ -27,7 +26,7 @@ use std::{
     thread,
 };
 
-use node::{ConnectListConfig, NodeConfig};
+use crate::node::{ConnectListConfig, NodeConfig};
 
 /// Implements loading and saving TOML-encoded configurations.
 #[derive(Debug)]

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ctrlc;
-
 use std::{
     collections::HashMap,
     env,
@@ -31,9 +29,9 @@ use super::{
     maintenance::Maintenance,
     CommandName, Context, ServiceFactory,
 };
-use blockchain::Service;
-use helpers::ZeroizeOnDrop;
-use node::{ExternalMessage, Node};
+use crate::blockchain::Service;
+use crate::helpers::ZeroizeOnDrop;
+use crate::node::{ExternalMessage, Node};
 
 const EXONUM_CONSENSUS_PASS: &str = "EXONUM_CONSENSUS_PASS";
 const EXONUM_SERVICE_PASS: &str = "EXONUM_SERVICE_PASS";

--- a/exonum/src/helpers/fabric/clap_backend.rs
+++ b/exonum/src/helpers/fabric/clap_backend.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap;
-
 use std::{collections::HashMap, ffi::OsString};
 
 use super::{

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -17,10 +17,6 @@
 //! This module implement all core commands.
 // spell-checker:ignore exts, rsplitn
 
-use crypto::generate_keys_file;
-use rpassword;
-use toml;
-
 use std::{
     collections::{BTreeMap, HashMap},
     env, fs, io,
@@ -37,12 +33,12 @@ use super::{
     },
     Argument, CommandName, Context, DEFAULT_EXONUM_LISTEN_PORT,
 };
-use api::backends::actix::AllowOrigin;
-use blockchain::{config::ValidatorKeys, GenesisConfig};
-use crypto::PublicKey;
-use helpers::{config::ConfigFile, generate_testnet_config, ZeroizeOnDrop};
-use node::{ConnectListConfig, NodeApiConfig, NodeConfig};
-use storage::{Database, DbOptions, RocksDB};
+use crate::api::backends::actix::AllowOrigin;
+use crate::blockchain::{config::ValidatorKeys, GenesisConfig};
+use crate::crypto::{generate_keys_file, PublicKey};
+use crate::helpers::{config::ConfigFile, generate_testnet_config, ZeroizeOnDrop};
+use crate::node::{ConnectListConfig, NodeApiConfig, NodeConfig};
+use crate::storage::{Database, DbOptions, RocksDB};
 
 const EXONUM_CONSENSUS_PASS: &str = "EXONUM_CONSENSUS_PASS";
 const EXONUM_SERVICE_PASS: &str = "EXONUM_SERVICE_PASS";

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -23,6 +23,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
 };
+
 use super::{
     super::path_relative_from,
     internal::{CollectedCommand, Command, Feedback},

--- a/exonum/src/helpers/fabric/info.rs
+++ b/exonum/src/helpers/fabric/info.rs
@@ -14,8 +14,6 @@
 
 //! This module implements information request commands.
 
-use serde_json;
-
 use std::collections::HashMap;
 
 use super::{

--- a/exonum/src/helpers/fabric/maintenance.rs
+++ b/exonum/src/helpers/fabric/maintenance.rs
@@ -20,10 +20,10 @@ use super::{
     internal::{CollectedCommand, Command, Feedback},
     Argument, CommandName, Context,
 };
-use blockchain::Schema;
-use helpers::config::ConfigFile;
-use node::NodeConfig;
-use storage::{Database, DbOptions, RocksDB};
+use crate::blockchain::Schema;
+use crate::helpers::config::ConfigFile;
+use crate::node::NodeConfig;
+use crate::storage::{Database, DbOptions, RocksDB};
 
 // Context entry for the path to the node config.
 const NODE_CONFIG_PATH: &str = "NODE_CONFIG_PATH";

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -23,14 +23,12 @@ pub use self::{
     shared::{AbstractConfig, CommonConfigTemplate, NodePrivateConfig, NodePublicConfig},
 };
 
-use clap;
-use failure;
 use serde::{Deserialize, Serialize};
 use toml::Value;
 
 use std::{collections::BTreeMap, str::FromStr};
 
-use blockchain::Service;
+use crate::blockchain::Service;
 
 mod builder;
 mod clap_backend;
@@ -149,11 +147,9 @@ impl Argument {
 pub mod keys {
     use std::{collections::BTreeMap, path::PathBuf};
 
-    use toml;
-
     use super::shared::{AbstractConfig, CommonConfigTemplate, NodePublicConfig};
     use super::ContextKey;
-    use node::NodeConfig;
+    use crate::node::NodeConfig;
 
     /// Configuration for this node.
     /// Set by `finalize` and `run` commands.

--- a/exonum/src/helpers/fabric/password.rs
+++ b/exonum/src/helpers/fabric/password.rs
@@ -14,12 +14,12 @@
 
 //! This module contains utilities for passphrase entry.
 
-use failure;
+use failure::bail;
 use rpassword::read_password_from_tty;
 
 use std::{env, io, str::FromStr};
 
-use helpers::ZeroizeOnDrop;
+use crate::helpers::ZeroizeOnDrop;
 
 /// Passphrase input methods
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -130,10 +130,10 @@ fn prompt_passphrase(prompt: &str, node_run: bool) -> io::Result<ZeroizeOnDrop<S
 
 #[cfg(test)]
 mod tests {
-    use helpers::ZeroizeOnDrop;
     use std::str::FromStr;
 
     use super::PassInputMethod;
+    use crate::helpers::ZeroizeOnDrop;
 
     #[test]
     fn test_pass_input_method_parse() {

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -14,12 +14,10 @@
 
 //! This module is used to collect structures that is shared into `CommandExtension` from `Command`.
 
-use toml;
-
 use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf};
 
-use blockchain::config::{ConsensusConfig, ValidatorKeys};
-use crypto::PublicKey;
+use crate::blockchain::config::{ConsensusConfig, ValidatorKeys};
+use crate::crypto::PublicKey;
 
 /// Abstract configuration.
 pub type AbstractConfig = BTreeMap<String, toml::Value>;

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -21,14 +21,15 @@ pub mod fabric;
 pub mod user_agent;
 #[macro_use]
 pub mod metrics;
-use crypto::gen_keypair;
+
 use env_logger::Builder;
 use log::SetLoggerError;
 
 use std::path::{Component, Path, PathBuf};
 
-use blockchain::{GenesisConfig, ValidatorKeys};
-use node::{ConnectListConfig, NodeConfig};
+use crate::blockchain::{GenesisConfig, ValidatorKeys};
+use crate::crypto::gen_keypair;
+use crate::node::{ConnectListConfig, NodeConfig};
 
 mod types;
 

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -14,11 +14,12 @@
 
 //! Common widely used type definitions.
 
-use std::{fmt, num::ParseIntError, str::FromStr};
-
-use crypto::{CryptoHash, Hash};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::Zeroize;
+
+use std::{fmt, num::ParseIntError, str::FromStr};
+
+use crate::crypto::{CryptoHash, Hash};
 
 /// Number of milliseconds.
 pub type Milliseconds = u64;

--- a/exonum/src/helpers/user_agent.rs
+++ b/exonum/src/helpers/user_agent.rs
@@ -14,8 +14,6 @@
 
 //! Information about current node including Exonum, Rust and OS versions.
 
-use os_info;
-
 static USER_AGENT: &str = include_str!(concat!(env!("OUT_DIR"), "/user_agent"));
 
 /// Returns "user agent" string containing information about Exonum, Rust and OS versions.

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -46,62 +46,31 @@
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-extern crate actix;
-extern crate actix_net;
-extern crate actix_web;
-extern crate atty;
-extern crate bit_vec;
-extern crate byteorder;
-extern crate bytes;
-extern crate chrono;
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
-extern crate env_logger;
-extern crate erased_serde;
-pub extern crate exonum_crypto as crypto;
 #[macro_use]
 extern crate exonum_derive;
-extern crate exonum_rocksdb as rocksdb;
 #[cfg(feature = "sodiumoxide-crypto")]
 extern crate exonum_sodiumoxide as sodiumoxide;
 #[macro_use]
 extern crate failure;
-extern crate futures;
-extern crate hex;
 #[macro_use]
 extern crate log;
-extern crate os_info;
-extern crate rand;
-extern crate rand_xorshift;
-extern crate rpassword;
-extern crate rust_decimal;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-extern crate ctrlc;
-extern crate protobuf;
-extern crate snow;
-extern crate tokio;
-extern crate tokio_codec;
-extern crate tokio_core;
-extern crate tokio_dns;
-extern crate tokio_io;
-extern crate tokio_retry;
-extern crate tokio_threadpool;
-extern crate toml;
-extern crate uuid;
-extern crate zeroize;
 
 // Test dependencies.
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
-#[cfg(test)]
-extern crate tempdir;
 #[cfg(all(test, feature = "long_benchmarks"))]
 extern crate test;
+
+pub use exonum_crypto as crypto;
+
+use exonum_rocksdb as rocksdb;
 
 pub mod proto;
 #[macro_use]

--- a/exonum/src/messages/authorization.rs
+++ b/exonum/src/messages/authorization.rs
@@ -4,7 +4,7 @@ use hex::{FromHex, ToHex};
 use std::fmt;
 
 use super::EMPTY_SIGNED_MESSAGE_SIZE;
-use crypto::{
+use crate::crypto::{
     self, hash, Hash, PublicKey, SecretKey, Signature, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH,
 };
 
@@ -24,7 +24,7 @@ use crypto::{
 /// as every `SignedMessage` instance is guaranteed to have a correct signature.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct SignedMessage {
-    pub(in messages) raw: Vec<u8>,
+    pub(in crate::messages) raw: Vec<u8>,
 }
 
 impl SignedMessage {
@@ -94,28 +94,28 @@ impl SignedMessage {
     }
 
     /// Returns `PublicKey` of message author.
-    pub(in messages) fn author(&self) -> PublicKey {
+    pub(in crate::messages) fn author(&self) -> PublicKey {
         PublicKey::from_slice(&self.raw[0..PUBLIC_KEY_LENGTH]).expect("Couldn't read PublicKey")
     }
 
     /// Returns message class, which is an ID inside protocol.
-    pub(in messages) fn message_class(&self) -> u8 {
+    pub(in crate::messages) fn message_class(&self) -> u8 {
         self.raw[PUBLIC_KEY_LENGTH]
     }
 
     /// Returns message type, which is an ID inside some class of messages.
-    pub(in messages) fn message_type(&self) -> u8 {
+    pub(in crate::messages) fn message_type(&self) -> u8 {
         self.raw[PUBLIC_KEY_LENGTH + 1]
     }
 
     /// Returns serialized payload of the message.
-    pub(in messages) fn payload(&self) -> &[u8] {
+    pub(in crate::messages) fn payload(&self) -> &[u8] {
         let sign_idx = self.raw.len() - SIGNATURE_LENGTH;
         &self.raw[PUBLIC_KEY_LENGTH + 2..sign_idx]
     }
 
     /// Returns ed25519 signature for this message.
-    pub(in messages) fn signature(&self) -> Signature {
+    pub(in crate::messages) fn signature(&self) -> Signature {
         let sign_idx = self.raw.len() - SIGNATURE_LENGTH;
         Signature::from_slice(&self.raw[sign_idx..]).expect("Couldn't read signature")
     }

--- a/exonum/src/messages/mod.rs
+++ b/exonum/src/messages/mod.rs
@@ -39,8 +39,8 @@ use serde::ser::{Serialize, Serializer};
 
 use std::{borrow::Cow, cmp::PartialEq, fmt, mem, ops::Deref};
 
-use crypto::{hash, CryptoHash, Hash, PublicKey};
-use storage::StorageValue;
+use crate::crypto::{hash, CryptoHash, Hash, PublicKey};
+use crate::storage::StorageValue;
 
 pub(crate) use self::{authorization::SignedMessage, helpers::HexStringRepresentation};
 pub use self::{
@@ -175,7 +175,7 @@ pub struct Signed<T> {
 
 impl<T: ProtocolMessage> Signed<T> {
     /// Creates a new instance of the message.
-    pub(in messages) fn new(payload: T, message: SignedMessage) -> Signed<T> {
+    pub(in crate::messages) fn new(payload: T, message: SignedMessage) -> Signed<T> {
         Signed { payload, message }
     }
 

--- a/exonum/src/messages/protocol.rs
+++ b/exonum/src/messages/protocol.rs
@@ -28,16 +28,15 @@
 
 use bit_vec::BitVec;
 use chrono::{DateTime, Utc};
-use failure;
 
 use std::{borrow::Cow, fmt::Debug, mem};
 
 use super::{BinaryForm, RawTransaction, ServiceTransaction, Signed, SignedMessage};
-use blockchain;
-use crypto::{CryptoHash, Hash, PublicKey, SecretKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
-use helpers::{Height, Round, ValidatorId};
-use proto;
-use storage::{proof_list_index as merkle, StorageValue};
+use crate::blockchain;
+use crate::crypto::{CryptoHash, Hash, PublicKey, SecretKey, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::proto;
+use crate::storage::{proof_list_index as merkle, StorageValue};
 
 /// `SignedMessage` size with zero bytes payload.
 #[doc(hidden)]

--- a/exonum/src/messages/tests.rs
+++ b/exonum/src/messages/tests.rs
@@ -1,20 +1,19 @@
 use chrono::Utc;
-use hex::{self, FromHex};
-use serde_json;
+use hex::FromHex;
 
 use super::{
     BinaryForm, BlockResponse, Message, Precommit, ProtocolMessage, RawTransaction,
     ServiceTransaction, Signed, SignedMessage, Status, TransactionsResponse,
     RAW_TRANSACTION_EMPTY_SIZE, TRANSACTION_RESPONSE_EMPTY_SIZE,
 };
-use blockchain::{Block, BlockProof};
-use crypto::{gen_keypair, hash, PublicKey, SecretKey};
-use helpers::{Height, Round, ValidatorId};
-use proto;
+use crate::blockchain::{Block, BlockProof};
+use crate::crypto::{gen_keypair, hash, PublicKey, SecretKey};
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::proto;
 
 #[test]
 fn test_block_response_empty_size() {
-    use crypto::{gen_keypair_from_seed, Seed};
+    use crate::crypto::{gen_keypair_from_seed, Seed};
     let (public_key, secret_key) = gen_keypair_from_seed(&Seed::new([1; 32]));
     let msg = TransactionsResponse::new(&public_key, vec![]);
     let msg = Message::concrete(msg, public_key, &secret_key);
@@ -65,7 +64,7 @@ fn test_known_transaction() {
 
 #[test]
 fn test_empty_tx_size() {
-    use crypto::{gen_keypair_from_seed, Seed};
+    use crate::crypto::{gen_keypair_from_seed, Seed};
     let (public_key, secret_key) = gen_keypair_from_seed(&Seed::new([1; 32]));
     let set = ServiceTransaction::from_raw_unchecked(0, vec![]);
     let msg = RawTransaction::new(0, set);
@@ -195,7 +194,7 @@ fn test_precommit_serde_correct() {
 #[test]
 #[should_panic(expected = "Cannot verify message.")]
 fn test_precommit_serde_wrong_signature() {
-    use crypto::SIGNATURE_LENGTH;
+    use crate::crypto::SIGNATURE_LENGTH;
 
     let (pub_key, secret_key) = gen_keypair();
     let ts = Utc::now();

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{self, Rng};
+use rand::Rng;
 
 use super::{NodeHandler, NodeRole, RequestData};
-use crypto::PublicKey;
-use events::error::LogError;
-use events::network::ConnectedPeerAddr;
-use helpers::Height;
-use messages::{Connect, Message, PeersRequest, Responses, Service, Signed, Status};
+use crate::crypto::PublicKey;
+use crate::events::error::LogError;
+use crate::events::network::ConnectedPeerAddr;
+use crate::helpers::Height;
+use crate::messages::{Connect, Message, PeersRequest, Responses, Service, Signed, Status};
 
 impl NodeHandler {
     /// Redirects message to the corresponding `handle_...` function.

--- a/exonum/src/node/connect_list.rs
+++ b/exonum/src/node/connect_list.rs
@@ -16,8 +16,8 @@
 
 use std::collections::BTreeMap;
 
-use crypto::PublicKey;
-use node::{ConnectInfo, ConnectListConfig};
+use crate::crypto::PublicKey;
+use crate::node::{ConnectInfo, ConnectListConfig};
 
 /// Network address of the peer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,8 +86,8 @@ mod test {
     use rand_xorshift::XorShiftRng;
 
     use super::*;
-    use crypto::{gen_keypair, PublicKey, PUBLIC_KEY_LENGTH};
-    use node::ConnectInfo;
+    use crate::crypto::{gen_keypair, PublicKey, PUBLIC_KEY_LENGTH};
+    use crate::node::ConnectInfo;
 
     static VALIDATORS: [[u8; 16]; 2] = [[1; 16], [2; 16]];
     static REGULAR_PEERS: [u8; 16] = [3; 16];

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -14,18 +14,17 @@
 
 use std::collections::HashSet;
 
-use blockchain::Schema;
-use crypto::{CryptoHash, Hash, PublicKey};
-use events::InternalRequest;
-use failure;
-use helpers::{Height, Round, ValidatorId};
-use messages::{
+use crate::blockchain::Schema;
+use crate::crypto::{CryptoHash, Hash, PublicKey};
+use crate::events::InternalRequest;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::{
     BlockRequest, BlockResponse, Consensus as ConsensusMessage, Precommit, Prevote,
     PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed, SignedMessage,
     TransactionsRequest, TransactionsResponse,
 };
-use node::{NodeHandler, RequestData};
-use storage::Patch;
+use crate::node::{NodeHandler, RequestData};
+use crate::storage::Patch;
 
 // TODO Reduce view invocations. (ECR-171)
 impl NodeHandler {

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use super::{ConnectListConfig, ExternalMessage, NodeHandler, NodeTimeout};
-use blockchain::Schema;
-use events::{error::LogError, Event, EventHandler, InternalEvent, InternalRequest, NetworkEvent};
+use crate::blockchain::Schema;
+use crate::events::{
+    error::LogError, Event, EventHandler, InternalEvent, InternalRequest, NetworkEvent,
+};
 
 impl EventHandler for NodeHandler {
     fn handle_event(&mut self, event: Event) {

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
 // TODO: Temporary solution to get access to WAIT constants. (ECR-167)
 pub mod state;
 
-use failure::{self, Error};
+use failure::Error;
 use futures::{sync::mpsc, Future, Sink};
 use tokio_core::reactor::Core;
 use tokio_threadpool::Builder as ThreadPoolBuilder;
@@ -41,28 +41,28 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use api::{
+use crate::api::{
     backends::actix::{AllowOrigin, ApiRuntimeConfig, App, AppConfig, Cors, SystemRuntimeConfig},
     ApiAccess, ApiAggregator,
 };
-use blockchain::{
+use crate::blockchain::{
     Blockchain, ConsensusConfig, GenesisConfig, Schema, Service, SharedNodeState, ValidatorKeys,
 };
-use crypto::{self, read_keys_from_file, CryptoHash, Hash, PublicKey, SecretKey};
-use events::{
+use crate::crypto::{self, read_keys_from_file, CryptoHash, Hash, PublicKey, SecretKey};
+use crate::events::{
     error::{into_failure, LogError},
     noise::HandshakeParams,
     HandlerPart, InternalEvent, InternalPart, InternalRequest, NetworkConfiguration, NetworkEvent,
     NetworkPart, NetworkRequest, SyncSender, TimeoutRequest,
 };
-use helpers::{
+use crate::helpers::{
     config::ConfigManager,
     fabric::{NodePrivateConfig, NodePublicConfig},
     user_agent, Height, Milliseconds, Round, ValidatorId,
 };
-use messages::{Connect, Message, ProtocolMessage, RawTransaction, Signed, SignedMessage};
-use node::state::SharedConnectList;
-use storage::{Database, DbOptions};
+use crate::messages::{Connect, Message, ProtocolMessage, RawTransaction, Signed, SignedMessage};
+use crate::node::state::SharedConnectList;
+use crate::storage::{Database, DbOptions};
 
 mod basic;
 mod connect_list;
@@ -1108,14 +1108,15 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use blockchain::{
+    use crate::blockchain::{
         ExecutionResult, Schema, Service, Transaction, TransactionContext, TransactionSet,
     };
-    use crypto::gen_keypair;
-    use events::EventHandler;
-    use helpers;
-    use proto::{schema::tests::TxSimple, ProtobufConvert};
-    use storage::{Database, MemoryDB, Snapshot};
+    use crate::crypto::gen_keypair;
+    use crate::events::EventHandler;
+    use crate::helpers;
+    use crate::proto::{schema::tests::TxSimple, ProtobufConvert};
+    use crate::storage::{Database, MemoryDB, Snapshot};
+
     const SERVICE_ID: u16 = 0;
 
     #[derive(Serialize, Deserialize, Clone, Debug, TransactionSet)]

--- a/exonum/src/node/requests.rs
+++ b/exonum/src/node/requests.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::NodeHandler;
-use blockchain::Schema;
-use messages::{
+use crate::blockchain::Schema;
+use crate::messages::{
     BlockRequest, BlockResponse, PrevotesRequest, ProposeRequest, Requests, Signed,
     TransactionsRequest, TransactionsResponse, RAW_TRANSACTION_HEADER,
     TRANSACTION_RESPONSE_EMPTY_SIZE,

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -15,7 +15,6 @@
 //! State of the `NodeHandler`.
 
 use bit_vec::BitVec;
-use failure;
 use serde_json::Value;
 
 use std::{
@@ -25,19 +24,19 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use blockchain::{ConsensusConfig, StoredConfiguration, ValidatorKeys};
-use crypto::{Hash, PublicKey, SecretKey};
-use events::network::ConnectedPeerAddr;
-use helpers::{Height, Milliseconds, Round, ValidatorId};
-use messages::{
+use crate::blockchain::{ConsensusConfig, StoredConfiguration, ValidatorKeys};
+use crate::crypto::{Hash, PublicKey, SecretKey};
+use crate::events::network::ConnectedPeerAddr;
+use crate::helpers::{Height, Milliseconds, Round, ValidatorId};
+use crate::messages::{
     BlockResponse, Connect, Consensus as ConsensusMessage, Precommit, Prevote, Propose,
     RawTransaction, Signed,
 };
-use node::{
+use crate::node::{
     connect_list::{ConnectList, PeerAddress},
     ConnectInfo,
 };
-use storage::{KeySetIndex, MapIndex, Patch, Snapshot};
+use crate::storage::{KeySetIndex, MapIndex, Patch, Snapshot};
 
 // TODO: Move request timeouts into node configuration. (ECR-171)
 

--- a/exonum/src/proto/mod.rs
+++ b/exonum/src/proto/mod.rs
@@ -70,16 +70,15 @@ pub mod schema;
 #[cfg(test)]
 mod tests;
 
-use bit_vec;
 use chrono::{DateTime, TimeZone, Utc};
 use failure::Error;
 use protobuf::{well_known_types, Message};
 
 use std::collections::HashMap;
 
-use crypto;
-use helpers::{Height, Round, ValidatorId};
-use messages::BinaryForm;
+use crate::crypto;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::BinaryForm;
 
 /// Used for establishing correspondence between rust struct
 /// and protobuf rust struct

--- a/exonum/src/proto/tests.rs
+++ b/exonum/src/proto/tests.rs
@@ -14,13 +14,13 @@
 
 use bit_vec::BitVec;
 use chrono::{DateTime, TimeZone, Utc};
-use crypto::{self, Hash, PublicKey};
 
 use std::collections::HashMap;
 
 use super::schema;
 use super::ProtobufConvert;
-use messages::BinaryForm;
+use crate::crypto::{self, Hash, PublicKey};
+use crate::messages::BinaryForm;
 
 #[test]
 fn test_hash_pb_convert() {

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use proto::schema::tests::TxConfig;
+pub use crate::proto::schema::tests::TxConfig;
 
-use blockchain::{
+use crate::blockchain::{
     ExecutionResult, Schema, Service, StoredConfiguration, Transaction, TransactionContext,
     TransactionSet,
 };
-use crypto::{Hash, PublicKey, SecretKey};
-use helpers::Height;
-use messages::{Message, RawTransaction, Signed};
-use proto::ProtobufConvert;
-use storage::Snapshot;
+use crate::crypto::{Hash, PublicKey, SecretKey};
+use crate::helpers::Height;
+use crate::messages::{Message, RawTransaction, Signed};
+use crate::proto::ProtobufConvert;
+use crate::storage::Snapshot;
 
 pub const CONFIG_SERVICE: u16 = 1;
 

--- a/exonum/src/sandbox/consensus/basic.rs
+++ b/exonum/src/sandbox/consensus/basic.rs
@@ -20,11 +20,11 @@ use rand::{thread_rng, Rng};
 
 use std::collections::BTreeMap;
 
-use blockchain::{Blockchain, Schema, CORE_SERVICE};
-use crypto::{gen_keypair_from_seed, CryptoHash, Hash, Seed, HASH_SIZE, SEED_LENGTH};
-use helpers::{Height, Round, ValidatorId};
-use messages::{Precommit, Signed};
-use sandbox::{
+use crate::blockchain::{Blockchain, Schema, CORE_SERVICE};
+use crate::crypto::{gen_keypair_from_seed, CryptoHash, Hash, Seed, HASH_SIZE, SEED_LENGTH};
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::{Precommit, Signed};
+use crate::sandbox::{
     sandbox::{self, timestamping_sandbox},
     sandbox_tests_helper::*,
     timestamping::{TimestampingTxGenerator, DATA_SIZE, TIMESTAMPING_SERVICE},

--- a/exonum/src/sandbox/consensus/block_request.rs
+++ b/exonum/src/sandbox/consensus/block_request.rs
@@ -16,10 +16,10 @@
 
 use std::time::Duration;
 
-use crypto::CryptoHash;
-use helpers::{Height, Round, ValidatorId};
-use node::state::{BLOCK_REQUEST_TIMEOUT, TRANSACTIONS_REQUEST_TIMEOUT};
-use sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use crate::crypto::CryptoHash;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::node::state::{BLOCK_REQUEST_TIMEOUT, TRANSACTIONS_REQUEST_TIMEOUT};
+use crate::sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
 
 /// HANDLE block response
 

--- a/exonum/src/sandbox/consensus/config.rs
+++ b/exonum/src/sandbox/consensus/config.rs
@@ -14,18 +14,19 @@
 
 //! Tests in this module are designed to test configuration change protocol.
 
-use blockchain::Schema;
-use crypto::CryptoHash;
-use helpers::{Height, ValidatorId};
-use sandbox::{config_updater::TxConfig, sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use crate::blockchain::Schema;
+use crate::crypto::CryptoHash;
+use crate::helpers::{Height, ValidatorId};
+use crate::sandbox::{
+    config_updater::TxConfig, sandbox::timestamping_sandbox, sandbox_tests_helper::*,
+};
+use crate::storage::StorageValue;
 
 /// - exclude validator from consensus
 /// - idea of test is to exclude sandbox validator from consensus
 /// - node continues as `full node`
 #[test]
 fn test_exclude_validator_from_consensus() {
-    use storage::StorageValue;
-
     let sandbox = timestamping_sandbox();
     let sandbox_state = SandboxState::new();
 
@@ -55,8 +56,6 @@ fn test_exclude_validator_from_consensus() {
 /// - idea of the test is check configurations method from schema
 #[test]
 fn test_schema_config_changes() {
-    use storage::StorageValue;
-
     let sandbox = timestamping_sandbox();
     let sandbox_state = SandboxState::new();
 

--- a/exonum/src/sandbox/consensus/invalid_message.rs
+++ b/exonum/src/sandbox/consensus/invalid_message.rs
@@ -15,9 +15,9 @@
 //! Tests in this module are designed to test ability of the node to handle
 //! incorrect messages.
 
-use helpers::{Height, Round, ValidatorId};
-use messages::{Message, Propose};
-use sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::{Message, Propose};
+use crate::sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
 
 /// HANDLE message
 /// - verify signature

--- a/exonum/src/sandbox/consensus/recovery.rs
+++ b/exonum/src/sandbox/consensus/recovery.rs
@@ -17,11 +17,10 @@
 
 use std::time::Duration;
 
-use crypto::CryptoHash;
-use helpers::{user_agent, Height, Round, ValidatorId};
-use node;
-
-use sandbox::{
+use crate::crypto::CryptoHash;
+use crate::helpers::{user_agent, Height, Round, ValidatorId};
+use crate::node;
+use crate::sandbox::{
     sandbox::{timestamping_sandbox, SandboxBuilder},
     sandbox_tests_helper::*,
 };

--- a/exonum/src/sandbox/consensus/round_details.rs
+++ b/exonum/src/sandbox/consensus/round_details.rs
@@ -23,13 +23,13 @@ use bit_vec::BitVec;
 
 use std::time::Duration;
 
-use crypto::CryptoHash;
-use helpers::{Height, Round, ValidatorId};
-use messages::{PrevotesRequest, ProtocolMessage, TransactionsRequest};
-use node::state::{
+use crate::crypto::CryptoHash;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::messages::{PrevotesRequest, ProtocolMessage, TransactionsRequest};
+use crate::node::state::{
     PREVOTES_REQUEST_TIMEOUT, PROPOSE_REQUEST_TIMEOUT, TRANSACTIONS_REQUEST_TIMEOUT,
 };
-use sandbox::{
+use crate::sandbox::{
     sandbox::{self, timestamping_sandbox},
     sandbox_tests_helper::*,
 };

--- a/exonum/src/sandbox/consensus/timeouts.rs
+++ b/exonum/src/sandbox/consensus/timeouts.rs
@@ -16,11 +16,10 @@
 
 use std::time::Duration;
 
-use crypto::CryptoHash;
-use helpers::{Height, Round, ValidatorId};
-use node::state::PROPOSE_REQUEST_TIMEOUT;
-
-use sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use crate::crypto::CryptoHash;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::node::state::PROPOSE_REQUEST_TIMEOUT;
+use crate::sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
 
 /// HANDLE ROUND TIMEOUT:
 /// - Ignore if height and round are not the same

--- a/exonum/src/sandbox/consensus/transactions.rs
+++ b/exonum/src/sandbox/consensus/transactions.rs
@@ -18,11 +18,11 @@ use bit_vec::BitVec;
 
 use std::time::Duration;
 
-use crypto::{gen_keypair, CryptoHash, Hash};
-use helpers::{Height, Milliseconds, Round, ValidatorId};
-use messages::{RawTransaction, Signed};
-use node::state::TRANSACTIONS_REQUEST_TIMEOUT;
-use sandbox::{
+use crate::crypto::{gen_keypair, CryptoHash, Hash};
+use crate::helpers::{Height, Milliseconds, Round, ValidatorId};
+use crate::messages::{RawTransaction, Signed};
+use crate::node::state::TRANSACTIONS_REQUEST_TIMEOUT;
+use crate::sandbox::{
     config_updater::TxConfig,
     sandbox::{timestamping_sandbox, timestamping_sandbox_builder, Sandbox},
     sandbox_tests_helper::*,
@@ -318,8 +318,8 @@ fn incorrect_tx_in_request() {
 
 #[test]
 fn response_size_larger_than_max_message_len() {
-    use messages::{RAW_TRANSACTION_HEADER, TRANSACTION_RESPONSE_EMPTY_SIZE};
-    use storage::StorageValue;
+    use crate::messages::{RAW_TRANSACTION_HEADER, TRANSACTION_RESPONSE_EMPTY_SIZE};
+    use crate::storage::StorageValue;
 
     let sandbox = timestamping_sandbox();
     let sandbox_state = SandboxState::new();

--- a/exonum/src/sandbox/consensus/unsynchronized_message.rs
+++ b/exonum/src/sandbox/consensus/unsynchronized_message.rs
@@ -17,9 +17,9 @@
 
 use std::time::Duration;
 
-use crypto::CryptoHash;
-use helpers::{Height, Round, ValidatorId};
-use sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
+use crate::crypto::CryptoHash;
+use crate::helpers::{Height, Round, ValidatorId};
+use crate::sandbox::{sandbox::timestamping_sandbox, sandbox_tests_helper::*};
 
 #[test]
 fn test_queue_message_from_future_round() {

--- a/exonum/src/sandbox/old.rs
+++ b/exonum/src/sandbox/old.rs
@@ -18,9 +18,9 @@ use super::{
     sandbox::timestamping_sandbox,
     sandbox_tests_helper::{gen_timestamping_tx, NOT_LOCKED},
 };
-use blockchain::Block;
-use crypto::{CryptoHash, Hash};
-use helpers::{Height, Round, ValidatorId};
+use crate::blockchain::Block;
+use crate::crypto::{CryptoHash, Hash};
+use crate::helpers::{Height, Round, ValidatorId};
 
 #[test]
 fn test_send_propose_and_prevote() {

--- a/exonum/src/sandbox/sandbox.rs
+++ b/exonum/src/sandbox/sandbox.rs
@@ -15,12 +15,9 @@
 // Workaround: Clippy does not correctly handle borrowing checking rules for returned types.
 #![cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
 use bit_vec::BitVec;
-use chrono;
-use env_logger;
-use futures::{self, sync::mpsc, Async, Future, Sink, Stream};
+use futures::{sync::mpsc, Async, Future, Sink, Stream};
 
 use std::{
-    self,
     cell::{Ref, RefCell, RefMut},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque},
     iter::FromIterator,
@@ -34,27 +31,29 @@ use super::{
     config_updater::ConfigUpdateService, sandbox_tests_helper::PROPOSE_TIMEOUT,
     timestamping::TimestampingService,
 };
-use blockchain::{
-    Block, BlockProof, Blockchain, ConsensusConfig, GenesisConfig, Schema, Service,
-    SharedNodeState, StoredConfiguration, Transaction, ValidatorKeys,
+use crate::{
+    blockchain::{
+        Block, BlockProof, Blockchain, ConsensusConfig, GenesisConfig, Schema, Service,
+        SharedNodeState, StoredConfiguration, Transaction, ValidatorKeys,
+    },
+    crypto::{gen_keypair, gen_keypair_from_seed, Hash, PublicKey, SecretKey, Seed, SEED_LENGTH},
+    events::{
+        network::NetworkConfiguration, Event, EventHandler, InternalEvent, InternalRequest,
+        NetworkEvent, NetworkRequest, TimeoutRequest,
+    },
+    helpers::{user_agent, Height, Milliseconds, Round, ValidatorId},
+    messages::{
+        BlockRequest, BlockResponse, Connect, Message, PeersRequest, Precommit, Prevote,
+        PrevotesRequest, Propose, ProposeRequest, ProtocolMessage, RawTransaction, Signed,
+        SignedMessage, Status, TransactionsRequest, TransactionsResponse,
+    },
+    node::{
+        ApiSender, Configuration, ConnectInfo, ConnectList, ConnectListConfig, ExternalMessage,
+        ListenerConfig, NodeHandler, NodeSender, PeerAddress, ServiceConfig, State,
+        SystemStateProvider,
+    },
+    storage::{MapProof, MemoryDB},
 };
-use crypto::{gen_keypair, gen_keypair_from_seed, Hash, PublicKey, SecretKey, Seed, SEED_LENGTH};
-use events::{
-    network::NetworkConfiguration, Event, EventHandler, InternalEvent, InternalRequest,
-    NetworkEvent, NetworkRequest, TimeoutRequest,
-};
-use helpers::{user_agent, Height, Milliseconds, Round, ValidatorId};
-use messages::{
-    BlockRequest, BlockResponse, Connect, Message, PeersRequest, Precommit, Prevote,
-    PrevotesRequest, Propose, ProposeRequest, ProtocolMessage, RawTransaction, Signed,
-    SignedMessage, Status, TransactionsRequest, TransactionsResponse,
-};
-use node::ConnectInfo;
-use node::{
-    ApiSender, Configuration, ConnectList, ConnectListConfig, ExternalMessage, ListenerConfig,
-    NodeHandler, NodeSender, PeerAddress, ServiceConfig, State, SystemStateProvider,
-};
-use storage::{MapProof, MemoryDB};
 
 pub type SharedTime = Arc<Mutex<SystemTime>>;
 
@@ -1161,12 +1160,12 @@ pub fn timestamping_sandbox_builder() -> SandboxBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use blockchain::{ExecutionResult, ServiceContext, TransactionContext, TransactionSet};
-    use crypto::{gen_keypair_from_seed, Seed};
-    use messages::RawTransaction;
-    use proto::schema::tests::TxAfterCommit;
-    use sandbox::sandbox_tests_helper::{add_one_height, SandboxState};
-    use storage::Snapshot;
+    use crate::blockchain::{ExecutionResult, ServiceContext, TransactionContext, TransactionSet};
+    use crate::crypto::{gen_keypair_from_seed, Seed};
+    use crate::messages::RawTransaction;
+    use crate::proto::schema::tests::TxAfterCommit;
+    use crate::sandbox::sandbox_tests_helper::{add_one_height, SandboxState};
+    use crate::storage::Snapshot;
 
     const SERVICE_ID: u16 = 1;
 

--- a/exonum/src/sandbox/sandbox_tests_helper.rs
+++ b/exonum/src/sandbox/sandbox_tests_helper.rs
@@ -19,13 +19,13 @@ use std::{cell::RefCell, collections::BTreeMap, time::Duration};
 
 use super::timestamping::DATA_SIZE;
 use super::{sandbox::Sandbox, timestamping::TimestampingTxGenerator};
-use blockchain::Block;
-use crypto::{CryptoHash, Hash, HASH_SIZE};
-use helpers::{Height, Milliseconds, Round, ValidatorId};
-use messages::{
+use crate::blockchain::Block;
+use crate::crypto::{CryptoHash, Hash, HASH_SIZE};
+use crate::helpers::{Height, Milliseconds, Round, ValidatorId};
+use crate::messages::{
     Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed,
 };
-use storage::Database;
+use crate::storage::{Database, MemoryDB, ProofListIndex};
 
 pub type TimestampingSandbox = Sandbox;
 
@@ -202,8 +202,6 @@ pub fn empty_hash() -> Hash {
 }
 
 pub fn compute_txs_merkle_root(txs: &[Hash]) -> Hash {
-    use storage::{MemoryDB, ProofListIndex};
-
     let mut fork = MemoryDB::new().fork();
     let mut hashes = ProofListIndex::new("name", &mut fork);
     hashes.extend(txs.iter().cloned());

--- a/exonum/src/sandbox/timestamping.rs
+++ b/exonum/src/sandbox/timestamping.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use proto::schema::tests::TimestampTx;
+pub use crate::proto::schema::tests::TimestampTx;
 
 use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
-use blockchain::{ExecutionResult, Service, Transaction, TransactionContext, TransactionSet};
-use crypto::{gen_keypair, Hash, PublicKey, SecretKey, HASH_SIZE};
-use messages::{Message, RawTransaction, Signed};
-use storage::Snapshot;
+use crate::blockchain::{
+    ExecutionResult, Service, Transaction, TransactionContext, TransactionSet,
+};
+use crate::crypto::{gen_keypair, Hash, PublicKey, SecretKey, HASH_SIZE};
+use crate::messages::{Message, RawTransaction, Signed};
+use crate::storage::Snapshot;
 
 pub const TIMESTAMPING_SERVICE: u16 = 129;
 pub const DATA_SIZE: usize = 64;

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -23,7 +23,7 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use super::{Fork, Iter, Snapshot, StorageKey, StorageValue};
-use storage::indexes_metadata::{self, IndexType, INDEXES_METADATA_TABLE_NAME};
+use crate::storage::indexes_metadata::{self, IndexType, INDEXES_METADATA_TABLE_NAME};
 
 /// Basic struct for all indices that implements common features.
 ///
@@ -308,7 +308,7 @@ impl<'a, K, V> ::std::fmt::Debug for BaseIndexIter<'a, K, V> {
 /// and underscores.
 fn is_valid_name<S: AsRef<str>>(name: S) -> bool {
     name.as_ref().as_bytes().iter().all(|c| match *c {
-        48...57 | 65...90 | 97...122 | 95 | 46 => true,
+        48..=57 | 65..=90 | 97..=122 | 95 | 46 => true,
         _ => false,
     })
 }

--- a/exonum/src/storage/entry.rs
+++ b/exonum/src/storage/entry.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 use super::{
     base_index::BaseIndex, indexes_metadata::IndexType, Fork, Snapshot, StorageKey, StorageValue,
 };
-use crypto::Hash;
+use crate::crypto::Hash;
 
 /// An index that may only contain one element.
 ///

--- a/exonum/src/storage/hash.rs
+++ b/exonum/src/storage/hash.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crypto::{CryptoHash, Hash};
+use crate::crypto::{CryptoHash, Hash};
 
 /// A common trait for the ability to compute a unique hash.
 ///

--- a/exonum/src/storage/indexes_metadata.rs
+++ b/exonum/src/storage/indexes_metadata.rs
@@ -14,13 +14,13 @@
 
 #![allow(unsafe_code)]
 
-use serde_json::{self, Error as JsonError};
+use serde_json::Error as JsonError;
 
 use std::fmt;
 
-use crypto::{self, CryptoHash, Hash};
-use proto::{self, ProtobufConvert};
-use storage::{base_index::BaseIndex, Fork, Snapshot, StorageValue};
+use crate::crypto::{self, CryptoHash, Hash};
+use crate::proto::{self, ProtobufConvert};
+use crate::storage::{base_index::BaseIndex, Fork, Snapshot, StorageValue};
 
 pub const INDEXES_METADATA_TABLE_NAME: &str = "__INDEXES_METADATA__";
 
@@ -195,8 +195,10 @@ mod tests {
         IndexMetadata, IndexType, StorageMetadata, CORE_STORAGE_METADATA,
         CORE_STORAGE_METADATA_KEY, INDEXES_METADATA_TABLE_NAME,
     };
-    use crypto::{Hash, PublicKey};
-    use storage::{base_index::BaseIndex, Database, Fork, MapIndex, MemoryDB, ProofMapIndex};
+    use crate::crypto::{Hash, PublicKey};
+    use crate::storage::{
+        base_index::BaseIndex, Database, Fork, MapIndex, MemoryDB, ProofMapIndex,
+    };
 
     #[test]
     fn index_metadata_roundtrip() {

--- a/exonum/src/storage/keys.rs
+++ b/exonum/src/storage/keys.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
-use crypto::{Hash, PublicKey, Signature, HASH_SIZE, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
+use crate::crypto::{Hash, PublicKey, Signature, HASH_SIZE, PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH};
 
 /// A type that can be (de)serialized as a key in the blockchain storage.
 ///
@@ -315,6 +315,8 @@ mod tests {
     use chrono::{Duration, TimeZone};
     use hex::FromHex;
 
+    use crate::storage::{Database, MapIndex, MemoryDB};
+
     // Number of samples for fuzz testing
     const FUZZ_SAMPLES: usize = 100_000;
 
@@ -393,8 +395,6 @@ mod tests {
 
     #[test]
     fn signed_int_key_in_index() {
-        use storage::{Database, MapIndex, MemoryDB};
-
         let db: Box<dyn Database> = Box::new(MemoryDB::new());
         let mut fork = db.fork();
         {
@@ -424,8 +424,6 @@ mod tests {
     // for signed integers.
     #[test]
     fn old_signed_int_key_in_index() {
-        use storage::{Database, MapIndex, MemoryDB};
-
         // Simple wrapper around a signed integer type with the `StorageKey` implementation,
         // which was used in Exonum <= 0.5.
         #[derive(Debug, PartialEq, Clone)]
@@ -519,8 +517,6 @@ mod tests {
 
     #[test]
     fn system_time_key_in_index() {
-        use storage::{Database, MapIndex, MemoryDB};
-
         let db: Box<dyn Database> = Box::new(MemoryDB::new());
         let x1 = Utc.timestamp(80, 0);
         let x2 = Utc.timestamp(10, 0);

--- a/exonum/src/storage/list_index.rs
+++ b/exonum/src/storage/list_index.rs
@@ -468,9 +468,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Fork, ListIndex, Snapshot};
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
-    use storage::Database;
+
+    use super::{Fork, ListIndex, Snapshot};
+    use crate::storage::Database;
 
     fn gen_tempdir_name() -> String {
         thread_rng().sample_iter(&Alphanumeric).take(10).collect()
@@ -594,9 +595,11 @@ mod tests {
         &[(0, 5, false), (5, 0, false), (1, 7, true), (7, 1, true)];
 
     mod memorydb_tests {
-        use std::path::Path;
-        use storage::{Database, ListIndex, MemoryDB};
         use tempdir::TempDir;
+
+        use std::path::Path;
+
+        use crate::storage::{Database, ListIndex, MemoryDB};
 
         const IDX_NAME: &'static str = "idx_name";
 
@@ -656,9 +659,11 @@ mod tests {
     }
 
     mod rocksdb_tests {
-        use std::path::Path;
-        use storage::{Database, DbOptions, ListIndex, RocksDB};
         use tempdir::TempDir;
+
+        use std::path::Path;
+
+        use crate::storage::{Database, DbOptions, ListIndex, RocksDB};
 
         const IDX_NAME: &'static str = "idx_name";
 

--- a/exonum/src/storage/map_index.rs
+++ b/exonum/src/storage/map_index.rs
@@ -606,9 +606,11 @@ mod tests {
     }
 
     mod memorydb_tests {
-        use std::path::Path;
-        use storage::{Database, MemoryDB};
         use tempdir::TempDir;
+
+        use std::path::Path;
+
+        use crate::storage::{Database, MemoryDB};
 
         fn create_database(_: &Path) -> Box<dyn Database> {
             Box::new(MemoryDB::new())
@@ -632,12 +634,13 @@ mod tests {
     }
 
     mod rocksdb_tests {
-        use std::path::Path;
-        use storage::Database;
         use tempdir::TempDir;
 
+        use std::path::Path;
+
+        use crate::storage::{Database, DbOptions, RocksDB};
+
         fn create_database(path: &Path) -> Box<dyn Database> {
-            use storage::{DbOptions, RocksDB};
             let opts = DbOptions::default();
             Box::new(RocksDB::open(path, &opts).unwrap())
         }

--- a/exonum/src/storage/proof_list_index/mod.rs
+++ b/exonum/src/storage/proof_list_index/mod.rs
@@ -24,7 +24,7 @@ use super::{
     indexes_metadata::IndexType,
     Fork, Snapshot, StorageKey, StorageValue,
 };
-use crypto::{hash, Hash, HashStream};
+use crate::crypto::{hash, Hash, HashStream};
 
 mod key;
 mod proof;

--- a/exonum/src/storage/proof_list_index/proof.rs
+++ b/exonum/src/storage/proof_list_index/proof.rs
@@ -16,7 +16,7 @@ use serde::{de::Error, ser::SerializeStruct, Deserialize, Deserializer, Serializ
 use serde_json::{from_value, Error as SerdeJsonError, Value};
 
 use super::{super::StorageValue, hash_one, hash_pair, key::ProofListKey};
-use crypto::Hash;
+use crate::crypto::Hash;
 
 /// An enum that represents a proof of existence for a proof list elements.
 #[derive(Debug, PartialEq, Eq)]

--- a/exonum/src/storage/proof_list_index/tests.rs
+++ b/exonum/src/storage/proof_list_index/tests.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng, RngCore};
+use serde::Serialize;
+use serde_json::{from_str, to_string};
 
 use self::ListProof::*;
 use super::{hash_one, hash_pair, root_hash, ListProof, ProofListIndex};
-use crypto::{hash, CryptoHash, Hash};
-use serde::Serialize;
-use serde_json::{from_str, to_string};
-use storage::Database;
+use crate::crypto::{hash, CryptoHash, Hash};
+use crate::storage::Database;
 
 const IDX_NAME: &'static str = "idx_name";
 
@@ -544,7 +544,7 @@ fn same_merkle_root(db1: Box<dyn Database>, db2: Box<dyn Database>) {
 }
 
 #[derive(Serialize)]
-struct ProofInfo<'a, V: Serialize + 'a> {
+struct ProofInfo<'a, V: Serialize> {
     merkle_root: Hash,
     list_length: u64,
     proof: &'a ListProof<V>,
@@ -553,9 +553,11 @@ struct ProofInfo<'a, V: Serialize + 'a> {
 }
 
 mod memorydb_tests {
-    use std::path::Path;
-    use storage::{Database, MemoryDB};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use crate::storage::{Database, MemoryDB};
 
     fn create_database(_: &Path) -> Box<dyn Database> {
         Box::new(MemoryDB::new())
@@ -665,9 +667,11 @@ mod memorydb_tests {
 }
 
 mod rocksdb_tests {
-    use std::path::Path;
-    use storage::{Database, DbOptions, RocksDB};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use crate::storage::{Database, DbOptions, RocksDB};
 
     fn create_database(path: &Path) -> Box<dyn Database> {
         let opts = DbOptions::default();
@@ -778,8 +782,8 @@ mod rocksdb_tests {
 }
 
 mod root_hash_tests {
-    use crypto::{self, Hash};
-    use storage::{Database, MemoryDB, ProofListIndex};
+    use crate::crypto::{self, Hash};
+    use crate::storage::{Database, MemoryDB, ProofListIndex};
 
     /// Cross-verify `root_hash()` with `ProofListIndex` against expected root hash value.
     fn assert_root_hash_correct(hashes: &[Hash]) {

--- a/exonum/src/storage/proof_map_index/key.rs
+++ b/exonum/src/storage/proof_map_index/key.rs
@@ -15,8 +15,8 @@
 use std::cmp::{min, Ordering};
 use std::ops;
 
-use crypto::{CryptoHash, Hash, PublicKey, HASH_SIZE};
-use storage::StorageKey;
+use crate::crypto::{CryptoHash, Hash, PublicKey, HASH_SIZE};
+use crate::storage::StorageKey;
 
 pub const BRANCH_KEY_PREFIX: u8 = 0;
 pub const LEAF_KEY_PREFIX: u8 = 1;
@@ -57,10 +57,10 @@ where
     /// The buffer is guaranteed to have size [`PROOF_MAP_KEY_SIZE`].
     ///
     /// [`PROOF_MAP_KEY_SIZE`]: constant.PROOF_MAP_KEY_SIZE.html
-    fn write_key(&self, &mut [u8]);
+    fn write_key(&self, key: &mut [u8]);
 
     /// Reads this key from the buffer.
-    fn read_key(&[u8]) -> Self::Output;
+    fn read_key(key: &[u8]) -> Self::Output;
 }
 
 /// A trait denoting that a certain storage value is suitable for use as a key for
@@ -472,8 +472,8 @@ impl PartialOrd for ProofPath {
 
 #[cfg(test)]
 mod tests {
-    use rand::{self, Rng};
-    use serde_json::{self, Value};
+    use rand::Rng;
+    use serde_json::Value;
 
     use super::*;
 

--- a/exonum/src/storage/proof_map_index/mod.rs
+++ b/exonum/src/storage/proof_map_index/mod.rs
@@ -31,7 +31,7 @@ use super::{
     indexes_metadata::IndexType,
     Fork, Snapshot, StorageKey, StorageValue,
 };
-use crypto::{CryptoHash, Hash, HashStream};
+use crate::crypto::{CryptoHash, Hash, HashStream};
 
 mod key;
 mod node;

--- a/exonum/src/storage/proof_map_index/node.rs
+++ b/exonum/src/storage/proof_map_index/node.rs
@@ -20,7 +20,7 @@ use super::{
     super::{StorageKey, StorageValue},
     key::{ChildKind, ProofPath, PROOF_PATH_SIZE},
 };
-use crypto::{hash, CryptoHash, Hash, HASH_SIZE};
+use crate::crypto::{hash, CryptoHash, Hash, HASH_SIZE};
 
 const BRANCH_NODE_SIZE: usize = 2 * (HASH_SIZE + PROOF_PATH_SIZE);
 

--- a/exonum/src/storage/proof_map_index/proof.rs
+++ b/exonum/src/storage/proof_map_index/proof.rs
@@ -22,8 +22,8 @@ use super::{
     key::{BitsRange, ChildKind, ProofMapKey, ProofPath, KEY_SIZE},
     node::{BranchNode, Node},
 };
-use crypto::{CryptoHash, Hash, HashStream};
-use storage::StorageValue;
+use crate::crypto::{CryptoHash, Hash, HashStream};
+use crate::storage::StorageValue;
 
 // Expected size of the proof, in number of hashed entries.
 const DEFAULT_PROOF_CAPACITY: usize = 8;

--- a/exonum/src/storage/proof_map_index/tests.rs
+++ b/exonum/src/storage/proof_map_index/tests.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use rand::{
-    self,
     distributions::Alphanumeric,
     seq::{IteratorRandom, SliceRandom},
     Rng, RngCore, SeedableRng,
 };
 use rand_xorshift::XorShiftRng;
-use serde_json;
+use serde::{de::DeserializeOwned, Serialize};
 
 use std::{cmp, collections::HashSet, fmt::Debug, hash::Hash as StdHash};
 
@@ -29,10 +28,9 @@ use super::{
     proof::MapProofBuilder,
     HashedKey, MapProof, MapProofError, ProofMapIndex, ProofMapKey, ProofPath,
 };
-use crypto::{hash, CryptoHash, Hash, HashStream};
-use proto;
-use serde::{de::DeserializeOwned, Serialize};
-use storage::{Database, Fork, StorageValue};
+use crate::crypto::{hash, CryptoHash, Hash, HashStream};
+use crate::proto;
+use crate::storage::{Database, Fork, StorageValue};
 
 const IDX_NAME: &'static str = "idx_name";
 
@@ -1393,9 +1391,11 @@ macro_rules! common_tests {
 }
 
 mod memorydb_tests {
-    use std::path::Path;
-    use storage::{Database, MemoryDB};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use crate::storage::{Database, MemoryDB};
 
     fn create_database(_: &Path) -> Box<dyn Database> {
         Box::new(MemoryDB::new())
@@ -1405,9 +1405,11 @@ mod memorydb_tests {
 }
 
 mod rocksdb_tests {
-    use std::path::Path;
-    use storage::{Database, DbOptions, RocksDB};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use crate::storage::{Database, DbOptions, RocksDB};
 
     fn create_database(path: &Path) -> Box<dyn Database> {
         let opts = DbOptions::default();

--- a/exonum/src/storage/rocksdb.rs
+++ b/exonum/src/storage/rocksdb.rs
@@ -16,13 +16,16 @@
 
 //! An implementation of `RocksDB` database.
 
-pub use rocksdb::{BlockBasedOptions as RocksBlockOptions, WriteOptions as RocksDBWriteOptions};
-
-use rocksdb::{self, utils::get_cf_names, DBIterator, Options as RocksDbOptions, WriteBatch};
+pub use crate::rocksdb::{
+    BlockBasedOptions as RocksBlockOptions, WriteOptions as RocksDBWriteOptions,
+};
 
 use std::{error::Error, fmt, iter::Peekable, mem, path::Path, sync::Arc};
 
-use storage::{self, db::Change, Database, DbOptions, Iter, Iterator, Patch, Snapshot};
+use crate::rocksdb::{
+    self, utils::get_cf_names, DBIterator, Options as RocksDbOptions, WriteBatch,
+};
+use crate::storage::{self, db::Change, Database, DbOptions, Iter, Iterator, Patch, Snapshot};
 
 impl From<rocksdb::Error> for storage::Error {
     fn from(err: rocksdb::Error) -> Self {
@@ -134,7 +137,7 @@ impl Snapshot for RocksDBSnapshot {
     }
 
     fn iter<'a>(&'a self, name: &str, from: &[u8]) -> Iter<'a> {
-        use rocksdb::{Direction, IteratorMode};
+        use crate::rocksdb::{Direction, IteratorMode};
         let iter = match self.db.cf_handle(name) {
             Some(cf) => self
                 .snapshot

--- a/exonum/src/storage/sparse_list_index.rs
+++ b/exonum/src/storage/sparse_list_index.rs
@@ -29,7 +29,7 @@ use super::{
     indexes_metadata::IndexType,
     Fork, Snapshot, StorageKey, StorageValue,
 };
-use crypto::{hash, CryptoHash, Hash};
+use crate::crypto::{hash, CryptoHash, Hash};
 
 #[derive(Debug, Default, Clone, Copy)]
 struct SparseListSize {
@@ -634,9 +634,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::SparseListIndex;
     use rand::{distributions::Alphanumeric, thread_rng, Rng};
-    use storage::db::Database;
+
+    use super::SparseListIndex;
+    use crate::storage::db::Database;
 
     const IDX_NAME: &'static str = "idx_name";
 
@@ -755,9 +756,11 @@ mod tests {
     }
 
     mod memorydb_tests {
-        use std::path::Path;
-        use storage::{Database, MemoryDB};
         use tempdir::TempDir;
+
+        use std::path::Path;
+
+        use crate::storage::{Database, MemoryDB};
 
         fn create_database(_: &Path) -> Box<dyn Database> {
             Box::new(MemoryDB::new())
@@ -781,9 +784,11 @@ mod tests {
     }
 
     mod rocksdb_tests {
-        use std::path::Path;
-        use storage::{Database, DbOptions, RocksDB};
         use tempdir::TempDir;
+
+        use std::path::Path;
+
+        use crate::storage::{Database, DbOptions, RocksDB};
 
         fn create_database(path: &Path) -> Box<dyn Database> {
             let opts = DbOptions::default();

--- a/exonum/src/storage/tests.rs
+++ b/exonum/src/storage/tests.rs
@@ -16,7 +16,7 @@ use super::{
     Database, Entry, Fork, KeySetIndex, ListIndex, MapIndex, ProofListIndex, ProofMapIndex,
     Snapshot, SparseListIndex, ValueSetIndex,
 };
-use crypto::Hash;
+use crate::crypto::Hash;
 
 const IDX_NAME: &'static str = "idx_name";
 
@@ -202,10 +202,12 @@ mod memorydb_tests {
 }
 
 mod rocksdb_tests {
-    use super::super::{DbOptions, RocksDB};
-    use std::path::Path;
-    use storage::{Database, ListIndex, Snapshot};
     use tempdir::TempDir;
+
+    use std::path::Path;
+
+    use super::super::{DbOptions, RocksDB};
+    use crate::storage::{Database, ListIndex, Snapshot};
 
     fn rocksdb_database(path: &Path) -> RocksDB {
         let options = DbOptions::default();
@@ -267,7 +269,7 @@ mod rocksdb_tests {
 // This should compile to ensure ?Sized bound on `new_in_family` (see #1024).
 #[allow(dead_code, unreachable_code, unused_variables)]
 fn should_compile() {
-    let mut fork: Fork = unimplemented!();
+    let fork: Fork = unimplemented!();
     let _: Entry<_, ()> = Entry::new_in_family("", "", &mut fork);
     let _: KeySetIndex<_, Hash> = KeySetIndex::new_in_family("", "", &mut fork);
     let _: ListIndex<_, ()> = ListIndex::new_in_family("", "", &mut fork);

--- a/exonum/src/storage/value_set_index.rs
+++ b/exonum/src/storage/value_set_index.rs
@@ -25,7 +25,7 @@ use super::{
     indexes_metadata::IndexType,
     Fork, Snapshot, StorageKey, StorageValue,
 };
-use crypto::Hash;
+use crate::crypto::Hash;
 
 /// A set of value items.
 ///

--- a/exonum/src/storage/values.rs
+++ b/exonum/src/storage/values.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 use std::{borrow::Cow, mem};
 
 use super::UniqueHash;
-use crypto::{Hash, PublicKey};
-use helpers::Round;
+use crate::crypto::{Hash, PublicKey};
+use crate::helpers::Round;
 
 /// A type that can be (de)serialized as a value in the blockchain storage.
 ///

--- a/exonum/tests/collections/main.rs
+++ b/exonum/tests/collections/main.rs
@@ -16,8 +16,6 @@
 
 #[macro_use]
 extern crate proptest;
-extern crate exonum;
-extern crate modifier;
 
 macro_rules! proptest_compare_collections {
     ($name:ident, $collection:ident, $reference:ident, $action:ident) => {

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 // This is a regression test for exonum configuration.
-extern crate exonum;
+
 #[macro_use]
 extern crate pretty_assertions;
 #[macro_use]
 extern crate serde_derive;
-extern crate toml;
 
 use exonum::{
     api::backends::actix::AllowOrigin,
@@ -185,7 +184,7 @@ fn override_validators_count(config: &str, n: usize, folder: &str) {
 
         let mut value = contents.as_str().parse::<Value>().unwrap();
         {
-            let mut count = value
+            let count = value
                 .get_mut("common")
                 .unwrap()
                 .get_mut("general_config")

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -14,10 +14,7 @@
 
 //! Simplified blockchain emulation for the `BlockchainExplorer`.
 
-extern crate failure;
-extern crate futures;
-
-use self::futures::sync::mpsc;
+use futures::sync::mpsc;
 
 use exonum::{
     blockchain::{
@@ -104,11 +101,11 @@ impl Service for MyService {
         "my-service"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         vec![]
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         ExplorerTransactions::tx_from_raw(raw).map(ExplorerTransactions::into)
     }
 }

--- a/exonum/tests/explorer/main.rs
+++ b/exonum/tests/explorer/main.rs
@@ -14,19 +14,15 @@
 
 //! Tests for the blockchain explorer functionality.
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
 extern crate serde_json;
-
 #[macro_use]
 extern crate serde_derive;
-
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-extern crate protobuf;
 
 use exonum::{
     blockchain::{Schema, TransactionErrorType, TransactionSet, TxLocation},
@@ -36,7 +32,7 @@ use exonum::{
     messages::{self, Message, RawTransaction, Signed},
 };
 
-use blockchain::{
+use crate::blockchain::{
     create_block, create_blockchain, CreateWallet, ExplorerTransactions, Transfer, SERVICE_ID,
 };
 
@@ -205,7 +201,7 @@ fn test_explorer_pool_transaction() {
     assert_eq!(tx_info.content().signed_message(), &tx_alice);
 }
 
-fn tx_generator() -> Box<Iterator<Item = Signed<RawTransaction>>> {
+fn tx_generator() -> Box<dyn Iterator<Item = Signed<RawTransaction>>> {
     Box::new((0..).map(|i| {
         let (pk, key) = crypto::gen_keypair();
         Message::sign_transaction(

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 // This is a regression test for exonum node.
-extern crate exonum;
-extern crate failure;
-extern crate futures;
-extern crate serde_json;
-extern crate tokio;
-extern crate tokio_core;
 
 use futures::{sync::oneshot, Future, IntoFuture};
 use serde_json::Value;
@@ -51,11 +45,11 @@ impl Service for CommitWatcherService {
         "commit_watcher"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
-    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         unreachable!("An unknown transaction received");
     }
 
@@ -77,11 +71,11 @@ impl Service for InitializeCheckerService {
         "initialize_checker"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
-    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, _raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         unreachable!("An unknown transaction received");
     }
 
@@ -152,7 +146,7 @@ fn test_node_restart_regression() {
         node_thread.join().unwrap();
     };
 
-    let db = Arc::from(Box::new(MemoryDB::new()) as Box<Database>) as Arc<Database>;
+    let db = Arc::from(Box::new(MemoryDB::new()) as Box<dyn Database>) as Arc<dyn Database>;
     let node_cfg = helpers::generate_testnet_config(1, 3600)[0].clone();
 
     let init_times = Arc::new(Mutex::new(0));

--- a/exonum/tests/proof_map_index.rs
+++ b/exonum/tests/proof_map_index.rs
@@ -22,17 +22,12 @@
 
 // cspell:ignore proptest
 
-extern crate exonum;
 #[macro_use]
 extern crate proptest;
 
 use exonum::storage::{
     proof_map_index::{ProofMapKey, ProofPath},
     Database, MapProof, MemoryDB, ProofMapIndex, Snapshot, StorageValue,
-};
-use prop::{
-    array,
-    collection::{btree_map, vec},
 };
 use proptest::{prelude::*, test_runner::Config};
 
@@ -42,11 +37,16 @@ use std::{
     ops::Range,
 };
 
+use crate::prop::{
+    array,
+    collection::{btree_map, vec},
+};
+
 const INDEX_NAME: &str = "index";
 
 fn check_map_proof<T, K, V>(proof: MapProof<K, V>, key: Option<K>, table: &ProofMapIndex<T, K, V>)
 where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: ProofMapKey + PartialEq + Debug,
     V: StorageValue + PartialEq + Debug,
 {
@@ -71,7 +71,7 @@ fn check_map_multiproof<T, K, V>(
     keys: BTreeSet<K>,
     table: &ProofMapIndex<T, K, V>,
 ) where
-    T: AsRef<Snapshot>,
+    T: AsRef<dyn Snapshot>,
     K: ProofMapKey + Clone + PartialEq + Debug,
     V: StorageValue + Clone + PartialEq + Debug,
 {

--- a/services/configuration/Cargo.toml
+++ b/services/configuration/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-configuration"
 version = "0.10.1"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/doc/advanced/configuration-updater/"
 repository = "https://github.com/exonum/exonum"

--- a/services/configuration/examples/configuration.rs
+++ b/services/configuration/examples/configuration.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_configuration as configuration;
-
 use exonum::helpers::fabric::NodeBuilder;
+use exonum_configuration as configuration;
 
 fn main() {
     exonum::helpers::init_logger().unwrap();

--- a/services/configuration/src/cmd.rs
+++ b/services/configuration/src/cmd.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use failure;
 use toml::Value;
 
 use exonum::{
@@ -25,8 +24,7 @@ use exonum::{
 
 use std::collections::BTreeMap;
 
-use config::ConfigurationServiceConfig;
-use errors::Error as ServiceError;
+use crate::{config::ConfigurationServiceConfig, errors::Error as ServiceError};
 
 pub struct GenerateCommonConfig;
 

--- a/services/configuration/src/errors.rs
+++ b/services/configuration/src/errors.rs
@@ -24,7 +24,7 @@ use exonum::{
     helpers::Height,
 };
 
-use transactions::Propose;
+use crate::transactions::Propose;
 
 /// Error codes emitted by `Propose` and/or `Vote` transactions during execution.
 #[derive(Debug)]

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -60,7 +60,6 @@
     bare_trait_objects
 )]
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_derive;
 #[macro_use]
@@ -71,7 +70,6 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
@@ -81,13 +79,12 @@ extern crate exonum_testkit;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-extern crate protobuf;
-extern crate serde_json;
-extern crate toml;
 
-pub use errors::ErrorCode;
-pub use schema::{MaybeVote, ProposeData, Schema, VotingDecision};
-pub use transactions::{ConfigurationTransactions, Propose, Vote, VoteAgainst};
+pub use crate::{
+    errors::ErrorCode,
+    schema::{MaybeVote, ProposeData, Schema, VotingDecision},
+    transactions::{ConfigurationTransactions, Propose, Vote, VoteAgainst},
+};
 
 use serde_json::{to_value, Value};
 
@@ -101,8 +98,10 @@ use exonum::{
     storage::{Fork, Snapshot},
 };
 
-use cmd::{Finalize, GenerateCommonConfig, GenerateTestnet};
-use config::ConfigurationServiceConfig;
+use crate::{
+    cmd::{Finalize, GenerateCommonConfig, GenerateTestnet},
+    config::ConfigurationServiceConfig,
+};
 
 mod api;
 mod cmd;

--- a/services/configuration/src/schema.rs
+++ b/services/configuration/src/schema.rs
@@ -21,8 +21,7 @@ use exonum::{
 
 use std::{borrow::Cow, ops::Deref};
 
-use proto;
-use transactions::Propose;
+use crate::{proto, transactions::Propose};
 
 const YEA_TAG: u8 = 1;
 const NAY_TAG: u8 = 2;

--- a/services/configuration/src/tests/api.rs
+++ b/services/configuration/src/tests/api.rs
@@ -25,11 +25,11 @@ use super::{
     new_tx_config_propose, new_tx_config_vote, new_tx_config_vote_against, ConfigurationSchema,
     ConfigurationTestKit,
 };
-use api::{
+use crate::api::{
     ConfigHashInfo, ConfigInfo, FilterQuery, HashQuery, ProposeHashInfo, ProposeResponse,
     VoteResponse, VotesInfo,
 };
-use SERVICE_NAME;
+use crate::SERVICE_NAME;
 
 trait ConfigurationApiTest {
     fn actual_config(&self) -> ConfigHashInfo;
@@ -292,7 +292,7 @@ fn test_votes_for_propose() {
 
 #[test]
 fn test_dissenting_votes_for_propose() {
-    use schema::VotingDecision;
+    use crate::schema::VotingDecision;
 
     let mut testkit: TestKit = TestKit::configuration_default();
     let api = testkit.api();

--- a/services/configuration/src/tests/mod.rs
+++ b/services/configuration/src/tests/mod.rs
@@ -20,15 +20,13 @@ use exonum::{
     storage::StorageValue,
 };
 use exonum_testkit::{TestKit, TestKitBuilder, TestNode};
-use serde_json;
 
 use std::str;
 
-use config::ConfigurationServiceConfig;
-use SERVICE_NAME;
-use {
-    ConfigurationTransactions, Propose, Schema as ConfigurationSchema,
-    Service as ConfigurationService, Vote, VoteAgainst, VotingDecision,
+use crate::{
+    config::ConfigurationServiceConfig, ConfigurationTransactions, Propose,
+    Schema as ConfigurationSchema, Service as ConfigurationService, Vote, VoteAgainst,
+    VotingDecision, SERVICE_NAME,
 };
 
 mod api;

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -14,8 +14,6 @@
 
 //! Transaction definitions for the configuration service.
 
-extern crate serde_json;
-
 use exonum::{
     blockchain::{
         ExecutionResult, Schema as CoreSchema, StoredConfiguration, Transaction, TransactionContext,
@@ -26,12 +24,13 @@ use exonum::{
     storage::{Fork, Snapshot},
 };
 
-use config::ConfigurationServiceConfig;
-use errors::Error as ServiceError;
-use proto;
-use schema::{MaybeVote, ProposeData, Schema, VotingDecision};
-use SERVICE_ID;
-use SERVICE_NAME;
+use crate::{
+    config::ConfigurationServiceConfig,
+    errors::Error as ServiceError,
+    proto,
+    schema::{MaybeVote, ProposeData, Schema, VotingDecision},
+    SERVICE_ID, SERVICE_NAME,
+};
 
 /// Propose a new configuration.
 ///
@@ -453,11 +452,13 @@ mod tests {
     use exonum_testkit::{TestKit, TestKitBuilder};
 
     use super::{Hash, VotingContext};
-    use config::ConfigurationServiceConfig;
-    use errors::Error as ServiceError;
-    use schema::VotingDecision;
-    use tests::{new_tx_config_vote, new_tx_config_vote_against};
-    use Service as ConfigurationService;
+    use crate::{
+        config::ConfigurationServiceConfig,
+        errors::Error as ServiceError,
+        schema::VotingDecision,
+        tests::{new_tx_config_vote, new_tx_config_vote_against},
+        Service as ConfigurationService,
+    };
 
     #[test]
     fn test_vote_without_propose() {

--- a/services/time/Cargo.toml
+++ b/services/time/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-time"
 version = "0.10.1"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/services/time/examples/exonum_time.rs
+++ b/services/time/examples/exonum_time.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_time;
-
 use exonum::helpers::fabric::NodeBuilder;
-
 use exonum_time::TimeServiceFactory;
 
 fn main() {

--- a/services/time/examples/simple_service/main.rs
+++ b/services/time/examples/simple_service/main.rs
@@ -14,19 +14,12 @@
 
 //! Service, which uses the time oracle.
 
-extern crate chrono;
-extern crate exonum;
 #[macro_use]
 extern crate exonum_testkit;
-extern crate exonum_time;
-extern crate serde;
-extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate exonum_derive;
-extern crate failure;
-extern crate protobuf;
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use exonum::{
@@ -52,14 +45,14 @@ pub struct MarkerSchema<T> {
     view: T,
 }
 
-impl<T: AsRef<Snapshot>> MarkerSchema<T> {
+impl<T: AsRef<dyn Snapshot>> MarkerSchema<T> {
     /// Constructs schema for the given `snapshot`.
     pub fn new(view: T) -> Self {
         MarkerSchema { view }
     }
 
     /// Returns the table mapping `i32` value to public keys authoring marker transactions.
-    pub fn marks(&self) -> ProofMapIndex<&Snapshot, PublicKey, i32> {
+    pub fn marks(&self) -> ProofMapIndex<&dyn Snapshot, PublicKey, i32> {
         ProofMapIndex::new(format!("{}.marks", SERVICE_NAME), self.view.as_ref())
     }
 
@@ -125,7 +118,7 @@ impl Service for MarkerService {
         SERVICE_NAME
     }
 
-    fn state_hash(&self, snapshot: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, snapshot: &dyn Snapshot) -> Vec<Hash> {
         let schema = MarkerSchema::new(snapshot);
         schema.state_hash()
     }
@@ -134,7 +127,7 @@ impl Service for MarkerService {
         SERVICE_ID
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         let tx = MarkerTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/services/time/src/api.rs
+++ b/services/time/src/api.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 
 use exonum::{api, blockchain::Schema, crypto::PublicKey};
 
-use TimeSchema;
+use crate::TimeSchema;
 
 /// Structure for saving public key of the validator and last known local time.
 #[derive(Debug, Serialize, Deserialize)]

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -26,17 +26,12 @@
     bare_trait_objects
 )]
 
-extern crate chrono;
-extern crate exonum;
 #[macro_use]
 extern crate failure;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 #[macro_use]
 extern crate exonum_derive;
-extern crate protobuf;
 
 /// Node API.
 pub mod api;
@@ -57,11 +52,13 @@ use exonum::{
     messages::RawTransaction,
     storage::{Fork, Snapshot},
 };
-use schema::TimeSchema;
 use serde_json::Value;
 
-use time_provider::{SystemTimeProvider, TimeProvider};
-use transactions::*;
+use crate::{
+    schema::TimeSchema,
+    time_provider::{SystemTimeProvider, TimeProvider},
+    transactions::*,
+};
 
 /// Time service id.
 pub const SERVICE_ID: u16 = 4;

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -25,7 +25,7 @@ use exonum::{
 };
 
 use super::{proto, SERVICE_ID};
-use schema::TimeSchema;
+use crate::schema::TimeSchema;
 
 /// Common errors emitted by transactions during execution.
 #[derive(Debug, Fail)]

--- a/services/time/tests/test_exonum_time.rs
+++ b/services/time/tests/test_exonum_time.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate chrono;
-extern crate exonum;
 #[macro_use]
 extern crate exonum_testkit;
-extern crate exonum_time;
 #[macro_use]
 extern crate pretty_assertions;
 
@@ -36,7 +33,7 @@ use exonum_time::{
 
 use std::{collections::HashMap, iter::FromIterator};
 
-fn assert_storage_times_eq<T: AsRef<Snapshot>>(
+fn assert_storage_times_eq<T: AsRef<dyn Snapshot>>(
     snapshot: T,
     validators: &[TestNode],
     expected_current_time: Option<DateTime<Utc>>,
@@ -57,7 +54,7 @@ fn assert_storage_times_eq<T: AsRef<Snapshot>>(
     }
 }
 
-fn assert_transaction_result<S: AsRef<Snapshot>>(
+fn assert_transaction_result<S: AsRef<dyn Snapshot>>(
     snapshot: S,
     transaction: &Signed<RawTransaction>,
     expected_code: u8,
@@ -307,7 +304,7 @@ fn test_mock_provider() {
         .create();
 
     let validators = testkit.network().validators().to_vec();
-    let assert_storage_times = |snapshot: Box<Snapshot>| {
+    let assert_storage_times = |snapshot: Box<dyn Snapshot>| {
         assert_storage_times_eq(
             snapshot,
             &validators,

--- a/testkit/Cargo.toml
+++ b/testkit/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exonum-testkit"
 version = "0.10.1"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/testkit/examples/configuration_change.rs
+++ b/testkit/examples/configuration_change.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_testkit;
-extern crate serde;
-extern crate serde_json;
-
 use exonum::{
     blockchain::Schema,
     crypto::CryptoHash,

--- a/testkit/examples/timestamping/main.rs
+++ b/testkit/examples/timestamping/main.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
 #[macro_use]
 extern crate exonum_testkit;
-extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate exonum_derive;
-extern crate failure;
-extern crate protobuf;
 
 use exonum::{
     api::node::public::explorer::{BlocksQuery, BlocksRange, TransactionQuery},
@@ -77,7 +73,7 @@ impl Service for TimestampingService {
         "timestamping"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
@@ -85,7 +81,7 @@ impl Service for TimestampingService {
         SERVICE_ID
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         let tx = TimestampingServiceTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/testkit/server/Cargo.toml
+++ b/testkit/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "exonum-testkit-server"
 publish = false
 version = "0.0.0"
+edition = "2018"
 authors = ["The Exonum Team <exonum@bitfury.com>"]
 homepage = "https://exonum.com/"
 repository = "https://github.com/exonum/exonum"

--- a/testkit/server/src/main.rs
+++ b/testkit/server/src/main.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_cryptocurrency as cryptocurrency;
-extern crate exonum_testkit;
-
-use cryptocurrency::service::CurrencyService;
+use exonum_cryptocurrency::service::CurrencyService;
 use exonum_testkit::TestKitBuilder;
 
 fn main() {

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -19,8 +19,6 @@ pub use exonum::api::ApiAccess;
 use actix_web::{test::TestServer, App};
 use reqwest::{Client, Response, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
-use serde_json;
-use serde_urlencoded;
 
 use std::fmt::{self, Display};
 
@@ -31,7 +29,7 @@ use exonum::{
     node::ApiSender,
 };
 
-use TestKit;
+use crate::TestKit;
 
 /// Kind of public or private REST API of an Exonum node.
 ///
@@ -48,7 +46,7 @@ pub enum ApiKind {
     Service(&'static str),
 }
 
-impl ::fmt::Display for ApiKind {
+impl fmt::Display for ApiKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ApiKind::System => write!(f, "api/system"),

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -145,31 +145,22 @@
     bare_trait_objects
 )]
 
-extern crate actix_web;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
 extern crate assert_matches;
-extern crate exonum;
 #[macro_use]
 extern crate failure;
-extern crate futures;
 #[macro_use]
 extern crate log;
-extern crate reqwest;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
 extern crate exonum_derive;
-extern crate protobuf;
-extern crate serde_json;
-extern crate serde_urlencoded;
-extern crate tokio_core;
 
-pub use api::{ApiKind, TestKitApi};
-pub use compare::ComparableSnapshot;
-pub use network::{TestNetwork, TestNetworkConfiguration, TestNode};
+pub use crate::api::{ApiKind, TestKitApi};
+pub use crate::compare::ComparableSnapshot;
+pub use crate::network::{TestNetwork, TestNetworkConfiguration, TestNode};
 
 pub mod compare;
 pub mod proto;
@@ -194,8 +185,8 @@ use exonum::{
     storage::{MemoryDB, Patch, Snapshot},
 };
 
-use checkpoint_db::{CheckpointDb, CheckpointDbHandler};
-use poll_events::poll_events;
+use crate::checkpoint_db::{CheckpointDb, CheckpointDbHandler};
+use crate::poll_events::poll_events;
 
 #[macro_use]
 mod macros;
@@ -664,7 +655,7 @@ impl TestKit {
     /// Update test network configuration if such an update has been scheduled
     /// with `commit_configuration_change`.
     fn update_configuration(&mut self, new_block_height: Height) -> Option<Patch> {
-        use ConfigurationProposalState::*;
+        use crate::ConfigurationProposalState::*;
 
         let actual_from = new_block_height.next();
         if let Some(cfg_proposal) = self.cfg_proposal.take() {
@@ -696,7 +687,7 @@ impl TestKit {
     /// Returns a reference to the scheduled configuration proposal, or `None` if
     /// there is no such proposal.
     pub fn next_configuration(&self) -> Option<&TestNetworkConfiguration> {
-        use ConfigurationProposalState::*;
+        use crate::ConfigurationProposalState::*;
 
         self.cfg_proposal.as_ref().map(|p| match *p {
             Committed(ref proposal) | Uncommitted(ref proposal) => proposal,

--- a/testkit/src/network.rs
+++ b/testkit/src/network.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 use exonum::{
     blockchain::{ConsensusConfig, GenesisConfig, StoredConfiguration, ValidatorKeys},

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -161,7 +161,7 @@ mod tests {
     use exonum::storage::Snapshot;
 
     use super::{super::proto, *};
-    use {TestKitApi, TestKitBuilder};
+    use crate::{TestKitApi, TestKitBuilder};
 
     type DeBlock = BlockWithTransactions;
     const TIMESTAMP_SERVICE_ID: u16 = 0;

--- a/testkit/tests/change_configuration.rs
+++ b/testkit/tests/change_configuration.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_testkit;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
 use exonum::{
     blockchain::Schema,

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -36,12 +36,12 @@ pub struct CounterSchema<T> {
     view: T,
 }
 
-impl<T: AsRef<Snapshot>> CounterSchema<T> {
+impl<T: AsRef<dyn Snapshot>> CounterSchema<T> {
     pub fn new(view: T) -> Self {
         CounterSchema { view }
     }
 
-    fn entry(&self) -> Entry<&Snapshot, u64> {
+    fn entry(&self) -> Entry<&dyn Snapshot, u64> {
         Entry::new("counter.count", self.view.as_ref())
     }
 
@@ -189,7 +189,7 @@ impl Service for CounterService {
         "counter"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
@@ -198,7 +198,7 @@ impl Service for CounterService {
     }
 
     /// Implement a method to deserialize transactions coming to the node.
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         let tx = CounterTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -14,22 +14,18 @@
 
 #[macro_use]
 extern crate assert_matches;
-extern crate exonum;
 #[macro_use]
 extern crate exonum_testkit;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate exonum_derive;
-extern crate hex;
-extern crate protobuf;
 
 use exonum::{
     api::{node::public::explorer::TransactionQuery, Error as ApiError},
@@ -42,7 +38,7 @@ use exonum_testkit::{ApiKind, ComparableSnapshot, TestKit, TestKitApi, TestKitBu
 use hex::FromHex;
 use serde_json::Value;
 
-use counter::{
+use crate::counter::{
     CounterSchema, CounterService, TransactionResponse, TxIncrement, TxReset, ADMIN_KEY,
 };
 

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate failure;
-extern crate serde;
-extern crate serde_json;
-
 use exonum::{
     api,
     blockchain::{
@@ -80,12 +76,12 @@ pub struct CurrencySchema<S> {
     view: S,
 }
 
-impl<S: AsRef<Snapshot>> CurrencySchema<S> {
+impl<S: AsRef<dyn Snapshot>> CurrencySchema<S> {
     pub fn new(view: S) -> Self {
         CurrencySchema { view }
     }
 
-    pub fn wallets(&self) -> MapIndex<&Snapshot, PublicKey, Wallet> {
+    pub fn wallets(&self) -> MapIndex<&dyn Snapshot, PublicKey, Wallet> {
         MapIndex::new("cryptocurrency.wallets", self.view.as_ref())
     }
 
@@ -120,7 +116,7 @@ pub struct TxTransfer {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, TransactionSet)]
-pub(in inflating_cryptocurrency) enum CurrencyTransactions {
+pub(in crate::inflating_cryptocurrency) enum CurrencyTransactions {
     TxCreateWallet(TxCreateWallet),
     TxTransfer(TxTransfer),
 }
@@ -236,7 +232,7 @@ impl Service for CurrencyService {
         "cryptocurrency"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
@@ -245,7 +241,7 @@ impl Service for CurrencyService {
     }
 
     /// Implement a method to deserialize transactions coming to the node.
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         let tx = CurrencyTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/testkit/tests/inflating_currency/main.rs
+++ b/testkit/tests/inflating_currency/main.rs
@@ -16,19 +16,14 @@
 //! integration test, with the difference that the balance of each created wallet increases by 1
 //! on each block. Correspondingly, the initial wallet balance is set to 0.
 
-extern crate exonum;
+#[macro_use]
+extern crate exonum_derive;
 #[macro_use]
 extern crate exonum_testkit;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate rand;
 #[macro_use]
 extern crate serde_derive;
-extern crate hex;
-#[macro_use]
-extern crate exonum_derive;
-extern crate protobuf;
-
 #[macro_use]
 extern crate serde_json;
 
@@ -41,7 +36,7 @@ use exonum::{
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 use rand::Rng;
 
-use inflating_cryptocurrency::{CurrencyService, TxCreateWallet, TxTransfer};
+use crate::inflating_cryptocurrency::{CurrencyService, TxCreateWallet, TxTransfer};
 
 mod inflating_cryptocurrency;
 mod proto;

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -57,7 +57,7 @@ impl Service for AfterCommitService {
         "after_commit"
     }
 
-    fn state_hash(&self, _: &Snapshot) -> Vec<Hash> {
+    fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
     }
 
@@ -65,7 +65,7 @@ impl Service for AfterCommitService {
         SERVICE_ID
     }
 
-    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<Transaction>, failure::Error> {
+    fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         let tx = HandleCommitTransactions::tx_from_raw(raw)?;
         Ok(tx.into())
     }

--- a/testkit/tests/service_hooks/main.rs
+++ b/testkit/tests/service_hooks/main.rs
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_testkit;
-extern crate serde;
-extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate exonum_derive;
-extern crate protobuf;
 
 // HACK: Silent "dead_code" warning.
-pub use hooks::{AfterCommitService, HandleCommitTransactions, TxAfterCommit, SERVICE_ID};
+pub use crate::hooks::{AfterCommitService, HandleCommitTransactions, TxAfterCommit, SERVICE_ID};
 
 use exonum::{blockchain::TransactionSet, helpers::Height, messages::Message};
 use exonum_testkit::TestKitBuilder;

--- a/testkit/tests/system_api.rs
+++ b/testkit/tests/system_api.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate exonum;
-extern crate exonum_testkit;
 #[macro_use]
 extern crate pretty_assertions;
 


### PR DESCRIPTION
## Overview

We'll have to modernize the code at some point. Let's do it now.

Usually it is enough to do `cargo fix --edition && cargo fix --edition-idioms && cargo fmt`, but there are some things which require manual editing. Sometimes `cargo fix` will encounter a bug and overwrite the whole line with garbage. Take that into account when you have to migrate a project a newer edition.

## Rust 2018 guidelines

Using Rust 2018 edition means that we require rustc 1.31 or later. IIRC, Exonum's dependencies require at least this version already, but if you're slow then please upgrade.

Most of the changes here are related to crate and module imports, but there are some other minor fixes interspersed between them. Using old style usually results in warnings from compiler, rustfmt, or clippy so you're pretty safe. However, here's a bunch of things that I had to fix in this PR and that we have to maintain from now on:

- `extern crate foo;` **is not required now** (in most cases)

    The compiler is finally able to figure out crate imports (with Cargo's help) so these lines are not necessary now.

    Using them explicitly does not result in warnings. However, I've heard rumors of `extern crate` being deprecated in some later edition, so let's go ahead and remove what we can.

  There are a bunch of uses that we leave. Mostly these are for `#[macro_use]` with crates that provide a whole bunch of macros (e.g., `log`) or custom derives (`serde_derive`). Importing this stuff directly is either too tedious now, or did not work for me, so I've left them as is. (There's also a special case of `proc_macro`, because reasons.)

- **You can import macros like any other item**

    If you just need one macro then just `use quote::quote` to import `quote!`, for example. There's no need to `#[macro_use]`

- **It is not necessary to import top-level crate module**

    Due to uniform paths ([read more here](https://rust-lang-nursery.github.io/edition-guide/rust-2018/module-system/path-clarity.html)] you don't have to `use exonum;` in order to write `exonum::init_log()` or something. Just use the crate name directly. There are many other simplifications in paths and imports due to this change.

- **Use** `crate`/`self`/`super` **to import from the current context**

    Uniform paths have a price. Previously if was possible to refer to currently visible modules implicitly. For example, to import module `foo` from current crate you wrote `use foo` and that's it. However, sometimes this conflicted with another `foo` imported from other places.

    Now you have to explicitly name the source of the import. All paths start either with a top-level crate name, or one of the keywords:

    * `crate::thing` to address the current crate starting from its root

    * `dependency::item` to address the some other extrnal crate starting from its root

    * `self::stuff` to import from modules you have imported earlier

    * `super::*` to import from your parent module

    [Read the docs](https://rust-lang-nursery.github.io/edition-guide/rust-2018/module-system/path-clarity.html) to learn more.

- `mod.rs` **is now not required**

    Previously, if you had a module named `foo` living in `foo.rs` and wanted to add a submodule `foo::bar` to it then you _had_ to rename this:

  ```
  src
  |- foo.rs
  \- zog.rs
  ```

    Into this:

  ```
  src
  |- foo
  |  |- mod.rs  (previously foo.rs)
  |  \- bar.rs
  \- zog.rs
  ```

  With Rust 2018 edition you can add submodules more directly: 

  ```
  src
  |- foo.rs
  |- foo
  |  \- bar.rs
  \- zog.rs
  ```

    Currently our code has a lot of `mod.rs` files. I did not rename them to avoid diff noise. However, please avoid them for new modules. Rename the old ones if that makes sense to do during a refactoring.

- **It is not necessary to prefix top-level paths with** `::`

    For example, now you can simply write `std::ptr::null()`. In Rust 2015 you had to either spell it `::std::ptr::null()`, or first `use std::ptr;` then call `ptr::null()`.

    Currently our code has _tons_ of paths like this. I did not change them to avoid diff noise. However, please don't add new ones. And please do fix old ones if you refactor the code around them.

- **Trait objects now require** `dyn` **prefix**

    It is now `dyn Snapshot`, `&mut dyn Fork`, `Box<dyn Transaction>`, etc. Previously this was optional, but in Rust 2018 this is required.

- **Trait methods now require argument names**

    In Rust 2015 trait method were allowed to have unnamed parameters. Now you have to give them names.

```diff
 pub trait ProofMapKey
 where
     Self::Output: ProofMapKey,
 {
     type Output;
 
-    fn write_key(&self, &mut [u8]);
+    fn write_key(&self, key: &mut [u8]);
 
-    fn read_key(&[u8]) -> Self::Output;
+    fn read_key(key: &[u8]) -> Self::Output;
 }
```

- **Prefer new syntax for inclusive (closed) ranges**

    Write `0..=9` instead of `0...9` if you mean [`0`, ..., `9`].

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-2816
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] ~~Change is covered by automated tests~~
- [x] ~~Benchmark results are attached (if applicable)~~
- [x] The [coding guidelines] are updated
- [x] ~~Public API has proper documentation~~
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions