### PR TITLE
Use an immutable fork in initialize method

### DIFF
--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -206,10 +206,10 @@ impl Blockchain {
         };
 
         let patch = {
-            let mut fork = self.fork();
+            let fork = self.fork();
             // Update service tables
             for (_, service) in self.service_map.iter() {
-                let cfg = service.initialize(&mut fork);
+                let cfg = service.initialize(&fork);
                 let name = service.service_name();
                 if config_propose.services.contains_key(name) {
                     panic!(

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -181,7 +181,7 @@ pub trait Service: Send + Sync + 'static {
     ///
     /// [doc:global_cfg]: https://exonum.com/doc/version/latest/architecture/services/#global-configuration
     /// [`&mut Fork`]: https://exonum.com/doc/version/latest/architecture/storage/#forks
-    fn initialize(&self, fork: &mut Fork) -> Value {
+    fn initialize(&self, fork: &Fork) -> Value {
         Value::Null
     }
 

--- a/exonum/tests/node.rs
+++ b/exonum/tests/node.rs
@@ -80,7 +80,7 @@ impl Service for InitializeCheckerService {
         unreachable!("An unknown transaction received");
     }
 
-    fn initialize(&self, _fork: &mut Fork) -> Value {
+    fn initialize(&self, _fork: &Fork) -> Value {
         *self.0.lock().unwrap() += 1;
         Value::Null
     }

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -143,7 +143,7 @@ impl blockchain::Service for Service {
         ConfigurationTransactions::tx_from_raw(raw).map(Into::into)
     }
 
-    fn initialize(&self, _fork: &mut Fork) -> Value {
+    fn initialize(&self, _fork: &Fork) -> Value {
         to_value(self.config.clone()).unwrap()
     }
 

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -96,6 +96,10 @@ impl TimeService {
 }
 
 impl Service for TimeService {
+    fn service_id(&self) -> u16 {
+        SERVICE_ID
+    }
+
     fn service_name(&self) -> &str {
         SERVICE_NAME
     }
@@ -105,15 +109,11 @@ impl Service for TimeService {
         schema.state_hash()
     }
 
-    fn service_id(&self) -> u16 {
-        SERVICE_ID
-    }
-
     fn tx_from_raw(&self, raw: RawTransaction) -> Result<Box<dyn Transaction>, failure::Error> {
         TimeTransactions::tx_from_raw(raw).map(Into::into)
     }
 
-    fn initialize(&self, _fork: &mut Fork) -> Value {
+    fn initialize(&self, _fork: &Fork) -> Value {
         Value::Null
     }
 


### PR DESCRIPTION
## Overview

According to the MerkleDB a parameter of `initialize` method should be immutable reference to a   Fork.

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
