### PR TITLE
Changed a response code for the `/block` endpoint [ECR-2974 ECR-2975]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Changed a response for `/healthcheck` endpoint. (#1252)
 
+- Changed a response code for the `/block` endpoint for the case when
+  the requested block doesn't exist. (#1262)
+
 #### exonum-crypto
 
 - Renamed `create_keys_file` function to `generate_keys_file`


### PR DESCRIPTION

## Overview

Changed a response code for the `/block` endpoint for the case when the requested block doesn't exist. And fixed a response for the genesis block.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: 
https://jira.bf.local/browse/ECR-2974
https://jira.bf.local/browse/ECR-2975
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
