### PR TITLE
Check a service id in filter for transaction subscription [ECR-3297]

### DIFF
--- a/exonum/src/api/node/public/explorer.rs
+++ b/exonum/src/api/node/public/explorer.rs
@@ -321,13 +321,17 @@ impl ExplorerApi {
             service_api_state.clone(),
             shared_node_state.clone(),
             |request| {
-                Ok(Query::from_request(request, &Default::default())
-                    .map(
-                        move |query: Query<TransactionFilter>| SubscriptionType::Transactions {
+                if request.query().is_empty() {
+                    return Ok(SubscriptionType::Transactions { filter: None });
+                }
+
+                Query::from_request(request, &Default::default())
+                    .map(|query: Query<TransactionFilter>| {
+                        Ok(SubscriptionType::Transactions {
                             filter: Some(query.into_inner()),
-                        },
-                    )
-                    .unwrap_or(SubscriptionType::Transactions { filter: None }))
+                        })
+                    })
+                    .unwrap_or(Ok(SubscriptionType::None))
             },
         );
         // Default websocket connection.


### PR DESCRIPTION
## Overview

If a service id is missing in transaction filter then no output for such subscription at all. 

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3297
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions