### PR TITLE
Added endpoint for displaying info about available services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Allowed to use symbol `-` in index names. (#1277)
 
+- Added a new endpoint `system/v1/services` for displaying information 
+  about available services. (#1288)
+
 #### exonum-testkit
 
 - Implemented "stopping" and "resuming" a `TestKit`, allowing to emulate node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `rocksdb` crate is now used instead of `exonum_rocksdb`. (#1286)
 
-- Added a new endpoint `system/v1/services` for displaying information 
+- Added a new endpoint `system/v1/services` for displaying information
   about available services. (#1288)
   
 #### exonum-testkit

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -107,7 +107,7 @@ impl SystemApi {
     ) -> Self {
         api_scope.endpoint(name, move |state: &ServiceApiState, _query: ()| {
             let blockchain = state.blockchain();
-            let services = blockchan
+            let services = blockchain
                 .service_map()
                 .iter()
                 .map(|(&id, service)| ServiceInfo {

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -106,7 +106,7 @@ impl SystemApi {
         api_scope: &mut ServiceApiScope,
     ) -> Self {
         api_scope.endpoint(name, move |state: &ServiceApiState, _query: ()| {
-            let blockchan = state.blockchain();
+            let blockchain = state.blockchain();
             let services = blockchan
                 .service_map()
                 .iter()

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -110,9 +110,9 @@ impl SystemApi {
             let services = blockchan
                 .service_map()
                 .iter()
-                .map(|(id, service)| ServiceInfo {
+                .map(|(&id, service)| ServiceInfo {
                     name: service.service_name().to_string(),
-                    id: *id,
+                    id,
                 })
                 .collect::<Vec<_>>();
             Ok(ServicesResponse { services })


### PR DESCRIPTION
## Overview

A tiny improvement for light clients. Added possibility to get a list of available services with its id and service name. 

Example of response: 
```json
{
    "services": [
        {
            "name": "configuration",
            "id": 1
        },
        {
            "name": "timestamping",
            "id": 130
        },
        {
            "name": "exonum_time",
            "id": 4
        }
    ]
}
```

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
