### PR TITLE
Improve key files password entry [ECR-2519]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Node secret keys are now stored in separate files in a secure way.
   CLI for generating node configs and starting nodes has been extended
-  in order to reflect these changes. (#1222, #1096)
+  in order to reflect these changes. (#1222, #1096, #1235)
 
 #### exonum-crypto
 

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -49,7 +49,7 @@ failure = "0.1.5"
 os_info = "1.0.1"
 chrono = { version = "=0.4.6", features = ["serde"] }
 uuid = { version = "=0.7.1", features = ["serde"] }
-snow = "=0.4.1"
+snow = "=0.4.2"
 rust_decimal = "=0.10.2"
 protobuf = { version = "2.2.0", features = ["with-serde"] }
 ctrlc = "3.1.1"

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -16,7 +16,6 @@ use ctrlc;
 
 use std::{
     collections::HashMap,
-    env,
     ffi::OsString,
     fmt,
     panic::{self, PanicInfo},
@@ -29,14 +28,11 @@ use super::{
     internal::{CollectedCommand, Command, Feedback},
     keys,
     maintenance::Maintenance,
+    password::{PassInputMethod, SecretKeyType},
     CommandName, Context, ServiceFactory,
 };
 use blockchain::Service;
-use helpers::ZeroizeOnDrop;
 use node::{ExternalMessage, Node};
-
-const EXONUM_CONSENSUS_PASS: &str = "EXONUM_CONSENSUS_PASS";
-const EXONUM_SERVICE_PASS: &str = "EXONUM_SERVICE_PASS";
 
 /// `NodeBuilder` is a high level object,
 /// usable for fast prototyping and creating app from services list.
@@ -162,15 +158,25 @@ impl NodeBuilder {
             .map(|mut factory| factory.make_service(ctx))
             .collect();
 
-        let consensus_passphrase =
-            ZeroizeOnDrop(env::var(EXONUM_CONSENSUS_PASS).unwrap_or_default());
-        let service_passphrase = ZeroizeOnDrop(env::var(EXONUM_SERVICE_PASS).unwrap_or_default());
+        let config = {
+            let run_config = ctx.get(keys::RUN_CONFIG).unwrap();
+            let consensus_passphrase = run_config
+                .consensus_pass_method
+                .parse::<PassInputMethod>()
+                .expect("Incorrect passphrase input method for consensus key.")
+                .get_passphrase(SecretKeyType::Consensus, true);
+            let service_passphrase = run_config
+                .service_pass_method
+                .parse::<PassInputMethod>()
+                .expect("Incorrect passphrase input method for service key.")
+                .get_passphrase(SecretKeyType::Service, true);
 
-        let config = config.read_secret_keys(
-            &config_file_path,
-            consensus_passphrase.0.as_bytes(),
-            service_passphrase.0.as_bytes(),
-        );
+            config.read_secret_keys(
+                &config_file_path,
+                consensus_passphrase.0.as_bytes(),
+                service_passphrase.0.as_bytes(),
+            )
+        };
         Node::new(db, services, config, Some(config_file_path))
     }
 }

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -19,6 +19,7 @@ use std::{
     ffi::OsString,
     fmt,
     panic::{self, PanicInfo},
+    str::FromStr,
 };
 
 use super::{
@@ -160,21 +161,17 @@ impl NodeBuilder {
 
         let config = {
             let run_config = ctx.get(keys::RUN_CONFIG).unwrap();
-            let consensus_passphrase = run_config
-                .consensus_pass_method
-                .parse::<PassInputMethod>()
+            let consensus_passphrase = PassInputMethod::from_str(&run_config.consensus_pass_method)
                 .expect("Incorrect passphrase input method for consensus key.")
                 .get_passphrase(SecretKeyType::Consensus, true);
-            let service_passphrase = run_config
-                .service_pass_method
-                .parse::<PassInputMethod>()
+            let service_passphrase = PassInputMethod::from_str(&run_config.service_pass_method)
                 .expect("Incorrect passphrase input method for service key.")
                 .get_passphrase(SecretKeyType::Service, true);
 
             config.read_secret_keys(
                 &config_file_path,
-                consensus_passphrase.0.as_bytes(),
-                service_passphrase.0.as_bytes(),
+                consensus_passphrase.as_bytes(),
+                service_passphrase.as_bytes(),
             )
         };
         Node::new(db, services, config, Some(config_file_path))

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -593,7 +593,7 @@ impl Command for GenerateNodeConfig {
                 consensus_key_pass_method,
                 SecretKeyType::Consensus,
             );
-            create_secret_key_file(&consensus_secret_key_path, &passphrase.0)
+            create_secret_key_file(&consensus_secret_key_path, passphrase.as_bytes())
         };
         let service_public_key = {
             let passphrase = Self::get_passphrase(
@@ -601,7 +601,7 @@ impl Command for GenerateNodeConfig {
                 service_key_pass_method,
                 SecretKeyType::Service,
             );
-            create_secret_key_file(&service_secret_key_path, &passphrase.0)
+            create_secret_key_file(&service_secret_key_path, passphrase.as_bytes())
         };
 
         let pub_config_dir = Path::new(&pub_config_path)

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -94,7 +94,7 @@ impl Run {
             SecretKeyType::Consensus => CONSENSUS_KEY_PASS_METHOD,
             SecretKeyType::Service => SERVICE_KEY_PASS_METHOD,
         };
-        ctx.arg(arg_key).unwrap_or_else(|_| "".into())
+        ctx.arg(arg_key).unwrap_or_default()
     }
 }
 
@@ -462,7 +462,7 @@ impl GenerateNodeConfig {
         secret_key_type: SecretKeyType,
     ) -> ZeroizeOnDrop<String> {
         if context.get_flag_occurrences(NO_PASSWORD).is_some() {
-            ZeroizeOnDrop("".to_owned())
+            ZeroizeOnDrop::default()
         } else {
             method.get_passphrase(secret_key_type, false)
         }
@@ -570,12 +570,12 @@ impl Command for GenerateNodeConfig {
             .into();
         let consensus_key_pass_method: PassInputMethod = context
             .arg::<String>(CONSENSUS_KEY_PASS_METHOD)
-            .unwrap_or_else(|_| "".to_owned())
+            .unwrap_or_default()
             .parse()
             .expect("expected correct passphrase input method for consensus key");
         let service_key_pass_method: PassInputMethod = context
             .arg::<String>(SERVICE_KEY_PASS_METHOD)
-            .unwrap_or_else(|_| "".to_owned())
+            .unwrap_or_default()
             .parse()
             .expect("expected correct passphrase input method for service key");
 

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -136,7 +136,9 @@ impl Command for Run {
             Argument::new_named(
                 CONSENSUS_KEY_PASS_METHOD,
                 false,
-                "Passphrase for consensus key.",
+                "Passphrase entry method for consensus key.\n\
+                 Possible values are: stdin, env{:ENV_VAR_NAME}, pass:PASSWORD (default: stdin)\n\
+                 If ENV_VAR_NAME is not specified $EXONUM_CONSENSUS_PASS is used",
                 None,
                 "consensus-key-pass",
                 false,
@@ -144,7 +146,9 @@ impl Command for Run {
             Argument::new_named(
                 SERVICE_KEY_PASS_METHOD,
                 false,
-                "Passphrase for service key.",
+                "Passphrase entry method for service key.\n\
+                 Possible values are: stdin, env{:ENV_VAR_NAME}, pass:PASSWORD (default: stdin)\n\
+                 If ENV_VAR_NAME is not specified $EXONUM_SERVICE_PASS is used",
                 None,
                 "service-key-pass",
                 false,
@@ -513,7 +517,9 @@ impl Command for GenerateNodeConfig {
             Argument::new_named(
                 CONSENSUS_KEY_PASS_METHOD,
                 false,
-                "Passphrase for consensus key.",
+                "Passphrase entry method for consensus key.\n\
+                 Possible values are: stdin, env{:ENV_VAR_NAME}, pass:PASSWORD (default: stdin)\n\
+                 If ENV_VAR_NAME is not specified $EXONUM_CONSENSUS_PASS is used",
                 None,
                 "consensus-key-pass",
                 false,
@@ -521,7 +527,9 @@ impl Command for GenerateNodeConfig {
             Argument::new_named(
                 SERVICE_KEY_PASS_METHOD,
                 false,
-                "Passphrase for service key.",
+                "Passphrase entry method for service key.\n\
+                 Possible values are: stdin, env{:ENV_VAR_NAME}, pass:PASSWORD (default: stdin)\n\
+                 If ENV_VAR_NAME is not specified $EXONUM_SERVICE_PASS is used",
                 None,
                 "service-key-pass",
                 false,

--- a/exonum/src/helpers/fabric/mod.rs
+++ b/exonum/src/helpers/fabric/mod.rs
@@ -41,6 +41,7 @@ mod maintenance;
 mod shared;
 #[macro_use]
 mod context_key;
+mod password;
 
 /// Default port value.
 pub const DEFAULT_EXONUM_LISTEN_PORT: u16 = 6333;
@@ -151,7 +152,7 @@ pub mod keys {
 
     use toml;
 
-    use super::shared::{AbstractConfig, CommonConfigTemplate, NodePublicConfig};
+    use super::shared::{AbstractConfig, CommonConfigTemplate, NodePublicConfig, NodeRunConfig};
     use super::ContextKey;
     use node::NodeConfig;
 
@@ -193,6 +194,9 @@ pub mod keys {
     /// Auditor mode.
     /// Set by `finalize` command.
     pub const AUDITOR_MODE: ContextKey<bool> = context_key!("auditor_mode");
+
+    /// Configuration for starting node that is not stored in the `NodeConfig`.
+    pub const RUN_CONFIG: ContextKey<NodeRunConfig> = context_key!("run_config");
 }
 
 /// `Context` is a type, used to keep some values from `Command` into

--- a/exonum/src/helpers/fabric/password.rs
+++ b/exonum/src/helpers/fabric/password.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Exonum Team
+// Copyright 2019 The Exonum Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exonum/src/helpers/fabric/password.rs
+++ b/exonum/src/helpers/fabric/password.rs
@@ -80,7 +80,7 @@ impl FromStr for PassInputMethod {
     type Err = failure::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "" {
+        if s.is_empty() {
             return Ok(Default::default());
         }
 
@@ -89,12 +89,12 @@ impl FromStr for PassInputMethod {
         }
 
         if s.starts_with("env") {
-            let env_var = s.split(':').nth(1).map(|s| s.to_owned());
+            let env_var = s.split(':').nth(1).map(String::from);
             return Ok(PassInputMethod::EnvVariable(env_var));
         }
 
         if s.starts_with("pass") {
-            let pass = s.split(':').nth(1).unwrap_or("");
+            let pass = s.split(':').nth(1).unwrap_or_default();
             return Ok(PassInputMethod::CmdLineParameter(ZeroizeOnDrop(
                 pass.to_owned(),
             )));

--- a/exonum/src/helpers/fabric/password.rs
+++ b/exonum/src/helpers/fabric/password.rs
@@ -1,0 +1,168 @@
+// Copyright 2018 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains utilities for passphrase entry.
+
+use failure;
+use rpassword::read_password_from_tty;
+
+use std::{env, io, str::FromStr};
+
+use helpers::ZeroizeOnDrop;
+
+/// Passphrase input methods
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum PassInputMethod {
+    /// Prompt passphrase from terminal.
+    Terminal,
+    /// Get passphrase from environment variable (default if `None`).
+    EnvVariable(Option<String>),
+    /// Passphrase is passed as a command line parameter.
+    CmdLineParameter(ZeroizeOnDrop<String>),
+}
+
+/// Secret key types.
+#[derive(Copy, Clone)]
+pub enum SecretKeyType {
+    Consensus,
+    Service,
+}
+
+impl PassInputMethod {
+    /// Get passphrase using selected method.
+    /// Details of this process differs for different secret key types and whether we run node
+    /// or generate config files.
+    pub fn get_passphrase(self, key_type: SecretKeyType, run: bool) -> ZeroizeOnDrop<String> {
+        match self {
+            PassInputMethod::Terminal => {
+                let prompt = match key_type {
+                    SecretKeyType::Consensus => "Enter consensus key passphrase",
+                    SecretKeyType::Service => "Enter service key passphrase",
+                };
+                prompt_passphrase(prompt, run).expect("Failed to read password from stdin")
+            }
+            PassInputMethod::EnvVariable(name) => {
+                let var = if let Some(ref name) = name {
+                    name
+                } else {
+                    match key_type {
+                        SecretKeyType::Consensus => "EXONUM_CONSENSUS_PASS",
+                        SecretKeyType::Service => "EXONUM_SERVICE_PASS",
+                    }
+                };
+                ZeroizeOnDrop(env::var(var).unwrap_or_else(|e| {
+                    panic!("Failed to get password from env variable: {}, {}", var, e)
+                }))
+            }
+            PassInputMethod::CmdLineParameter(pass) => pass,
+        }
+    }
+}
+
+impl Default for PassInputMethod {
+    fn default() -> Self {
+        PassInputMethod::Terminal
+    }
+}
+
+impl FromStr for PassInputMethod {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "" {
+            return Ok(Default::default());
+        }
+
+        if s == "stdin" {
+            return Ok(PassInputMethod::Terminal);
+        }
+
+        if let Some(prefix) = s.get(0..3) {
+            if prefix == "env" {
+                let env_var = s.split(':').nth(1).map(|s| s.to_owned());
+                return Ok(PassInputMethod::EnvVariable(env_var));
+            }
+        }
+
+        if let Some(prefix) = s.get(0..4) {
+            if prefix == "pass" {
+                let pass = s.split(':').nth(1).unwrap_or("");
+                return Ok(PassInputMethod::CmdLineParameter(ZeroizeOnDrop(
+                    pass.to_owned(),
+                )));
+            }
+        }
+
+        bail!("Failed to parse passphrase input method");
+    }
+}
+
+fn prompt_passphrase(prompt: &str, run: bool) -> io::Result<ZeroizeOnDrop<String>> {
+    if run {
+        return Ok(ZeroizeOnDrop(read_password_from_tty(Some(prompt))?));
+    }
+
+    loop {
+        let password = ZeroizeOnDrop(read_password_from_tty(Some(prompt))?);
+        if password.0.is_empty() {
+            eprintln!("Passphrase must not be empty. Try again.");
+            continue;
+        }
+
+        let second_password = ZeroizeOnDrop(read_password_from_tty(Some(
+            "Enter same passphrase again: ",
+        ))?);
+
+        if password.0 == second_password.0 {
+            return Ok(password);
+        } else {
+            eprintln!("Passphrases do not match. Try again.");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use helpers::ZeroizeOnDrop;
+    use std::str::FromStr;
+
+    use super::PassInputMethod;
+
+    #[test]
+    fn test_pass_input_method_parse() {
+        let correct_cases = vec![
+            ("", <PassInputMethod as Default>::default()),
+            ("stdin", PassInputMethod::Terminal),
+            ("env", PassInputMethod::EnvVariable(None)),
+            (
+                "env:VAR",
+                PassInputMethod::EnvVariable(Some("VAR".to_owned())),
+            ),
+            (
+                "pass",
+                PassInputMethod::CmdLineParameter(ZeroizeOnDrop("".to_owned())),
+            ),
+            (
+                "pass:PASS",
+                PassInputMethod::CmdLineParameter(ZeroizeOnDrop("PASS".to_owned())),
+            ),
+        ];
+
+        for (inp, out) in correct_cases {
+            let method = <PassInputMethod as FromStr>::from_str(inp);
+            assert!(method.is_ok());
+            assert_eq!(method.unwrap(), out)
+        }
+    }
+}

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -88,3 +88,10 @@ pub struct NodePrivateConfig {
     #[serde(default)]
     pub services_secret_configs: AbstractConfig,
 }
+
+/// Used for passing configuration for starting node from the command line that is not in the `NodeConfig`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NodeRunConfig {
+    pub consensus_pass_method: String,
+    pub service_pass_method: String,
+}

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -362,7 +362,7 @@ impl Iterator for RoundRangeIter {
 }
 
 /// Struct used to call zeroize on inner type on drop.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct ZeroizeOnDrop<T: Zeroize>(pub T);
 
 impl<T: Zeroize> Drop for ZeroizeOnDrop<T> {

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -362,7 +362,7 @@ impl Iterator for RoundRangeIter {
 }
 
 /// Struct used to call zeroize on inner type on drop.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ZeroizeOnDrop<T: Zeroize>(pub T);
 
 impl<T: Zeroize> Drop for ZeroizeOnDrop<T> {

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -14,7 +14,7 @@
 
 //! Common widely used type definitions.
 
-use std::{fmt, num::ParseIntError, str::FromStr};
+use std::{fmt, num::ParseIntError, ops::Deref, ops::DerefMut, str::FromStr};
 
 use crypto::{CryptoHash, Hash};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -368,5 +368,19 @@ pub struct ZeroizeOnDrop<T: Zeroize>(pub T);
 impl<T: Zeroize> Drop for ZeroizeOnDrop<T> {
     fn drop(&mut self) {
         self.0.zeroize()
+    }
+}
+
+impl<T: Zeroize> Deref for ZeroizeOnDrop<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: Zeroize> DerefMut for ZeroizeOnDrop<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }

--- a/exonum/tests/config.rs
+++ b/exonum/tests/config.rs
@@ -227,6 +227,10 @@ fn run_node(config: &str, folder: &str) {
         &full_tmp_name(config, folder),
         "-d",
         &full_tmp_folder(folder),
+        "--service-key-pass",
+        "env",
+        "--consensus-key-pass",
+        "env",
     ]));
 }
 
@@ -289,6 +293,9 @@ fn test_generate_config_ipv6() {
 fn test_generate_full_config_run() {
     let command = "finalize";
     let result = panic::catch_unwind(|| {
+        env::set_var(EXONUM_CONSENSUS_PASS, "");
+        env::set_var(EXONUM_SERVICE_PASS, "");
+
         fs::create_dir_all(full_tmp_name("", command)).expect("Can't create temp folder");
         for i in 0..PUB_CONFIG.len() {
             copy_file_to_temp(&format!("consensus{}.toml", i), command);


### PR DESCRIPTION
## Overview

This PR allows following passphrase entry methods while generating configs and running node.

```--{service,consensus}-key-pass [stdin,env:VAR,pass:PASS]```
Default password entry method is stdin.
If variable in env is not set default one is used. (EXONUM_SERVICE_PASS, EXONUM_CONSENSUS_PASS)

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-2519
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
