### PR TITLE
Add reference to Java Time Oracle [ECR-2896]

### DIFF
--- a/services/time/README.md
+++ b/services/time/README.md
@@ -95,6 +95,10 @@ the service Rust API, and the [service description in Exonum docs](https://exonu
 for a more high-level perspective, in particular, the design rationale
 and the proof of correctness.
 
+## Other languages support
+
+* [Java Time Oracle](https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/time-oracle)
+
 ## License
 
 `exonum-time` is licensed under the Apache License (Version 2.0).


### PR DESCRIPTION
## Overview

Add reference to Java Time Oracle. Link will be valid after https://github.com/exonum/exonum-java-binding/pull/754 is merged.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-2896
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
