### PR TITLE
Weird error-prone behaviour of latest param in blocks explorer API endpoint[ECR-3188]

### DIFF
--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -165,7 +165,9 @@ impl ExplorerApi {
 
         let (upper, upper_bound) = if let Some(upper) = query.latest {
             if upper > explorer.height() {
-                return Err(ApiError::NotFound("Requested latest height is not found".to_string()));
+                return Err(ApiError::NotFound(
+                    "Requested latest height is not found".to_string(),
+                ));
             }
             (upper, Bound::Included(upper))
         } else {

--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -165,9 +165,11 @@ impl ExplorerApi {
 
         let (upper, upper_bound) = if let Some(upper) = query.latest {
             if upper > explorer.height() {
-                return Err(ApiError::NotFound(
-                    "Requested latest height is not found".to_string(),
-                ));
+                return Err(ApiError::NotFound(format!(
+                    "Requested latest height {} is greater than the current blockchain height {}",
+                    upper,
+                    explorer.height()
+                )));
             }
             (upper, Bound::Included(upper))
         } else {

--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -164,6 +164,9 @@ impl ExplorerApi {
         }
 
         let (upper, upper_bound) = if let Some(upper) = query.latest {
+            if upper > explorer.height() {
+                return Err(ApiError::NotFound("Requested latest height is not found".to_string()));
+            }
             (upper, Bound::Included(upper))
         } else {
             (explorer.height(), Bound::Unbounded)

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -656,6 +656,22 @@ fn test_explorer_blocks_bounds() {
     assert_eq!(blocks[0].block.height(), Height(4));
     assert_eq!(range.start, Height(3));
     assert_eq!(range.end, Height(5));
+
+    // Check `latest` param isn't exceed the height.
+    let BlocksRange { blocks, range } = api
+        .public(ApiKind::Explorer)
+        .get("v1/blocks?count=2&latest=5")
+        .unwrap();
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0].block.height(), Height(5));
+    assert_eq!(range.start, Height(4));
+    assert_eq!(range.end, Height(6));
+
+    // Check `latest` param is exceed the height.
+    let result: Result<BlocksRange, ApiError> = api
+        .public(ApiKind::Explorer)
+        .get("v1/blocks?count=2&latest=6");
+    assert!(result.is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here 
  and list any open questions you might have. -->
Return 404 error for latest param exceed current height.
---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
