### PR TITLE
Use unbounded channel for rest api requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Added a new endpoint `system/v1/services` for displaying information
   about available services. (#1288)
+  
+- A channel for api requests has been changed for unbounded. (#1308)
 
 #### exonum-merkledb
 

--- a/exonum/src/api/node/private/mod.rs
+++ b/exonum/src/api/node/private/mod.rs
@@ -162,7 +162,7 @@ impl SystemApi {
     fn handle_peer_add(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
         api_scope.endpoint_mut(
             name,
-            move |state: &ServiceApiState, connect_info: ConnectInfo| {
+            move |state: &ServiceApiState, connect_info: ConnectInfo| -> Result<(), ApiError> {
                 state
                     .sender()
                     .peer_add(connect_info)
@@ -200,7 +200,7 @@ impl SystemApi {
         let self_ = self.clone();
         api_scope.endpoint_mut(
             name,
-            move |state: &ServiceApiState, query: ConsensusEnabledQuery| {
+            move |state: &ServiceApiState, query: ConsensusEnabledQuery| -> Result<(), ApiError> {
                 state
                     .sender()
                     .send_external_message(ExternalMessage::Enable(query.enabled))
@@ -211,22 +211,28 @@ impl SystemApi {
     }
 
     fn handle_shutdown(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
-        api_scope.endpoint_mut(name, move |state: &ServiceApiState, _query: ()| {
-            state
-                .sender()
-                .send_external_message(ExternalMessage::Shutdown)
-                .map_err(ApiError::from)
-        });
+        api_scope.endpoint_mut(
+            name,
+            move |state: &ServiceApiState, _query: ()| -> Result<(), ApiError> {
+                state
+                    .sender()
+                    .send_external_message(ExternalMessage::Shutdown)
+                    .map_err(ApiError::from)
+            },
+        );
         self
     }
 
     fn handle_rebroadcast(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
-        api_scope.endpoint_mut(name, move |state: &ServiceApiState, _query: ()| {
-            state
-                .sender()
-                .send_external_message(ExternalMessage::Rebroadcast)
-                .map_err(ApiError::from)
-        });
+        api_scope.endpoint_mut(
+            name,
+            move |state: &ServiceApiState, _query: ()| -> Result<(), ApiError> {
+                state
+                    .sender()
+                    .send_external_message(ExternalMessage::Rebroadcast)
+                    .map_err(ApiError::from)
+            },
+        );
         self
     }
 }

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -379,7 +379,7 @@ mod memorydb_tests {
 
     fn create_blockchain() -> Blockchain {
         let service_keypair = gen_keypair();
-        let api_channel = mpsc::channel(1);
+        let api_channel = mpsc::unbounded();
         Blockchain::new(
             TemporaryDB::new(),
             vec![Box::new(super::TestService) as Box<dyn Service>],
@@ -391,7 +391,7 @@ mod memorydb_tests {
 
     fn create_blockchain_with_service(service: Box<dyn Service>) -> Blockchain {
         let service_keypair = gen_keypair();
-        let api_channel = mpsc::channel(1);
+        let api_channel = mpsc::unbounded();
         Blockchain::new(
             TemporaryDB::new(),
             vec![service],
@@ -458,7 +458,7 @@ mod rocksdb_tests {
     fn create_blockchain(path: &Path) -> Blockchain {
         let db = create_database(path);
         let service_keypair = gen_keypair();
-        let api_channel = mpsc::channel(1);
+        let api_channel = mpsc::unbounded();
         Blockchain::new(
             db,
             vec![Box::new(super::TestService) as Box<dyn Service>],
@@ -471,7 +471,7 @@ mod rocksdb_tests {
     fn create_blockchain_with_service(path: &Path, service: Box<dyn Service>) -> Blockchain {
         let db = create_database(path);
         let service_keypair = gen_keypair();
-        let api_channel = mpsc::channel(1);
+        let api_channel = mpsc::unbounded();
         Blockchain::new(
             db,
             vec![service],

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -682,7 +682,7 @@ mod tests {
 
     fn create_blockchain() -> Blockchain {
         let service_keypair = crypto::gen_keypair();
-        let api_channel = mpsc::channel(1);
+        let api_channel = mpsc::unbounded();
         Blockchain::new(
             TemporaryDB::new(),
             vec![Box::new(TxResultService) as Box<dyn Service>],

--- a/exonum/src/events/mod.rs
+++ b/exonum/src/events/mod.rs
@@ -34,6 +34,7 @@ use std::{cmp::Ordering, time::SystemTime};
 use crate::helpers::{Height, Round};
 use crate::messages::Message;
 use crate::node::{ExternalMessage, NodeTimeout};
+use futures::sync::mpsc::UnboundedSender;
 
 #[cfg(all(test, feature = "long_benchmarks"))]
 mod benches;
@@ -41,6 +42,7 @@ mod benches;
 mod tests;
 
 pub type SyncSender<T> = Wait<Sender<T>>;
+pub type UnboundedSyncSender<T> = Wait<UnboundedSender<T>>;
 
 /// This kind of events is used to schedule execution in next event-loop ticks
 /// Usable to make flat logic and remove recursions.
@@ -86,7 +88,7 @@ pub struct HandlerPart<H: EventHandler> {
     pub handler: H,
     pub internal_rx: mpsc::Receiver<InternalEvent>,
     pub network_rx: mpsc::Receiver<NetworkEvent>,
-    pub api_rx: mpsc::Receiver<ExternalMessage>,
+    pub api_rx: mpsc::UnboundedReceiver<ExternalMessage>,
 }
 
 impl<H: EventHandler + 'static> HandlerPart<H> {

--- a/exonum/src/messages/authorization.rs
+++ b/exonum/src/messages/authorization.rs
@@ -73,7 +73,6 @@ impl SignedMessage {
             buffer.len()
         );
         let signed = SignedMessage { raw: buffer };
-
         let pk = signed.author();
         let signature = signed.signature();
 

--- a/exonum/src/sandbox/mod.rs
+++ b/exonum/src/sandbox/mod.rs
@@ -90,7 +90,7 @@ pub struct SandboxInner {
     pub timers: BinaryHeap<TimeoutRequest>,
     pub network_requests_rx: mpsc::Receiver<NetworkRequest>,
     pub internal_requests_rx: mpsc::Receiver<InternalRequest>,
-    pub api_requests_rx: mpsc::Receiver<ExternalMessage>,
+    pub api_requests_rx: mpsc::UnboundedReceiver<ExternalMessage>,
 }
 
 impl SandboxInner {
@@ -826,7 +826,7 @@ impl Sandbox {
     pub fn restart_uninitialized_with_time(self, time: SystemTime) -> Sandbox {
         let network_channel = mpsc::channel(100);
         let internal_channel = mpsc::channel(100);
-        let api_channel = mpsc::channel(100);
+        let api_channel = mpsc::unbounded();
 
         let address: SocketAddr = self
             .address(ValidatorId(0))
@@ -1057,7 +1057,7 @@ fn sandbox_with_services_uninitialized(
         })
         .collect();
 
-    let api_channel = mpsc::channel(100);
+    let api_channel = mpsc::unbounded();
     let db = TemporaryDB::new();
     let mut blockchain = Blockchain::new(
         db,

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -127,7 +127,7 @@ pub fn create_blockchain() -> Blockchain {
     let (consensus_key, _) = consensus_keys();
     let service_keys = crypto::gen_keypair();
 
-    let api_channel = mpsc::channel(10);
+    let api_channel = mpsc::unbounded();
     let mut blockchain = Blockchain::new(
         TemporaryDB::new(),
         vec![MyService.into()],

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -422,7 +422,7 @@ impl TestKit {
         network: TestNetwork,
         genesis: GenesisConfig,
     ) -> Self {
-        let api_channel = mpsc::channel(1_000);
+        let api_channel = mpsc::unbounded();
         let api_sender = ApiSender::new(api_channel.0.clone());
 
         let db = CheckpointDb::new(database);


### PR DESCRIPTION
## Overview

Using an unbounded channel for REST API requests to prevent a node freezing when sending transactions in `after_commit` method. Also this change increases RPS for POST requests at `/api/explorer/v1/transactions` endpoint.  

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
