### PR TITLE
WIP: Proof list lazy hash

### DIFF
--- a/components/merkledb/benches/lazy.rs
+++ b/components/merkledb/benches/lazy.rs
@@ -1,0 +1,51 @@
+use criterion::{black_box, Bencher, Criterion};
+use exonum_merkledb::{
+    Database, IndexAccess, LazyListIndex, ListIndex, ObjectAccess, ObjectHash, ProofListIndex,
+    RefMut, TemporaryDB,
+};
+use rand::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
+
+const ITEM_COUNT: u16 = 1000;
+
+fn bench_fn<T, F>(b: &mut Bencher, index_access: T, benchmark: F)
+where
+    T: IndexAccess,
+    F: Fn(T),
+{
+    b.iter(|| benchmark(index_access.clone()))
+}
+
+fn bench_default_list<T: IndexAccess>(index_access: T) {
+    let mut index: ProofListIndex<_, u32> = ProofListIndex::new("index", index_access.clone());
+    for i in 0..ITEM_COUNT {
+        index.push(i.into());
+    }
+    let hash = index.object_hash();
+    black_box(index);
+    black_box(hash);
+}
+
+fn bench_default_lazy_list<T: ObjectAccess>(index_access: T) {
+    let mut index: LazyListIndex<_, u32> = LazyListIndex::new("index", index_access.clone());
+    for i in 0..ITEM_COUNT {
+        index.push(i.into());
+    }
+    let hash = index.object_hash();
+    black_box(index);
+    black_box(hash);
+}
+
+pub fn bench_lazy_hash(c: &mut Criterion) {
+    c.bench_function("lazy/index/default", move |b| {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        bench_fn(b, &fork, |fork| bench_default_list(fork));
+    });
+
+    c.bench_function("lazy/index/lazy_object_hash", move |b| {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        bench_fn(b, &fork, |fork| bench_default_lazy_list(fork));
+    });
+}

--- a/components/merkledb/benches/lazy.rs
+++ b/components/merkledb/benches/lazy.rs
@@ -7,7 +7,7 @@ use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 const SEED: [u8; 16] = [100; 16];
-const ITEM_COUNT: u16 = 100;
+const ITEM_COUNT: u16 = 1000;
 
 fn bench_fn<T, F>(b: &mut Bencher, index_access: T, benchmark: F)
 where

--- a/components/merkledb/benches/lib.rs
+++ b/components/merkledb/benches/lib.rs
@@ -16,7 +16,7 @@ use criterion::{criterion_group, criterion_main};
 
 use crate::{
     encoding::bench_encoding, lazy::bench_lazy_hash, refs::bench_refs, storage::bench_storage,
-    transactions::bench_transactions, transactions_lazy::bench_transactions_lazy,
+    transactions::bench_transactions,
 };
 
 mod encoding;
@@ -24,14 +24,12 @@ mod lazy;
 mod refs;
 mod storage;
 mod transactions;
-mod transactions_lazy;
 
 criterion_group!(
     benches,
     bench_storage,
     bench_encoding,
     bench_transactions,
-    bench_transactions_lazy,
     bench_refs,
     bench_lazy_hash,
 );

--- a/components/merkledb/benches/lib.rs
+++ b/components/merkledb/benches/lib.rs
@@ -16,7 +16,7 @@ use criterion::{criterion_group, criterion_main};
 
 use crate::{
     encoding::bench_encoding, lazy::bench_lazy_hash, refs::bench_refs, storage::bench_storage,
-    transactions::bench_transactions,
+    transactions::bench_transactions, transactions_lazy::bench_transactions_lazy,
 };
 
 mod encoding;
@@ -24,12 +24,14 @@ mod lazy;
 mod refs;
 mod storage;
 mod transactions;
+mod transactions_lazy;
 
 criterion_group!(
     benches,
     bench_storage,
     bench_encoding,
     bench_transactions,
+    bench_transactions_lazy,
     bench_refs,
     bench_lazy_hash,
 );

--- a/components/merkledb/benches/lib.rs
+++ b/components/merkledb/benches/lib.rs
@@ -15,11 +15,12 @@
 use criterion::{criterion_group, criterion_main};
 
 use crate::{
-    encoding::bench_encoding, refs::bench_refs, storage::bench_storage,
+    encoding::bench_encoding, lazy::bench_lazy_hash, refs::bench_refs, storage::bench_storage,
     transactions::bench_transactions,
 };
 
 mod encoding;
