### PR TITLE
Improvement of the process of adding auditing.

### DIFF
--- a/exonum/src/api/node/private/mod.rs
+++ b/exonum/src/api/node/private/mod.rs
@@ -48,8 +48,8 @@ pub struct NodeInfo {
 impl NodeInfo {
     /// Creates new `NodeInfo` from services list.
     pub fn new<'a, I>(services: I) -> Self
-        where
-            I: IntoIterator<Item=&'a Box<dyn Service>>,
+    where
+        I: IntoIterator<Item = &'a Box<dyn Service>>,
     {
         let core_version = option_env!("CARGO_PKG_VERSION").map(ToOwned::to_owned);
         Self {
@@ -251,24 +251,27 @@ impl SystemApi {
     }
 
     fn handle_add_auditor(self, name: &'static str, api_scope: &mut ServiceApiScope) -> Self {
-        api_scope.endpoint_mut(name, move |state: &ServiceApiState, query: AddAuditorRequest| {
-            use crate::messages;
+        api_scope.endpoint_mut(
+            name,
+            move |state: &ServiceApiState, query: AddAuditorRequest| {
+                use crate::messages;
 
-            let message = messages::Message::concrete(
-                messages::AddAuditor {
-                    address: query.address,
-                    public_key: query.public_key,
-                    connect_all: query.connect_all,
-                    validators: query.validators,
-                },
-                state.public_key().clone(),
-                state.secret_key(),
-            );
-            state
-                .sender()
-                .send_external_message(ExternalMessage::AuditorAdd(message))?;
-            Ok(())
-        });
+                let message = messages::Message::concrete(
+                    messages::AddAuditor {
+                        address: query.address,
+                        public_key: query.public_key,
+                        connect_all: query.connect_all,
+                        validators: query.validators,
+                    },
+                    state.public_key().clone(),
+                    state.secret_key(),
+                );
+                state
+                    .sender()
+                    .send_external_message(ExternalMessage::AuditorAdd(message))?;
+                Ok(())
+            },
+        );
         self
     }
 }

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -19,7 +19,7 @@ use crate::blockchain::{Schema, SharedNodeState, GenesisConfig};
 use crate::helpers::user_agent;
 use crate::crypto::PublicKey;
 use exonum_merkledb::DbOptions;
-use crate::node::{NodeConfig, MemoryPoolConfig, ConnectListConfig, AuditorConfig};
+use crate::node::{NodeConfig, MemoryPoolConfig, ConnectListConfig, AuditorConfig, NodeApiConfig};
 use std::path::PathBuf;
 use crate::events::NetworkConfiguration;
 use std::collections::btree_map::BTreeMap;
@@ -78,6 +78,8 @@ pub struct KeyInfo {
 /// Shared configuration
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct SharedConfiguration {
+    /// Api configuration.
+    pub api: NodeApiConfig,
     /// Initial config that will be written in the first block.
     pub genesis: GenesisConfig,
     /// Remote Network address used by this node.
@@ -106,6 +108,7 @@ impl SharedConfiguration {
     /// Create new shared configuration.
     pub fn new(config: NodeConfig<PathBuf>) -> SharedConfiguration {
         SharedConfiguration {
+            api: config.api,
             genesis: config.genesis,
             external_address: config.external_address,
             network: config.network,

--- a/exonum/src/blockchain/service.rs
+++ b/exonum/src/blockchain/service.rs
@@ -24,8 +24,8 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     net::SocketAddr,
-    sync::{Arc, RwLock},
     path::PathBuf,
+    sync::{Arc, RwLock},
 };
 
 use crate::{
@@ -33,9 +33,9 @@ use crate::{
     blockchain::{ConsensusConfig, Schema, StoredConfiguration, ValidatorKeys},
     crypto::{Hash, PublicKey, SecretKey},
     events::network::ConnectedPeerAddr,
-    helpers::{Height, Milliseconds, ValidatorId, config::ConfigAccessor},
+    helpers::{config::ConfigAccessor, Height, Milliseconds, ValidatorId},
     messages::{Message, RawTransaction, ServiceTransaction, Signed},
-    node::{ApiSender, ConnectInfo, NodeRole, State, NodeConfig},
+    node::{ApiSender, ConnectInfo, NodeConfig, NodeRole, State},
 };
 
 use super::transaction::Transaction;
@@ -392,7 +392,10 @@ pub struct SharedNodeState {
 
 impl SharedNodeState {
     /// Creates a new `SharedNodeState` instance.
-    pub fn new(state_update_timeout: Milliseconds, config_accessor: Option<ConfigAccessor>) -> Self {
+    pub fn new(
+        state_update_timeout: Milliseconds,
+        config_accessor: Option<ConfigAccessor>,
+    ) -> Self {
         Self {
             state: Arc::new(RwLock::new(ApiNodeState::new())),
             state_update_timeout,
@@ -441,7 +444,10 @@ impl SharedNodeState {
         lock.majority_count = state.majority_count();
         lock.node_role = NodeRole::new(state.validator_id());
         lock.validators = state.validators().to_vec();
-        lock.peers = state.connect_list().peers().iter()
+        lock.peers = state
+            .connect_list()
+            .peers()
+            .iter()
             .map(|ci| ci.public_key.to_owned())
             .collect();
 
@@ -569,7 +575,9 @@ impl SharedNodeState {
 
     /// Load stored configuration.
     pub(crate) fn load_configuration(&self) -> Option<NodeConfig<PathBuf>> {
-        self.config_accessor.as_ref().and_then(|accessor| accessor.load().ok())
+        self.config_accessor
+            .as_ref()
+            .and_then(|accessor| accessor.load().ok())
     }
 }
 

--- a/exonum/src/helpers/config.rs
+++ b/exonum/src/helpers/config.rs
@@ -32,35 +32,36 @@ use std::sync::{Arc, RwLock};
 /// Stored configuration accessor.
 #[derive(Debug, Clone)]
 pub struct ConfigAccessor {
-    path: Arc<RwLock<PathBuf>>
+    path: Arc<RwLock<PathBuf>>,
 }
 
 impl ConfigAccessor {
     /// Create new stored configuration accessor.
     pub fn new<P>(path: P) -> Self
-        where
-            P: AsRef<Path> + Send + 'static,
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         ConfigAccessor {
-            path: Arc::new(RwLock::new(path.as_ref().to_path_buf()))
+            path: Arc::new(RwLock::new(path.as_ref().to_path_buf())),
         }
     }
 
     /// Loads TOML-encoded configuration.
     pub fn load<T>(&self) -> Result<T, Error>
-        where
-            T: for<'r> Deserialize<'r>, {
+    where
+        T: for<'r> Deserialize<'r>,
+    {
         ConfigFile::load(self.path.read().unwrap().as_path())
     }
 
     /// Saves TOML-encoded configuration.
     pub fn save<T>(&self, value: &T) -> Result<(), Error>
-        where
-            T: Serialize {
+    where
+        T: Serialize,
+    {
         ConfigFile::save(value, self.path.write().unwrap().as_path())
     }
 }
-
 
 /// Implements loading and saving TOML-encoded configurations.
 #[derive(Debug)]
@@ -69,9 +70,9 @@ pub struct ConfigFile {}
 impl ConfigFile {
     /// Loads TOML-encoded file.
     pub fn load<P, T>(path: P) -> Result<T, Error>
-        where
-            T: for<'r> Deserialize<'r>,
-            P: AsRef<Path>,
+    where
+        T: for<'r> Deserialize<'r>,
+        P: AsRef<Path>,
     {
         let path = path.as_ref();
         let res = do_load(path).context(format!("loading config from {}", path.display()))?;
@@ -80,9 +81,9 @@ impl ConfigFile {
 
     /// Saves TOML-encoded file.
     pub fn save<P, T>(value: &T, path: P) -> Result<(), Error>
-        where
-            T: Serialize,
-            P: AsRef<Path>,
+    where
+        T: Serialize,
+        P: AsRef<Path>,
     {
         let path = path.as_ref();
         do_save(value, path).with_context(|_| format!("saving config to {}", path.display()))?;
@@ -162,7 +163,10 @@ impl ConfigManager {
     // Updates ConnectList on file system synchronously.
     // This method is public only for testing and should not be used explicitly.
     #[doc(hidden)]
-    pub fn update_connect_list(connect_list: ConnectListConfig, accessor: &ConfigAccessor) -> Result<(), Error> {
+    pub fn update_connect_list(
+        connect_list: ConnectListConfig,
+        accessor: &ConfigAccessor,
+    ) -> Result<(), Error> {
         let mut current_config: NodeConfig<PathBuf> = accessor.load()?;
         current_config.connect_list = connect_list;
         accessor.save(&current_config)?;

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -32,8 +32,8 @@ use super::{
 };
 
 use crate::blockchain::Service;
+use crate::helpers::fabric::details::{AddAuditor, FinalizeAuditorConfig, RequestConnectAuditor};
 use crate::node::{ExternalMessage, Node};
-use crate::helpers::fabric::details::{RequestConnectAuditor, AddAuditor, FinalizeAuditorConfig};
 
 /// `NodeBuilder` is a high level object,
 /// usable for fast prototyping and creating app from services list.

--- a/exonum/src/helpers/fabric/builder.rs
+++ b/exonum/src/helpers/fabric/builder.rs
@@ -33,6 +33,7 @@ use super::{
 
 use crate::blockchain::Service;
 use crate::node::{ExternalMessage, Node};
+use crate::helpers::fabric::details::{RequestConnectAuditor, AddAuditor, FinalizeAuditorConfig};
 
 /// `NodeBuilder` is a high level object,
 /// usable for fast prototyping and creating app from services list.
@@ -137,6 +138,9 @@ impl NodeBuilder {
             Box::new(GenerateCommonConfig),
             Box::new(Finalize),
             Box::new(Maintenance),
+            Box::new(RequestConnectAuditor),
+            Box::new(AddAuditor),
+            Box::new(FinalizeAuditorConfig),
         ]
         .into_iter()
         .map(|c| (c.name(), CollectedCommand::new(c)))

--- a/exonum/src/helpers/fabric/details.rs
+++ b/exonum/src/helpers/fabric/details.rs
@@ -1201,6 +1201,9 @@ impl FinalizeAuditorConfig {
             });
             peers
         } else {
+            // Waiting for waiting for state update.
+            thread::sleep_ms(node_cfg.api.state_update_timeout as u32);
+
             primary_cfg.add_auditor_request.validators_api.iter()
                 .filter_map(|api| Self::load_node_configuration(api, &primary_cfg.consensus_public_key, sys))
                 .map(|config| ConnectInfo {

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -100,7 +100,7 @@ pub struct AddAuditorInfo {
     /// Validators api addresses.
     pub validators_api: Vec<String>,
     /// Connect to all validator nodes.
-    pub connect_all: bool
+    pub connect_all: bool,
 }
 
 /// `AuditorPrimaryConfig` collects all public and secret keys and add auditor request.

--- a/exonum/src/helpers/fabric/shared.rs
+++ b/exonum/src/helpers/fabric/shared.rs
@@ -93,3 +93,31 @@ pub struct NodeRunConfig {
     pub consensus_pass_method: String,
     pub service_pass_method: String,
 }
+
+/// `AddAuditorRequest` Add auditor request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddAuditorInfo {
+    /// Validators api addresses.
+    pub validators_api: Vec<String>,
+    /// Connect to all validator nodes.
+    pub connect_all: bool
+}
+
+/// `AuditorPrimaryConfig` collects all public and secret keys and add auditor request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuditorPrimaryConfig {
+    /// Listen address.
+    pub listen_address: SocketAddr,
+    /// External address.
+    pub external_address: String,
+    /// Consensus public key.
+    pub consensus_public_key: PublicKey,
+    /// Path to the consensus secret key file.
+    pub consensus_secret_key: PathBuf,
+    /// Service public key.
+    pub service_public_key: PublicKey,
+    /// Path to the service secret key file.
+    pub service_secret_key: PathBuf,
+    /// Add auditor request
+    pub add_auditor_request: AddAuditorInfo,
+}

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -78,6 +78,7 @@ pub fn generate_testnet_config(count: u16, start_port: u16) -> Vec<NodeConfig> {
             services_configs: Default::default(),
             database: Default::default(),
             thread_pool_size: Default::default(),
+            auditor: Default::default(),
         })
         .collect::<Vec<_>>()
 }

--- a/exonum/src/messages/protocol.rs
+++ b/exonum/src/messages/protocol.rs
@@ -699,6 +699,20 @@ impl Precommit {
     }
 }
 
+/// Add auditor event.
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert)]
+#[exonum(pb = "proto::AddAuditor", crate = "crate")]
+pub struct AddAuditor {
+    /// Peer address.
+    pub address: String,
+    /// Peer public key.
+    pub public_key: PublicKey,
+    /// Connect to all validators.
+    pub connect_all: bool,
+    /// Validators public keys.
+    pub validators: Vec<PublicKey>,
+}
+
 /// Full message constraints list.
 #[doc(hidden)]
 pub trait ProtocolMessage: Debug + Clone + BinaryValue {
@@ -876,7 +890,11 @@ impl_protocol! {
             /// Request of some future block.
             BlockRequest = 4,
         },
-
+        /// Exonum node event.
+        4 => Event {
+            /// Add auditor event.
+            AddAuditor = 0,
+        },
     }
 }
 

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -94,7 +94,7 @@ impl NodeHandler {
         }
 
         if !self.state.connect_list().is_peer_allowed(&public_key) {
-            error!(
+            warn!(
                 "Received connect message from {:?} peer which not in ConnectList.",
                 public_key
             );

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -19,7 +19,7 @@ use crate::crypto::PublicKey;
 use crate::events::error::LogError;
 use crate::events::network::ConnectedPeerAddr;
 use crate::helpers::Height;
-use crate::messages::{Connect, Message, PeersRequest, Responses, Service, Signed, Status, Event};
+use crate::messages::{Connect, Event, Message, PeersRequest, Responses, Service, Signed, Status};
 
 impl NodeHandler {
     /// Redirects message to the corresponding `handle_...` function.

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -19,7 +19,7 @@ use crate::crypto::PublicKey;
 use crate::events::error::LogError;
 use crate::events::network::ConnectedPeerAddr;
 use crate::helpers::Height;
-use crate::messages::{Connect, Message, PeersRequest, Responses, Service, Signed, Status};
+use crate::messages::{Connect, Message, PeersRequest, Responses, Service, Signed, Status, Event};
 
 impl NodeHandler {
     /// Redirects message to the corresponding `handle_...` function.
@@ -38,6 +38,7 @@ impl NodeHandler {
             Message::Responses(Responses::TransactionsResponse(msg)) => {
                 self.handle_txs_batch(&msg).log_error()
             }
+            Message::Event(Event::AddAuditor(evn)) => self.handle_add_auditor_event(evn),
         }
     }
 

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -18,8 +18,12 @@ use crate::blockchain::Schema;
 use crate::crypto::{CryptoHash, Hash, PublicKey};
 use crate::events::InternalRequest;
 use crate::helpers::{Height, Round, ValidatorId};
-use crate::messages::{BlockRequest, BlockResponse, Consensus as ConsensusMessage, Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed, SignedMessage, TransactionsRequest, TransactionsResponse, AddAuditor};
-use crate::node::{NodeHandler, RequestData, ConnectInfo};
+use crate::messages::{
+    AddAuditor, BlockRequest, BlockResponse, Consensus as ConsensusMessage, Precommit, Prevote,
+    PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed, SignedMessage,
+    TransactionsRequest, TransactionsResponse,
+};
+use crate::node::{ConnectInfo, NodeHandler, RequestData};
 use exonum_merkledb::Patch;
 
 // TODO Reduce view invocations. (ECR-171)
@@ -596,7 +600,12 @@ impl NodeHandler {
     pub fn handle_add_auditor_event(&mut self, evn: Signed<AddAuditor>) {
         info!("Received Add auditor event.");
         if self.allow_auto_connect {
-            if !self.state.validators().iter().any(|e| e.service_key == evn.author()) {
+            if !self
+                .state
+                .validators()
+                .iter()
+                .any(|e| e.service_key == evn.author())
+            {
                 info!("Skip AddAuditor event. Only validator can send add auditor event.");
                 return;
             }

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -18,12 +18,8 @@ use crate::blockchain::Schema;
 use crate::crypto::{CryptoHash, Hash, PublicKey};
 use crate::events::InternalRequest;
 use crate::helpers::{Height, Round, ValidatorId};
-use crate::messages::{
-    BlockRequest, BlockResponse, Consensus as ConsensusMessage, Precommit, Prevote,
-    PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed, SignedMessage,
-    TransactionsRequest, TransactionsResponse,
-};
-use crate::node::{NodeHandler, RequestData};
+use crate::messages::{BlockRequest, BlockResponse, Consensus as ConsensusMessage, Precommit, Prevote, PrevotesRequest, Propose, ProposeRequest, RawTransaction, Signed, SignedMessage, TransactionsRequest, TransactionsResponse, AddAuditor};
+use crate::node::{NodeHandler, RequestData, ConnectInfo};
 use exonum_merkledb::Patch;
 
 // TODO Reduce view invocations. (ECR-171)
@@ -594,6 +590,29 @@ impl NodeHandler {
             self.execute_later(InternalRequest::VerifyMessage(tx));
         }
         Ok(())
+    }
+
+    /// Check add auditor event and add auditor peer.
+    pub fn handle_add_auditor_event(&mut self, evn: Signed<AddAuditor>) {
+        info!("Received Add auditor event.");
+        if self.allow_auto_connect {
+            if !self.state.validators().iter().any(|e| e.service_key == evn.author()) {
+                info!("Skip AddAuditor event. Only validator can send add auditor event.");
+                return;
+            }
+
+            if evn.connect_all || evn.validators.contains(self.state.service_public_key()) {
+                let connect_info = ConnectInfo {
+                    address: evn.address.to_owned(),
+                    public_key: evn.public_key,
+                };
+                self.add_peer(connect_info);
+            } else {
+                info!("Skip AddAuditor event. Validator is not in the list to add auditor.");
+            }
+        } else {
+            info!("Skip AddAuditor event. Flag allow_auto_connect is false.");
+        }
     }
 
     /// Handles external boxed transaction. Additionally transaction will be broadcast to the

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -55,14 +55,16 @@ use crate::events::{
     HandlerPart, InternalEvent, InternalPart, InternalRequest, NetworkConfiguration, NetworkEvent,
     NetworkPart, NetworkRequest, SyncSender, TimeoutRequest, UnboundedSyncSender,
 };
+use crate::helpers::config::ConfigAccessor;
 use crate::helpers::{
     config::ConfigManager,
     fabric::{NodePrivateConfig, NodePublicConfig},
     user_agent, Height, Milliseconds, Round, ValidatorId,
 };
-use crate::messages::{Connect, Message, ProtocolMessage, RawTransaction, Signed, SignedMessage, AddAuditor};
+use crate::messages::{
+    AddAuditor, Connect, Message, ProtocolMessage, RawTransaction, Signed, SignedMessage,
+};
 use crate::node::state::SharedConnectList;
-use crate::helpers::config::ConfigAccessor;
 use exonum_merkledb::{Database, DbOptions};
 
 mod basic;
@@ -249,7 +251,7 @@ pub struct AuditorConfig {
 impl Default for AuditorConfig {
     fn default() -> Self {
         Self {
-            allow_auto_connect: false
+            allow_auto_connect: false,
         }
     }
 }
@@ -665,7 +667,6 @@ impl NodeHandler {
         }
     }
 
-
     /// Add peer.
     pub fn add_peer(&mut self, connect_info: ConnectInfo) {
         info!("Send Connect message to {}", connect_info);
@@ -796,7 +797,7 @@ impl NodeHandler {
         let previous_round: u64 = round.previous().into();
         let ms = previous_round * self.first_round_timeout()
             + (previous_round * previous_round.saturating_sub(1)) / 2
-            * self.round_timeout_increase();
+                * self.round_timeout_increase();
         self.state.height_start_time() + Duration::from_millis(ms)
     }
 }
@@ -1097,7 +1098,7 @@ impl Node {
                 self.handler.api_state.clone(),
             ),
         }
-            .start()?;
+        .start()?;
 
         // Runs NodeHandler.
         let handshake_params = HandshakeParams::new(

--- a/exonum/src/proto/mod.rs
+++ b/exonum/src/proto/mod.rs
@@ -62,8 +62,8 @@
 pub use self::schema::blockchain::{Block, ConfigReference, TransactionResult, TxLocation};
 pub use self::schema::helpers::{BitVec, Hash, PublicKey, Signature};
 pub use self::schema::protocol::{
-    BlockRequest, BlockResponse, Connect, PeersRequest, Precommit, Prevote, PrevotesRequest,
-    Propose, ProposeRequest, Status, TransactionsRequest, TransactionsResponse, AddAuditor,
+    AddAuditor, BlockRequest, BlockResponse, Connect, PeersRequest, Precommit, Prevote,
+    PrevotesRequest, Propose, ProposeRequest, Status, TransactionsRequest, TransactionsResponse,
 };
 
 pub mod schema;

--- a/exonum/src/proto/mod.rs
+++ b/exonum/src/proto/mod.rs
@@ -63,7 +63,7 @@ pub use self::schema::blockchain::{Block, ConfigReference, TransactionResult, Tx
 pub use self::schema::helpers::{BitVec, Hash, PublicKey, Signature};
 pub use self::schema::protocol::{
     BlockRequest, BlockResponse, Connect, PeersRequest, Precommit, Prevote, PrevotesRequest,
-    Propose, ProposeRequest, Status, TransactionsRequest, TransactionsResponse,
+    Propose, ProposeRequest, Status, TransactionsRequest, TransactionsResponse, AddAuditor,
 };
 
 pub mod schema;

--- a/exonum/src/proto/schema/exonum/protocol.proto
+++ b/exonum/src/proto/schema/exonum/protocol.proto
@@ -93,3 +93,10 @@ message BlockRequest {
   exonum.PublicKey to = 1;
   uint64 height = 2;
 }
+
+message AddAuditor {
+  string address = 1;
+  exonum.PublicKey public_key = 2;
+  bool connect_all = 3;
+  repeated exonum.PublicKey validators = 4;
+}

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -74,7 +74,7 @@ impl TestKitApi {
     /// Creates a new instance of API.
     pub fn new(testkit: &TestKit) -> Self {
         Self::from_raw_parts(
-            ApiAggregator::new(testkit.blockchain().clone(), SharedNodeState::new(10_000)),
+            ApiAggregator::new(testkit.blockchain().clone(), SharedNodeState::new(10_000, None)),
             testkit.api_sender.clone(),
         )
     }

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -74,7 +74,10 @@ impl TestKitApi {
     /// Creates a new instance of API.
     pub fn new(testkit: &TestKit) -> Self {
         Self::from_raw_parts(
-            ApiAggregator::new(testkit.blockchain().clone(), SharedNodeState::new(10_000, None)),
+            ApiAggregator::new(
+                testkit.blockchain().clone(),
+                SharedNodeState::new(10_000, None),
+            ),
             testkit.api_sender.clone(),
         )
     }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -456,7 +456,8 @@ impl TestKit {
                     ExternalMessage::PeerAdd(_)
                     | ExternalMessage::Enable(_)
                     | ExternalMessage::Rebroadcast
-                    | ExternalMessage::Shutdown => { /* Ignored */ }
+                    | ExternalMessage::Shutdown
+                    | ExternalMessage::AuditorAdd(_) => { /* Ignored */ }
                 }
                 blockchain.merge(fork.into_patch()).unwrap();
                 drop(guard);

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -148,7 +148,7 @@ pub fn create_testkit_handlers(inner: &Arc<RwLock<TestKit>>) -> ServiceApiBuilde
 pub fn create_testkit_api_aggregator(testkit: &Arc<RwLock<TestKit>>) -> ApiAggregator {
     let mut aggregator = ApiAggregator::new(
         testkit.read().unwrap().blockchain().clone(),
-        SharedNodeState::new(10_000),
+        SharedNodeState::new(10_000, None),
     );
     aggregator.insert("testkit", create_testkit_handlers(testkit));
     aggregator


### PR DESCRIPTION
## Overview
This PR adds some CL commands that should make it easier to add a validator to the network.

1.  `request_connect_auditor` `path to output  node primary config` `--validators-api list of public validators api` `--peer-address auditor peer host:port` `--connect-all flag for connecting to all validators`
This command creates primary node configuration and as an output, returns the command `add_auditor` to be executed on the validator to add this node.

2. `add_auditor` `--connect-all` `--peer-address` `--consensus-pub-key` `--validators-api` `--private-api-address private api validator address` 
This command is executed on the validator node and adds to the list of peers of all nodes from the request a connection with a new auditor.

Also added a flag in the node configuration
which allows you to ignore the request to add an auditor.
```
[auditor]
allow_auto_connect = true/false 
```

3. `finalize_auditor_config` `path to the node primary config` `path to output  node config` `-w`
This command attempts to get a configuration from one of the nodes and creates a node configuration.
the `-w` flag causes the command to wait until the validators add this node.

Note: 
_This process allows the auditor to be added to the part of the nodes in the network. And while running, due to the 'PeersRequest' process, the remaining nodes will try to connect to the node, which causes an error in the log.
`Received connect message from {:?} peer which not in ConnectList.`
I decided to change the level of this output in the warn log. Since it is not so critical to talk about an error._

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions