### PR TITLE
Add len() to MapIndex and ProofMapIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   An additional field in the response of the endpoint was added. The field
   corresponds to the total number of transactions in the blockchain. (#1289)
 
-- `system/v1/mempool` endpoint has been renamed into `system/v1/stats`.
-  An additional field in the response of the endpoint was added. The field
-  corresponds to the total number of transactions in the blockchain. (#1289)
-
 #### exonum-merkledb
 
 - Changed storage layout (#1293)
@@ -140,9 +136,6 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - A channel for api requests has been changed to unbounded. (#1308)
 
-- Added a new endpoint `system/v1/services` for displaying information
-  about available services. (#1288)
-
 #### exonum-merkledb
 
 - Updated `ProofMapIndex` data layout. (#1293)
@@ -159,9 +152,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
   - `get_object_existed` and `get_object_existed_mut` methods of `Fork` and `Snapshot`
     returns optional references to index.
+
 - `rocksdb` crate is now used instead of `exonum_rocksdb`. (#1286)
 
-- Added `len` method to `MapIndex` and `ProofMapIndex`. (#)
+- Added `len` method to `MapIndex` and `ProofMapIndex`. (#1312)
 
 #### exonum-testkit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,8 +137,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Added a new endpoint `system/v1/services` for displaying information
   about available services. (#1288)
-  
+
 - A channel for api requests has been changed to unbounded. (#1308)
+
+- Added a new endpoint `system/v1/services` for displaying information
+  about available services. (#1288)
 
 #### exonum-merkledb
 
@@ -158,8 +161,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
     returns optional references to index.
 - `rocksdb` crate is now used instead of `exonum_rocksdb`. (#1286)
 
-- Added a new endpoint `system/v1/services` for displaying information
-  about available services. (#1288)
+- Added `len` method to `MapIndex` and `ProofMapIndex`. (#)
 
 #### exonum-testkit
 
@@ -536,7 +538,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   - Remove old dependencies on `iron` and its companions `bodyparser`, `router`
     and others.
   - Simplify the API handlers as follows:
-  
+
     ```rust
     fn my_handler(state: &ServiceApiState, query: MyQueryType)
     -> Result<MyResponse, ApiError>
@@ -544,7 +546,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
       // ...
     }
     ```
-  
+
     where `MyQueryType` type implements `Deserialize` trait and `MyResponse`
     implements `Serialize` trait.
   - Replace old methods `public_api_handler` and `private_api_handler` of

--- a/components/merkledb/src/map_index.rs
+++ b/components/merkledb/src/map_index.rs
@@ -635,7 +635,7 @@ mod tests {
 
         assert!(!map_index.contains(&2_u8));
         assert!(!map_index.contains(&3_u8));
-        assert_eq!(map_index.len(), 0);
+        assert!(map_index.is_empty());
     }
 
     #[test]

--- a/components/merkledb/src/map_index.rs
+++ b/components/merkledb/src/map_index.rs
@@ -493,6 +493,26 @@ where
         self.state.get()
     }
 
+    /// Returns `true` if the map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exonum_merkledb::{TemporaryDB, Database, MapIndex};
+    ///
+    /// let db = TemporaryDB::new();
+    /// let name = "name";
+    /// let fork = db.fork();
+    /// let mut index = MapIndex::new(name, &fork);
+    /// assert!(index.is_empty());
+    ///
+    /// index.put(&0, 10);
+    /// assert!(!index.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     fn set_len(&mut self, len: u64) {
         self.state.set(len)
     }

--- a/components/merkledb/src/proof_map_index/mod.rs
+++ b/components/merkledb/src/proof_map_index/mod.rs
@@ -936,6 +936,26 @@ where
         self.state.get().len
     }
 
+    /// Returns `true` if the proof map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exonum_merkledb::{TemporaryDB, Database, ProofMapIndex};
+    ///
+    /// let db = TemporaryDB::new();
+    /// let name = "name";
+    /// let fork = db.fork();
+    /// let mut index = ProofMapIndex::new(name, &fork);
+    /// assert!(index.is_empty());
+    ///
+    /// index.put(&0, 10);
+    /// assert!(!index.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     fn set_len(&mut self, len: u64) {
         let mut metadata = self.state.get();
         metadata.update_len(len);

--- a/components/merkledb/src/proof_map_index/mod.rs
+++ b/components/merkledb/src/proof_map_index/mod.rs
@@ -210,32 +210,6 @@ impl BinaryAttribute for ProofMapState {
     }
 }
 
-impl BinaryAttribute for Option<ProofPath> {
-    fn size(&self) -> usize {
-        match self {
-            Some(path) => path.size(),
-            None => 0,
-        }
-    }
-
-    fn write<W: Write>(&self, buffer: &mut W) {
-        if let Some(path) = self {
-            let mut tmp = [0_u8; PROOF_PATH_SIZE];
-            path.write(&mut tmp);
-            buffer.write_all(&tmp).unwrap();
-        }
-    }
-
-    fn read<R: Read>(buffer: &mut R) -> Self {
-        let mut tmp = [0_u8; PROOF_PATH_SIZE];
-        match buffer.read(&mut tmp).unwrap() {
-            0 => None,
-            PROOF_PATH_SIZE => Some(ProofPath::read(&tmp)),
-            other => panic!("Unexpected attribute length: {}", other),
-        }
-    }
-}
-
 impl<T, K, V> ProofMapIndex<T, K, V>
 where
     T: IndexAccess,

--- a/components/merkledb/src/proof_map_index/tests.rs
+++ b/components/merkledb/src/proof_map_index/tests.rs
@@ -119,7 +119,7 @@ fn test_map_methods() {
 
     assert!(!index.contains(&[2; 32]));
     assert!(!index.contains(&[3; 32]));
-    assert_eq!(index.len(), 0);
+    assert!(index.is_empty());
 }
 
 #[test]

--- a/components/merkledb/src/proof_map_index/tests.rs
+++ b/components/merkledb/src/proof_map_index/tests.rs
@@ -93,23 +93,33 @@ fn test_map_methods() {
 
     assert_eq!(index.get(&[1; 32]), None);
     assert!(!index.contains(&[1; 32]));
+    assert_eq!(index.len(), 0);
 
     index.put(&[1; 32], 1_u8);
 
     assert_eq!(index.get(&[1; 32]), Some(1_u8));
     assert!(index.contains(&[1; 32]));
+    assert_eq!(index.len(), 1);
 
     index.remove(&[1; 32]);
 
     assert!(!index.contains(&[1; 32]));
     assert_eq!(index.get(&[1; 32]), None);
+    assert_eq!(index.len(), 0);
 
+    index.put(&[1; 32], 1_u8);
     index.put(&[2; 32], 2_u8);
     index.put(&[3; 32], 3_u8);
+
+    index.remove(&[3; 32]);
+    index.remove(&[2; 32]);
+    assert_eq!(index.len(), 1);
+
     index.clear();
 
     assert!(!index.contains(&[2; 32]));
     assert!(!index.contains(&[3; 32]));
+    assert_eq!(index.len(), 0);
 }
 
 #[test]

--- a/services/configuration/src/lib.rs
+++ b/services/configuration/src/lib.rs
@@ -163,7 +163,6 @@ impl fabric::ServiceFactory for ServiceFactory {
     }
 
     fn command(&mut self, command: CommandName) -> Option<Box<dyn CommandExtension>> {
-        use exonum::helpers::fabric;
         Some(match command {
             v if v == fabric::GenerateCommonConfig.name() => Box::new(GenerateCommonConfig),
             v if v == fabric::Finalize.name() => Box::new(Finalize),


### PR DESCRIPTION
## Overview
A number of elements for MapIndex and ProofMapIndex now stored in state.
<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