+mod lazy;
 mod refs;
 mod storage;
 mod transactions;
@@ -29,6 +30,7 @@ criterion_group!(
     bench_storage,
     bench_encoding,
     bench_transactions,
-    bench_refs
+    bench_refs,
+    bench_lazy_hash,
 );
 criterion_main!(benches);

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -31,7 +31,7 @@ const SEED: [u8; 16] = [100; 16];
 const SAMPLE_SIZE: usize = 10;
 
 #[cfg(all(test, not(feature = "long_benchmarks")))]
-const ITEM_COUNT: [BenchParams; 10] = [
+const ITEM_COUNT: [BenchParams; 5] = [
     BenchParams {
         users: 10_000,
         blocks: 1,
@@ -57,65 +57,65 @@ const ITEM_COUNT: [BenchParams; 10] = [
         blocks: 100,
         txs_in_block: 100,
     },
-    BenchParams {
-        users: 100,
-        blocks: 100,
-        txs_in_block: 100,
-    },
-    BenchParams {
-        users: 10_000,
-        blocks: 1_000,
-        txs_in_block: 10,
-    },
-    BenchParams {
-        users: 100,
-        blocks: 1_000,
-        txs_in_block: 10,
-    },
-    BenchParams {
-        users: 10_000,
-        blocks: 10_000,
-        txs_in_block: 1,
-    },
-    BenchParams {
-        users: 100,
-        blocks: 10_000,
-        txs_in_block: 1,
-    },
+    //  BenchParams {
+    //       users: 100,
+    //       blocks: 100,
+    //       txs_in_block: 100,
+    //   },
+    //   BenchParams {
+    //       users: 10_000,
+    //       blocks: 1_000,
+    //       txs_in_block: 10,
+    //   },
+    //   BenchParams {
+    //       users: 100,
+    //       blocks: 1_000,
+    //       txs_in_block: 10,
+    //   },
+    //   BenchParams {
+    //       users: 10_000,
+    //       blocks: 10_000,
+    //       txs_in_block: 1,
+    //   },
+    //   BenchParams {
+    //       users: 100,
+    //       blocks: 10_000,
+    //       txs_in_block: 1,
+    //   },
 ];
 
 #[cfg(all(test, feature = "long_benchmarks"))]
-const ITEM_COUNT: [BenchParams; 6] = [
+const ITEM_COUNT: [BenchParams; 1] = [
     BenchParams {
         users: 1_000,
         blocks: 10,
         txs_in_block: 10_000,
     },
-    BenchParams {
-        users: 1_000,
-        blocks: 100,
-        txs_in_block: 1_000,
-    },
-    BenchParams {
-        users: 1_000,
-        blocks: 1_000,
-        txs_in_block: 100,
-    },
-    BenchParams {
-        users: 1_000,
-        blocks: 10_000,
-        txs_in_block: 10,
-    },
-    BenchParams {
-        users: 1_000,
-        blocks: 100_000,
-        txs_in_block: 1,
-    },
-    BenchParams {
-        users: 1_000,
-        blocks: 1_000,
-        txs_in_block: 1_000,
-    },
+    //   BenchParams {
+    //       users: 1_000,
+    //       blocks: 100,
+    //       txs_in_block: 1_000,
+    //   },
+    //   BenchParams {
+    //       users: 1_000,
+    //       blocks: 1_000,
+    //       txs_in_block: 100,
+    //   },
+    //   BenchParams {
+    //       users: 1_000,
+    //       blocks: 10_000,
+    //       txs_in_block: 10,
+    //   },
+    //   BenchParams {
+    //       users: 1_000,
+    //       blocks: 100_000,
+    //       txs_in_block: 1,
+    //   },
+    //   BenchParams {
+    //       users: 1_000,
+    //       blocks: 1_000,
+    //       txs_in_block: 1_000,
+    //   },
 ];
 
 #[derive(Clone, Copy, Debug)]
@@ -214,22 +214,22 @@ impl<T: ObjectAccess> RefSchema<T> {
         self.0.get_object("wallets")
     }
 
-    fn wallets_history(&self, owner: &PublicKey) -> RefMut<LazyListIndex<T, Hash>> {
-        RefMut {
-            value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
-        }
-    }
+    //   fn wallets_history(&self, owner: &PublicKey) -> RefMut<LazyListIndex<T, Hash>> {
+    //       RefMut {
+    //           value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
+    //       }
+    //   }
 
-    //  fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
-    //      self.0.get_object(("wallets.history", owner))
-    //  }
+    fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
+        self.0.get_object(("wallets.history", owner))
+    }
 }
 
 impl<T: ObjectAccess> RefSchema<T> {
     fn add_transaction_to_history(&self, owner: &PublicKey, tx_hash: Hash) -> Hash {
         let mut history = self.wallets_history(owner);
         history.push(tx_hash);
-        history.update_hashes();
+        //history.update_hashes();
         history.object_hash()
     }
 }

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -219,6 +219,10 @@ impl<T: ObjectAccess> RefSchema<T> {
             value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
         }
     }
