### PR TITLE
A small amount of code improvements. [ECR-3222]

### DIFF
--- a/exonum/src/api/mod.rs
+++ b/exonum/src/api/mod.rs
@@ -29,7 +29,6 @@ use crate::{
     blockchain::{Blockchain, SharedNodeState},
     crypto::PublicKey,
     node::ApiSender,
-    runtime::RuntimeEnvironment,
 };
 
 pub mod backends;

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -107,12 +107,12 @@ impl Blockchain {
         internal_req_sender: mpsc::Sender<InternalRequest>,
     ) -> Self {
         let dispatcher = DispatcherBuilder::new(internal_req_sender)
-            .builtin_service(
+            .with_builtin_service(
                 ConfigurationServiceFactory,
                 ConfigurationServiceFactory::BUILTIN_ID,
                 ConfigurationServiceFactory::BUILTIN_NAME,
             )
-            .service_factories(services)
+            .with_service_factories(services)
             .finalize();
 
         Self {

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -67,8 +67,8 @@ use crate::{
     runtime::configuration_new::ConfigurationServiceFactory,
     runtime::{
         dispatcher::{Dispatcher, DispatcherBuilder},
-        rust::{service::ServiceFactory, RustRuntime},
-        RuntimeContext, RuntimeIdentifier,
+        rust::service::ServiceFactory,
+        RuntimeContext,
     },
 };
 
@@ -98,8 +98,8 @@ pub struct Blockchain {
 
 impl Blockchain {
     /// Constructs a blockchain for the given `storage` and list of `services`.
-    pub fn new<D: Into<Arc<dyn Database>>>(
-        storage: D,
+    pub fn new(
+        storage: impl Into<Arc<dyn Database>>,
         services: Vec<Box<dyn ServiceFactory>>,
         service_public_key: PublicKey,
         service_secret_key: SecretKey,
@@ -394,7 +394,7 @@ impl Blockchain {
 
         let catch_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             let author = signed_tx.author();
-            let mut context = RuntimeContext::new(fork, &author, &tx_hash);
+            let mut context = RuntimeContext::new(fork, author, tx_hash);
             self.dispatcher
                 .lock()
                 .expect("Expected lock on Dispatcher")

--- a/exonum/src/runtime/configuration_new/mod.rs
+++ b/exonum/src/runtime/configuration_new/mod.rs
@@ -14,21 +14,19 @@
 
 pub use self::transactions::{Deploy, Init};
 
-use exonum_merkledb::{BinaryValue, Fork, IndexAccess, Snapshot};
-use protobuf::well_known_types::Any;
+use exonum_merkledb::{Fork, IndexAccess, Snapshot};
 
 use crate::{
     blockchain::Schema as CoreSchema,
     crypto::Hash,
-    node::State,
     runtime::{
-        dispatcher::{Action, Dispatcher},
-        error::{ExecutionError, InitError, WRONG_ARG_ERROR},
+        dispatcher::Action,
+        error::ExecutionError,
         rust::{
             service::{Service, ServiceFactory},
             RustArtifactSpec, TransactionContext,
         },
-        DeployStatus, RuntimeEnvironment, ServiceConstructor,
+        ServiceConstructor,
     },
 };
 

--- a/exonum/src/runtime/configuration_new/schema.rs
+++ b/exonum/src/runtime/configuration_new/schema.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 use exonum_merkledb::{
-    BinaryValue, IndexAccess, MapIndex, ObjectHash, ProofListIndex, ProofMapIndex, Snapshot,
+    BinaryValue, IndexAccess, MapIndex, ObjectHash, ProofListIndex, ProofMapIndex,
 };
 
 use std::{borrow::Cow, ops::Deref};

--- a/exonum/src/runtime/configuration_new/transactions.rs
+++ b/exonum/src/runtime/configuration_new/transactions.rs
@@ -232,7 +232,7 @@ impl Propose {
         // Start writing to storage.
         // NB. DO NOT write to the service schema anywhere else during `Propose::execute`, it may
         // break invariants.
-        let mut schema = Schema::new(fork);
+        let schema = Schema::new(fork);
 
         let propose_data = {
             let mut votes_table = schema.votes_by_config_hash(&cfg_hash);
@@ -340,7 +340,7 @@ impl VotingContext {
         // Start writing to storage.
         // NB. DO NOT write to the service schema anywhere else during `Vote::execute`, it may
         // break invariants.
-        let mut schema = Schema::new(fork);
+        let schema = Schema::new(fork);
 
         let propose_data = {
             let mut votes = schema.votes_by_config_hash(cfg_hash);

--- a/exonum/src/runtime/dispatcher.rs
+++ b/exonum/src/runtime/dispatcher.rs
@@ -193,7 +193,7 @@ impl DispatcherBuilder {
 
     /// Adds built-in service with predefined identifier, keep in mind that the initialize method
     /// of service will not be invoked and thus service must have and empty constructor.
-    pub fn builtin_service(
+    pub fn with_builtin_service(
         mut self,
         service_factory: impl Into<Box<dyn ServiceFactory>>,
         instance_id: ServiceInstanceId,
@@ -212,14 +212,17 @@ impl DispatcherBuilder {
     }
 
     /// Adds service factory to the Rust runtime.
-    pub fn service_factory(mut self, service_factory: impl Into<Box<dyn ServiceFactory>>) -> Self {
+    pub fn with_service_factory(
+        mut self,
+        service_factory: impl Into<Box<dyn ServiceFactory>>,
+    ) -> Self {
         self.builtin_runtime
             .add_service_factory(service_factory.into());
         self
     }
 
     /// Adds given service factories to the Rust runtime.
-    pub fn service_factories(
+    pub fn with_service_factories(
         mut self,
         service_factories: impl IntoIterator<Item = impl Into<Box<dyn ServiceFactory>>>,
     ) -> Self {
@@ -230,7 +233,7 @@ impl DispatcherBuilder {
     }
 
     /// Adds additional runtime.
-    pub fn runtime(mut self, id: u32, runtime: impl Into<Box<dyn Runtime>>) -> Self {
+    pub fn with_runtime(mut self, id: u32, runtime: impl Into<Box<dyn Runtime>>) -> Self {
         self.dispatcher.add_runtime(id, runtime);
         self
     }
@@ -371,8 +374,8 @@ mod tests {
         let runtime_b = SampleRuntime::new(RuntimeIdentifier::Java as u32, 1, 0);
 
         let dispatcher = DispatcherBuilder::dummy()
-            .runtime(runtime_a.runtime_type, runtime_a)
-            .runtime(runtime_b.runtime_type, runtime_b)
+            .with_runtime(runtime_a.runtime_type, runtime_a)
+            .with_runtime(runtime_b.runtime_type, runtime_b)
             .finalize();
 
         assert!(dispatcher
@@ -407,8 +410,8 @@ mod tests {
         );
 
         let mut dispatcher = DispatcherBuilder::dummy()
-            .runtime(runtime_a.runtime_type, runtime_a)
-            .runtime(runtime_b.runtime_type, runtime_b)
+            .with_runtime(runtime_a.runtime_type, runtime_a)
+            .with_runtime(runtime_b.runtime_type, runtime_b)
             .finalize();
 
         let sample_rust_spec = ArtifactSpec {

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -17,8 +17,6 @@
 
 pub use crate::blockchain::ExecutionError;
 
-use crate::blockchain;
-
 // TODO: summarize error codes/simplify error creation
 
 pub const DISPATCH_ERROR: u8 = 255;

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -84,9 +84,9 @@ impl From<RustArtifactSpec> for ArtifactSpec {
 
 // TODO Think about environment methods' names. [ECR-3222]
 
-/// Service runtime environment.
+/// Runtime environment for services.
 /// It does not assign id to services/interfaces, ids are given to runtime from outside.
-pub trait RuntimeEnvironment: Send + Debug + 'static {
+pub trait Runtime: Send + Debug + 'static {
     /// Start artifact deploy.
     fn start_deploy(&mut self, artifact: ArtifactSpec) -> Result<(), DeployError>;
 
@@ -137,7 +137,7 @@ pub struct RuntimeContext<'a> {
 }
 
 impl<'a> RuntimeContext<'a> {
-    pub fn new(fork: &'a Fork, &author: &PublicKey, &tx_hash: &Hash) -> Self {
+    pub fn new(fork: &'a Fork, author: PublicKey, tx_hash: Hash) -> Self {
         Self {
             fork,
             author,
@@ -155,16 +155,11 @@ impl<'a> RuntimeContext<'a> {
         std::mem::swap(&mut self.dispatcher_actions, &mut other);
         other
     }
-
-    // TODO Implement author enum. [ECR-3222]
-    fn from_fork(fork: &'a Fork) -> Self {
-        Self::new(fork, &PublicKey::zero(), &Hash::zero())
-    }
 }
 
-impl<T> From<T> for Box<dyn RuntimeEnvironment>
+impl<T> From<T> for Box<dyn Runtime>
 where
-    T: RuntimeEnvironment,
+    T: Runtime,
 {
     fn from(runtime: T) -> Self {
         Box::new(runtime) as Self

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -15,6 +15,8 @@
 use exonum_merkledb::{BinaryValue, Fork, Snapshot};
 use protobuf::well_known_types::Any;
 
+use std::fmt::Debug;
+
 use crate::{
     api::ServiceApiBuilder,
     crypto::{Hash, PublicKey},
@@ -84,7 +86,7 @@ impl From<RustArtifactSpec> for ArtifactSpec {
 
 /// Service runtime environment.
 /// It does not assign id to services/interfaces, ids are given to runtime from outside.
-pub trait RuntimeEnvironment: Send + 'static {
+pub trait RuntimeEnvironment: Send + Debug + 'static {
     /// Start artifact deploy.
     fn start_deploy(&mut self, artifact: ArtifactSpec) -> Result<(), DeployError>;
 

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -356,7 +356,7 @@ impl<'a, 'b> TransactionContext<'a, 'b> {
         self.runtime_context.author
     }
 
-    // TODO Should we support the ability to call other service from the rust runtime during 
+    // TODO Should we support the ability to call other service from the rust runtime during
     // the transaction execution?
     pub fn dispatch_call(
         &mut self,

--- a/exonum/src/runtime/rust/service.rs
+++ b/exonum/src/runtime/rust/service.rs
@@ -58,10 +58,11 @@ pub trait ServiceFactory: Debug + 'static {
     fn new_instance(&self) -> Box<dyn Service>;
 }
 
-impl<T> From<T> for Box<dyn ServiceFactory> 
-    where T: ServiceFactory
+impl<T> From<T> for Box<dyn ServiceFactory>
+where
+    T: ServiceFactory,
 {
-    fn from(factory: T) -> Self { 
+    fn from(factory: T) -> Self {
         Box::new(factory) as Self
     }
 }


### PR DESCRIPTION
- Implemented `DispatcherBuilder` to hide logic of built-in services creation.
- Renamed `RuntimeEnvironment` to `Runtime`.
- Added `service_id` method to `TransactionContext`.