### PR TITLE
Improvements in `TestKitApi`

### DIFF
--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -17,7 +17,7 @@
 pub use exonum::api::ApiAccess;
 
 use actix_web::{test::TestServer, App};
-use reqwest::{Client, Response, StatusCode, RequestBuilder as ReqwestBuilder};
+use reqwest::{Client, RequestBuilder as ReqwestBuilder, Response, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
 
 use std::fmt::{self, Display};

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -181,9 +181,9 @@ impl CounterApi {
             .endpoint("count", Self::count)
             .endpoint_mut("count", Self::increment);
 
-        // Check processing of custom HTTP headers. We test this using strawman authorization
+        // Check processing of custom HTTP headers. We test this using simple authorization
         // with a fixed bearer token; for practical apps, the tokens might
-        // be [JWTs](https://jwt.io/).
+        // be [JSON Web Tokens](https://jwt.io/).
         let handler = |request: HttpRequest| -> api::Result<u64> {
             let auth_header = request
                 .headers()

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -13,18 +13,24 @@
 // limitations under the License.
 
 //! Sample counter service.
-use std::borrow::Cow;
 
-use exonum_merkledb::{Entry, IndexAccess, Snapshot};
-
+use actix_web::{http::Method, HttpResponse};
 use exonum::{
-    api,
+    api::backends::actix::{HttpRequest, RawHandler, RequestHandler},
+    api::{self, ServiceApiBackend},
     blockchain::{
         ExecutionError, ExecutionResult, Service, Transaction, TransactionContext, TransactionSet,
     },
     crypto::{Hash, PublicKey, SecretKey},
     messages::{Message, RawTransaction, Signed},
 };
+use exonum_derive::*;
+use exonum_merkledb::{Entry, IndexAccess, Snapshot};
+use futures::{Future, IntoFuture};
+use log::trace;
+use serde_derive::*;
+
+use std::{borrow::Cow, sync::Arc};
 
 use super::proto;
 
@@ -174,6 +180,41 @@ impl CounterApi {
             .public_scope()
             .endpoint("count", Self::count)
             .endpoint_mut("count", Self::increment);
+
+        // Check processing of custom HTTP headers. We test this using strawman authorization
+        // with a fixed bearer token; for practical apps, the tokens might
+        // be [JWTs](https://jwt.io/).
+        let handler = |request: HttpRequest| -> api::Result<u64> {
+            let auth_header = request
+                .headers()
+                .get("Authorization")
+                .ok_or_else(|| api::Error::Unauthorized)?
+                .to_str()
+                .map_err(|_| api::Error::BadRequest("Malformed `Authorization`".to_owned()))?;
+            if auth_header != "Bearer SUPER_SECRET_111" {
+                return Err(api::Error::Unauthorized);
+            }
+
+            let state = request.state();
+            Self::count(&state, ())
+        };
+        let handler: Arc<RawHandler> = Arc::new(move |request| {
+            Box::new(
+                handler(request)
+                    .into_future()
+                    .from_err()
+                    .map(|v| HttpResponse::Ok().json(v)),
+            )
+        });
+
+        builder
+            .public_scope()
+            .web_backend()
+            .raw_handler(RequestHandler {
+                name: "v1/counter-with-auth".to_string(),
+                method: Method::GET,
+                inner: handler,
+            });
     }
 }
 


### PR DESCRIPTION
This PR improves HTTP API-related functionality of the testkit, allowing to modify HTTP requests before sending them (e.g., in order to add some headers). Another change is fixing `response_to_api_result` method in `RequestBuilder`, which previously did not convert `Unauthorized` API error correctly (the converter expected 403 HTTP status, while in reality `Unauthorized` error translates to 401 status.