+
+    //  fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
+    //      self.0.get_object(("wallets.history", owner))
+    //  }
 }
 
 impl<T: ObjectAccess> RefSchema<T> {

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -23,15 +23,15 @@ use serde_derive::{Deserialize, Serialize};
 
 use exonum_crypto::{Hash, PublicKey, PUBLIC_KEY_LENGTH};
 use exonum_merkledb::{
-    impl_object_hash_for_binary_value, BinaryValue, Database, Fork, ListIndex, MapIndex,
-    ObjectAccess, ObjectHash, ProofListIndex, ProofMapIndex, RefMut, TemporaryDB,
+    impl_object_hash_for_binary_value, BinaryValue, Database, Fork, LazyListIndex, ListIndex,
+    MapIndex, ObjectAccess, ObjectHash, ProofListIndex, ProofMapIndex, RefMut, TemporaryDB,
 };
 
 const SEED: [u8; 16] = [100; 16];
 const SAMPLE_SIZE: usize = 10;
 
 #[cfg(all(test, not(feature = "long_benchmarks")))]
-const ITEM_COUNT: [BenchParams; 10] = [
+const ITEM_COUNT: [BenchParams; 4] = [
     BenchParams {
         users: 10_000,
         blocks: 1,
@@ -52,36 +52,36 @@ const ITEM_COUNT: [BenchParams; 10] = [
         blocks: 10,
         txs_in_block: 1_000,
     },
-    BenchParams {
-        users: 10_000,
-        blocks: 100,
-        txs_in_block: 100,
-    },
-    BenchParams {
-        users: 100,
-        blocks: 100,
-        txs_in_block: 100,
-    },
-    BenchParams {
-        users: 10_000,
-        blocks: 1_000,
-        txs_in_block: 10,
-    },
-    BenchParams {
-        users: 100,
-        blocks: 1_000,
-        txs_in_block: 10,
-    },
-    BenchParams {
-        users: 10_000,
-        blocks: 10_000,
-        txs_in_block: 1,
-    },
-    BenchParams {
-        users: 100,
-        blocks: 10_000,
-        txs_in_block: 1,
-    },
+    // BenchParams {
+    //     users: 10_000,
+    //     blocks: 100,
+    //     txs_in_block: 100,
+    // },
+    // BenchParams {
+    //     users: 100,
+    //     blocks: 100,
+    //     txs_in_block: 100,
+    // },
+    // BenchParams {
+    //     users: 10_000,
+    //     blocks: 1_000,
+    //     txs_in_block: 10,
+    // },
+    // BenchParams {
+    //     users: 100,
+    //     blocks: 1_000,
+    //     txs_in_block: 10,
+    // },
+    // BenchParams {
+    //     users: 10_000,
+    //     blocks: 10_000,
+    //     txs_in_block: 1,
+    // },
+    // BenchParams {
+    //     users: 100,
+    //     blocks: 10_000,
+    //     txs_in_block: 1,
+    // },
 ];
 
 #[cfg(all(test, feature = "long_benchmarks"))]
@@ -214,8 +214,10 @@ impl<T: ObjectAccess> RefSchema<T> {
         self.0.get_object("wallets")
     }
 
-    fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
-        self.0.get_object(("wallets.history", owner))
+    fn wallets_history(&self, owner: &PublicKey) -> RefMut<LazyListIndex<T, Hash>> {
+        RefMut {
+            value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
+        }
     }
 }
 
@@ -223,6 +225,7 @@ impl<T: ObjectAccess> RefSchema<T> {
     fn add_transaction_to_history(&self, owner: &PublicKey, tx_hash: Hash) -> Hash {
         let mut history = self.wallets_history(owner);
         history.push(tx_hash);
+        history.update_hashes();
         history.object_hash()
     }
 }

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -52,36 +52,36 @@ const ITEM_COUNT: [BenchParams; 4] = [
         blocks: 10,
         txs_in_block: 1_000,
     },
-    // BenchParams {
-    //     users: 10_000,
-    //     blocks: 100,
-    //     txs_in_block: 100,
-    // },
-    // BenchParams {
-    //     users: 100,
-    //     blocks: 100,
-    //     txs_in_block: 100,
-    // },
-    // BenchParams {
-    //     users: 10_000,
-    //     blocks: 1_000,
-    //     txs_in_block: 10,
-    // },
-    // BenchParams {
-    //     users: 100,
-    //     blocks: 1_000,
-    //     txs_in_block: 10,
-    // },
-    // BenchParams {
-    //     users: 10_000,
-    //     blocks: 10_000,
-    //     txs_in_block: 1,
-    // },
-    // BenchParams {
-    //     users: 100,
-    //     blocks: 10_000,
-    //     txs_in_block: 1,
-    // },
+    BenchParams {
+        users: 10_000,
+        blocks: 100,
+        txs_in_block: 100,
+    },
+    BenchParams {
+        users: 100,
+        blocks: 100,
+        txs_in_block: 100,
+    },
+    BenchParams {
+        users: 10_000,
+        blocks: 1_000,
+        txs_in_block: 10,
+    },
+    BenchParams {
+        users: 100,
+        blocks: 1_000,
+        txs_in_block: 10,
+    },
+    BenchParams {
+        users: 10_000,
+        blocks: 10_000,
+        txs_in_block: 1,
+    },
+    BenchParams {
+        users: 100,
+        blocks: 10_000,
+        txs_in_block: 1,
+    },
 ];
 
 #[cfg(all(test, feature = "long_benchmarks"))]

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -31,7 +31,7 @@ const SEED: [u8; 16] = [100; 16];
 const SAMPLE_SIZE: usize = 10;
 
 #[cfg(all(test, not(feature = "long_benchmarks")))]
-const ITEM_COUNT: [BenchParams; 5] = [
+const ITEM_COUNT: [BenchParams; 10] = [
     BenchParams {
         users: 10_000,
         blocks: 1,
@@ -57,65 +57,65 @@ const ITEM_COUNT: [BenchParams; 5] = [
         blocks: 100,
         txs_in_block: 100,
     },
-    //  BenchParams {
-    //       users: 100,
-    //       blocks: 100,
-    //       txs_in_block: 100,
-    //   },
-    //   BenchParams {
-    //       users: 10_000,
-    //       blocks: 1_000,
-    //       txs_in_block: 10,
-    //   },
-    //   BenchParams {
-    //       users: 100,
-    //       blocks: 1_000,
-    //       txs_in_block: 10,
-    //   },
-    //   BenchParams {
-    //       users: 10_000,
-    //       blocks: 10_000,
-    //       txs_in_block: 1,
-    //   },
-    //   BenchParams {
-    //       users: 100,
-    //       blocks: 10_000,
-    //       txs_in_block: 1,
-    //   },
+    BenchParams {
+        users: 100,
+        blocks: 100,
+        txs_in_block: 100,
+    },
+    BenchParams {
+        users: 10_000,
+        blocks: 1_000,
+        txs_in_block: 10,
+    },
+    BenchParams {
+        users: 100,
+        blocks: 1_000,
+        txs_in_block: 10,
+    },
+    BenchParams {
+        users: 10_000,
+        blocks: 10_000,
+        txs_in_block: 1,
+    },
+    BenchParams {
+        users: 100,
+        blocks: 10_000,
+        txs_in_block: 1,
+    },
 ];
 
 #[cfg(all(test, feature = "long_benchmarks"))]
-const ITEM_COUNT: [BenchParams; 1] = [
+const ITEM_COUNT: [BenchParams; 6] = [
     BenchParams {
         users: 1_000,
         blocks: 10,
         txs_in_block: 10_000,
     },
-    //   BenchParams {
-    //       users: 1_000,
-    //       blocks: 100,
-    //       txs_in_block: 1_000,
-    //   },
-    //   BenchParams {
-    //       users: 1_000,
-    //       blocks: 1_000,
-    //       txs_in_block: 100,
-    //   },
-    //   BenchParams {
-    //       users: 1_000,
-    //       blocks: 10_000,
-    //       txs_in_block: 10,
-    //   },
-    //   BenchParams {
-    //       users: 1_000,
-    //       blocks: 100_000,
-    //       txs_in_block: 1,
-    //   },
-    //   BenchParams {
-    //       users: 1_000,
-    //       blocks: 1_000,
-    //       txs_in_block: 1_000,
-    //   },
+    BenchParams {
+        users: 1_000,
+        blocks: 100,
+        txs_in_block: 1_000,
+    },
+    BenchParams {
+        users: 1_000,
+        blocks: 1_000,
+        txs_in_block: 100,
+    },
+    BenchParams {
+        users: 1_000,
+        blocks: 10_000,
+        txs_in_block: 10,
+    },
+    BenchParams {
+        users: 1_000,
+        blocks: 100_000,
+        txs_in_block: 1,
+    },
+    BenchParams {
+        users: 1_000,
+        blocks: 1_000,
+        txs_in_block: 1_000,
+    },
 ];
 
 #[derive(Clone, Copy, Debug)]
@@ -214,22 +214,22 @@ impl<T: ObjectAccess> RefSchema<T> {
         self.0.get_object("wallets")
     }
 
-    //   fn wallets_history(&self, owner: &PublicKey) -> RefMut<LazyListIndex<T, Hash>> {
-    //       RefMut {
-    //           value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
-    //       }
-    //   }
-
-    fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
-        self.0.get_object(("wallets.history", owner))
+    fn wallets_history(&self, owner: &PublicKey) -> RefMut<LazyListIndex<T, Hash>> {
+        RefMut {
+            value: LazyListIndex::new_in_family("wallets_history", owner, self.0.clone()),
+        }
     }
+
+    //  fn wallets_history(&self, owner: &PublicKey) -> RefMut<ProofListIndex<T, Hash>> {
+    //      self.0.get_object(("wallets.history", owner))
+    //  }
 }
 
 impl<T: ObjectAccess> RefSchema<T> {
     fn add_transaction_to_history(&self, owner: &PublicKey, tx_hash: Hash) -> Hash {
         let mut history = self.wallets_history(owner);
         history.push(tx_hash);
-        //history.update_hashes();
+        history.update_hashes();
         history.object_hash()
     }
 }

--- a/components/merkledb/benches/transactions.rs
+++ b/components/merkledb/benches/transactions.rs
@@ -31,7 +31,7 @@ const SEED: [u8; 16] = [100; 16];
 const SAMPLE_SIZE: usize = 10;
 
 #[cfg(all(test, not(feature = "long_benchmarks")))]
-const ITEM_COUNT: [BenchParams; 4] = [
+const ITEM_COUNT: [BenchParams; 10] = [
     BenchParams {
         users: 10_000,
         blocks: 1,

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -137,7 +137,7 @@ pub use self::{
     list_index::ListIndex,
     map_index::MapIndex,
     options::DbOptions,
-    proof_list_index::{ListProof, ProofListIndex},
+    proof_list_index::{lazy::LazyListIndex, ListProof, ProofListIndex},
     sparse_list_index::SparseListIndex,
     value_set_index::ValueSetIndex,
     values::BinaryValue,

--- a/components/merkledb/src/proof_list_index/lazy.rs
+++ b/components/merkledb/src/proof_list_index/lazy.rs
@@ -307,7 +307,7 @@ where
     fn get_branch_new(&self, key: ProofListKey) -> Branch {
         debug_assert!(self.has_branch(key));
 
-        self.base.get(&key).unwrap()
+        self.base.get(&key).unwrap_or(Branch::new(None))
     }
 
     fn root_key(&self) -> ProofListKey {
@@ -605,7 +605,6 @@ where
         self.set_len(len + 1);
 
         let mut key = ProofListKey::new(1, len);
-        self.base.put(&key, Branch::new(None));
         self.base.put(&ProofListKey::leaf(len), value);
 
         while key.height() < self.height() {
@@ -720,15 +719,13 @@ where
             return HashTag::empty_list_hash();
         }
 
-        let vec: Vec<(_, Branch, V)> = self
-            .iter()
-            .enumerate()
-            .map(|(index, value)| {
-                let key = ProofListKey::new(1, index as u64);
-                let branch = self.get_branch_new(key);
-                (key, branch, value)
-            })
-            .collect();
+        let mut vec = Vec::with_capacity(self.len() as usize);
+
+        for (index, value) in self.iter().enumerate() {
+            let key = ProofListKey::new(1, index as u64);
+            let branch = self.get_branch_new(key);
+            vec.push((key, branch, value));
+        }
 
         let mut hashes: Vec<Hash> = Vec::with_capacity(self.len() as usize);
 

--- a/components/merkledb/src/proof_list_index/mod.rs
+++ b/components/merkledb/src/proof_list_index/mod.rs
@@ -49,7 +49,6 @@ mod tests;
 pub struct ProofListIndex<T: IndexAccess, V> {
     base: View<T>,
     state: IndexState<T, u64>,
-    pub counter: u32,
     _v: PhantomData<V>,
 }
 
@@ -120,7 +119,6 @@ where
         Self {
             base,
             state,
-            counter: 0,
             _v: PhantomData,
         }
     }
@@ -166,7 +164,6 @@ where
         Self {
             base,
             state,
-            counter: 0,
             _v: PhantomData,
         }
     }
@@ -179,7 +176,6 @@ where
         Self {
             base,
             state,
-            counter: 0,
             _v: PhantomData,
         }
     }
@@ -191,7 +187,6 @@ where
             .map(|(base, state)| Self {
                 base,
                 state,
-                counter: 0,
                 _v: PhantomData,
             })
     }
@@ -509,11 +504,9 @@ where
         self.set_len(len + 1);
         let mut key = ProofListKey::new(1, len);
 
-        self.counter += 1;
         self.base.put(&key, HashTag::hash_leaf(&value.to_bytes()));
         self.base.put(&ProofListKey::leaf(len), value);
         while key.height() < self.height() {
-            self.counter += 1;
             let hash = if key.is_left() {
                 HashTag::hash_single_node(&self.get_branch_unchecked(key))
             } else {

--- a/components/merkledb/src/proof_list_index/mod.rs
+++ b/components/merkledb/src/proof_list_index/mod.rs
@@ -49,6 +49,7 @@ mod tests;
 pub struct ProofListIndex<T: IndexAccess, V> {
     base: View<T>,
     state: IndexState<T, u64>,
+    pub counter: u32,
     _v: PhantomData<V>,
 }
 
@@ -119,6 +120,7 @@ where
         Self {
             base,
             state,
+            counter: 0,
             _v: PhantomData,
         }
     }
@@ -164,6 +166,7 @@ where
         Self {
             base,
             state,
+            counter: 0,
             _v: PhantomData,
         }
     }
@@ -176,6 +179,7 @@ where
         Self {
             base,
             state,
+            counter: 0,
             _v: PhantomData,
         }
     }
@@ -187,6 +191,7 @@ where
             .map(|(base, state)| Self {
                 base,
                 state,
+                counter: 0,
                 _v: PhantomData,
             })
     }
@@ -504,9 +509,11 @@ where
         self.set_len(len + 1);
         let mut key = ProofListKey::new(1, len);
 
+        self.counter += 1;
         self.base.put(&key, HashTag::hash_leaf(&value.to_bytes()));
         self.base.put(&ProofListKey::leaf(len), value);
         while key.height() < self.height() {
+            self.counter += 1;
             let hash = if key.is_left() {
                 HashTag::hash_single_node(&self.get_branch_unchecked(key))
             } else {

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -232,7 +232,7 @@ pub struct IndexAddress {
 impl IndexAddress {
     /// Creates empty `IndexAddress`.
     pub fn new() -> Self {
-        Self::default()
+        Self::with_root("root")
     }
 
     /// Creates new `IndexAddress` with specified `root` name.

--- a/components/merkledb/src/views/refs.rs
+++ b/components/merkledb/src/views/refs.rs
@@ -277,7 +277,8 @@ pub struct Ref<T> {
 #[derive(Debug)]
 /// Utility trait to provide mutable references to `MerkleDB` objects.
 pub struct RefMut<T> {
-    value: T,
+    ///TODO: remove pub
+    pub value: T,
 }
 
 impl<T> Deref for Ref<T> {


### PR DESCRIPTION
## Overview

Introduced `LazyListIndex` with lazy hash calculations. Hash is now calculated on demand by invoking `update_hashes` method. Currently `LazyListIndex` is slower than `ProofListIndex`.

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
