### PR TITLE
Added counter for transactions of the blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `explorer/v1/blocks` endpoint with `add_blocks_time` param switched on now returns
   median precommit times in the `time` field within each returned block,
   rather than in a separate array. (#1278)
+  
+- `system/v1/mempool` endpoint has been renamed into `system/v1/stats`.
+  An additional field in the response of the endpoint was added. The field
+  corresponds to the total number of transactions in the blockchain. (#1289)
 
 ### Bug Fixes
 

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -20,9 +20,11 @@ use crate::helpers::user_agent;
 
 /// Information about the current state of the node memory pool.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-pub struct MemPoolInfo {
+pub struct StatsInfo {
     /// Total number of uncommitted transactions.
-    pub size: u64,
+    pub tx_pool_size: u64,
+    /// Total number of transactions in the blockchain.
+    pub tx_count: u64,
 }
 
 /// Information about whether it is possible to achieve the consensus between
@@ -71,12 +73,13 @@ impl SystemApi {
         Self { shared_api_state }
     }
 
-    fn handle_mempool_info(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
+    fn handle_stats_info(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
         api_scope.endpoint(name, move |state: &ServiceApiState, _query: ()| {
             let snapshot = state.snapshot();
             let schema = Schema::new(&snapshot);
-            Ok(MemPoolInfo {
-                size: schema.transactions_pool_len(),
+            Ok(StatsInfo {
+                tx_pool_size: schema.transactions_pool_len(),
+                tx_count: schema.transactions_len(),
             })
         });
         self
@@ -142,7 +145,7 @@ impl SystemApi {
 
     /// Adds public system API endpoints to the corresponding scope.
     pub fn wire(self, api_scope: &mut ServiceApiScope) -> &mut ServiceApiScope {
-        self.handle_mempool_info("v1/mempool", api_scope)
+        self.handle_stats_info("v1/stats", api_scope)
             .handle_healthcheck_info("v1/healthcheck", api_scope)
             .handle_user_agent_info("v1/user_agent", api_scope)
             .handle_list_services_info("v1/services", api_scope);

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -507,6 +507,7 @@ impl Blockchain {
                 schema
                     .transactions_pool_len_index_mut()
                     .set(txs_count - u64::from(txs_in_block));
+                schema.update_transaction_count(u64::from(txs_in_block));
             }
             fork.into_patch()
         };

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -149,7 +149,7 @@ where
         ProofMapIndex::new(TRANSACTION_RESULTS, &self.view)
     }
 
-    /// Returns an entry that represents count of transactions in the blockchain.
+    /// Returns an entry that represents a count of committed transactions in the blockchain.
     pub(crate) fn transactions_len_index(&self) -> Entry<&T, u64> {
         Entry::new(TRANSACTIONS_LEN, &self.view)
     }

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -156,6 +156,7 @@ where
 
     /// Returns the number of transactions in the blockchain.
     pub fn transactions_len(&self) -> u64 {
+        // TODO: Change a count of tx logic after replacement storage to MerkleDB. ECR-3087
         let pool = self.transactions_len_index();
         pool.get().unwrap_or(0)
     }

--- a/exonum/tests/explorer/main.rs
+++ b/exonum/tests/explorer/main.rs
@@ -72,7 +72,9 @@ fn test_explorer_basics() {
 
     {
         let explorer = BlockchainExplorer::new(&blockchain);
+        let schema = Schema::new(blockchain.snapshot());
         assert_eq!(explorer.height(), Height(1));
+        assert_eq!(schema.transactions_len(), 1);
         assert!(explorer.block(Height(2)).is_none());
 
         let block = explorer.block(Height(1)).unwrap();
@@ -118,7 +120,9 @@ fn test_explorer_basics() {
     create_block(&mut blockchain, vec![tx_bob.clone(), tx_transfer.clone()]);
 
     let explorer = BlockchainExplorer::new(&blockchain);
+    let schema = Schema::new(blockchain.snapshot());
     assert_eq!(explorer.height(), Height(2));
+    assert_eq!(schema.transactions_len(), 3);
     let block = explorer.block(Height(2)).unwrap();
     assert_eq!(block.len(), 2);
 

--- a/testkit/tests/system_api.rs
+++ b/testkit/tests/system_api.rs
@@ -18,7 +18,7 @@ extern crate pretty_assertions;
 use exonum::{
     api::node::{
         private::NodeInfo,
-        public::system::{ConsensusStatus, HealthCheckInfo},
+        public::system::{ConsensusStatus, HealthCheckInfo, StatsInfo},
     },
     helpers::user_agent,
     messages::PROTOCOL_MAJOR_VERSION,
@@ -39,6 +39,19 @@ fn healthcheck() {
     let expected = HealthCheckInfo {
         consensus_status: ConsensusStatus::Enabled,
         connected_peers: 0,
+    };
+    assert_eq!(info, expected);
+}
+
+#[test]
+fn stats() {
+    let testkit = TestKitBuilder::validator().with_validators(2).create();
+    let api = testkit.api();
+
+    let info: StatsInfo = api.public(ApiKind::System).get("v1/stats").unwrap();
+    let expected = StatsInfo {
+        tx_pool_size: 0,
+        tx_count: 0,
     };
     assert_eq!(info, expected);
 }


### PR DESCRIPTION
## Overview

`system/v1/mempool` endpoint has been renamed into `system/v1/stats`.
  An additional field in the response of the endpoint was added. The field
  corresponds to the total number of transactions in the blockchain.

Example of the response: 
```json
{
    "tx_pool_size": 1,
    "tx_count": 315
}
```

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions