### PR TITLE
Allow to use symbol `-` in index names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 #### exonum
 
 - Added `service_name` getter to the `TransactionContext`. (#1274)
-- Allowed to use symbol `-` in index names. (#1275)
+- Allowed to use symbol `-` in index names. (#1277)
 
 ## 0.11.0 - 2019-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 #### exonum
 
 - Added `service_name` getter to the `TransactionContext`. (#1274)
+- Allowed to use symbol `-` in index names. (#1275)
 
 ## 0.11.0 - 2019-03-15
 

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -348,8 +348,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Wrong characters using in name. Use: a-zA-Z0-9 and _")]
+    #[should_panic(expected = "Wrong characters using in name. Use: a-zA-Z0-9 and _-")]
     fn check_invalid_name() {
-        assert_valid_name("invalid-name");
+        assert_valid_name("invalid name");
     }
 }

--- a/exonum/src/storage/base_index.rs
+++ b/exonum/src/storage/base_index.rs
@@ -308,7 +308,7 @@ impl<'a, K, V> ::std::fmt::Debug for BaseIndexIter<'a, K, V> {
 /// and underscores.
 fn is_valid_name<S: AsRef<str>>(name: S) -> bool {
     name.as_ref().as_bytes().iter().all(|c| match *c {
-        48..=57 | 65..=90 | 97..=122 | 95 | 46 => true,
+        48..=57 | 65..=90 | 97..=122 | 95 | 45 | 46 => true,
         _ => false,
     })
 }
@@ -316,7 +316,7 @@ fn is_valid_name<S: AsRef<str>>(name: S) -> bool {
 /// Calls the `is_valid_name` function with the given name and panics if it returns `false`.
 fn assert_valid_name<S: AsRef<str>>(name: S) {
     if !is_valid_name(name) {
-        panic!("Wrong characters using in name. Use: a-zA-Z0-9 and _");
+        panic!("Wrong characters using in name. Use: a-zA-Z0-9 and _-");
     }
 }
 
@@ -333,13 +333,13 @@ mod tests {
         assert!(is_valid_name("core.index_name1Z"));
         assert!(is_valid_name("configuration.indeX_1namE"));
         assert!(is_valid_name("1index_Namez"));
+        assert!(is_valid_name("index-name"));
+        assert!(is_valid_name("_index-name"));
 
-        assert!(!is_valid_name("index-name"));
-        assert!(!is_valid_name("_index-name"));
         assert!(!is_valid_name("индекс_name_"));
-        assert!(!is_valid_name("core.index_имя3"));
-        assert!(!is_valid_name("indeX_1namE-"));
-        assert!(!is_valid_name("1in!dex_Namez"));
+        assert!(!is_valid_name(";core.index_имя3"));
+        assert!(!is_valid_name("*indeX_1namE-"));
+        assert!(!is_valid_name("(1in!dex_Namez"));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
