### PR TITLE
Move `impl_binary_value_for_message` macros to proto module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Trait `BinaryForm` has been replaced by `BinaryValue`. (#1298)
 
   To implement `BinaryValue` for types that implements `Protobuf::Message` use
-  `impl_binary_value_for_message` macros.
+  `impl_binary_value_for_pb_message` macros.
 
 - Module `storage` has been replaced by `exonum-merkledb` crate. See related section
   in changelog for details. (#1293)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Trait `BinaryForm` has been replaced by `BinaryValue`. (#1298)
 
   To implement `BinaryValue` for types that implements `Protobuf::Message` use
-  `impl_binary_value_for_message` macros from `exonum-merkledb` crate.
+  `impl_binary_value_for_message` macros.
 
 - Module `storage` has been replaced by `exonum-merkledb` crate. See related section
   in changelog for details. (#1293)

--- a/components/derive/src/tx_set.rs
+++ b/components/derive/src/tx_set.rs
@@ -205,7 +205,7 @@ fn implement_transaction_set_trait(
         let id = variant.id;
         let source_type = variant.source_type();
         quote! {
-            #id => #source_type::from_bytes(Cow::from(&vec)).map(#name::from),
+            #id => #source_type::from_bytes(std::borrow::Cow::from(&vec)).map(#name::from),
         }
     });
 

--- a/components/merkledb/src/macros.rs
+++ b/components/merkledb/src/macros.rs
@@ -57,22 +57,3 @@ macro_rules! impl_object_hash_for_binary_value {
         )*
     };
 }
-
-#[macro_export]
-macro_rules! impl_binary_value_for_message {
-    ($( $type:ty ),*) => {
-        $(
-            impl BinaryValue for $type {
-                fn to_bytes(&self) -> Vec<u8> {
-                    self.write_to_bytes().expect("Error while serializing value")
-                }
-
-                fn from_bytes(bytes: Cow<[u8]>) -> Result<Self, failure::Error> {
-                    let mut pb = Self::new();
-                    pb.merge_from_bytes(bytes.as_ref())?;
-                    Ok(pb)
-                }
-            }
-        )*
-    };
-}

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -18,8 +18,6 @@
 // ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
-use std::borrow::Cow;
-
 use exonum::{
     blockchain::{ExecutionError, ExecutionResult, Transaction, TransactionContext},
     crypto::{PublicKey, SecretKey},

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -119,8 +119,6 @@ pub mod schema {
 
 /// Transactions.
 pub mod transactions {
-    use std::borrow::Cow;
-
     use super::proto;
     use super::service::SERVICE_ID;
     use exonum::{

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -18,8 +18,6 @@
 // ECR-1771 for the details.
 #![allow(bare_trait_objects)]
 
-use std::borrow::Cow;
-
 use exonum::{
     blockchain::{ExecutionError, ExecutionResult, Transaction, TransactionContext},
     crypto::{PublicKey, SecretKey},

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -119,7 +119,6 @@ mod timestamping {
     };
     use exonum_merkledb::Snapshot;
     use rand::rngs::StdRng;
-    use std::borrow::Cow;
 
     const TIMESTAMPING_SERVICE_ID: u16 = 1;
 
@@ -218,7 +217,6 @@ mod cryptocurrency {
     };
     use exonum_merkledb::{MapIndex, ProofMapIndex, Snapshot};
     use rand::{rngs::StdRng, seq::SliceRandom};
-    use std::borrow::Cow;
 
     const CRYPTOCURRENCY_SERVICE_ID: u16 = 255;
 

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -16,8 +16,6 @@
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-use std::borrow::Cow;
-
 use crate::blockchain::{
     Blockchain, ExecutionError, ExecutionResult, Schema, Service, Transaction, TransactionContext,
     TransactionSet,
@@ -170,7 +168,6 @@ mod transactions_tests {
     use crate::crypto::gen_keypair;
     use crate::messages::Message;
     use crate::proto::schema::tests::{BlockchainTestTxA, BlockchainTestTxB};
-    use std::borrow::Cow;
 
     #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert)]
     #[exonum(pb = "BlockchainTestTxA", crate = "crate")]

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -72,6 +72,7 @@ extern crate test;
 
 pub use exonum_crypto as crypto;
 
+#[macro_use]
 pub mod proto;
 #[macro_use]
 pub mod messages;

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1132,7 +1132,7 @@ mod tests {
         TxSimple(TxSimple),
     }
 
-    impl_binary_value_for_message! { TxSimple }
+    impl_binary_value_for_pb_message! { TxSimple }
 
     impl Transaction for TxSimple {
         fn execute(&self, _: TransactionContext) -> ExecutionResult {

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1121,9 +1121,7 @@ mod tests {
     use crate::events::EventHandler;
     use crate::helpers;
     use crate::proto::{schema::tests::TxSimple, ProtobufConvert};
-    use exonum_merkledb::{
-        impl_binary_value_for_message, BinaryValue, Database, Snapshot, TemporaryDB,
-    };
+    use exonum_merkledb::{BinaryValue, Database, Snapshot, TemporaryDB};
     use protobuf::Message as ProtobufMessage;
 
     const SERVICE_ID: u16 = 0;

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1111,8 +1111,6 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
     use super::*;
     use crate::blockchain::{
         ExecutionResult, Schema, Service, Transaction, TransactionContext, TransactionSet,
@@ -1122,7 +1120,6 @@ mod tests {
     use crate::helpers;
     use crate::proto::{schema::tests::TxSimple, ProtobufConvert};
     use exonum_merkledb::{BinaryValue, Database, Snapshot, TemporaryDB};
-    use protobuf::Message as ProtobufMessage;
 
     const SERVICE_ID: u16 = 0;
 

--- a/exonum/src/proto/macros.rs
+++ b/exonum/src/proto/macros.rs
@@ -1,0 +1,34 @@
+// limitations under the License.
+
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+/// Implement `BinaryValue` trait for type that implements `Protobuf::Message`.
+#[macro_export]
+macro_rules! impl_binary_value_for_message {
+    ($( $type:ty ),*) => {
+        $(
+            impl BinaryValue for $type {
+                fn to_bytes(&self) -> Vec<u8> {
+                    self.write_to_bytes().expect("Error while serializing value")
+                }
+
+                fn from_bytes(bytes: Cow<[u8]>) -> Result<Self, failure::Error> {
+                    let mut pb = Self::new();
+                    pb.merge_from_bytes(bytes.as_ref())?;
+                    Ok(pb)
+                }
+            }
+        )*
+    };
+}

--- a/exonum/src/proto/macros.rs
+++ b/exonum/src/proto/macros.rs
@@ -17,16 +17,15 @@
 #[macro_export]
 macro_rules! impl_binary_value_for_pb_message {
     ($( $type:ty ),*) => {
-        use std::borrow::Cow;
-        use protobuf::Message as PbMessage;
-
         $(
             impl BinaryValue for $type {
                 fn to_bytes(&self) -> Vec<u8> {
+                    use protobuf::Message;
                     self.write_to_bytes().expect("Error while serializing value")
                 }
 
-                fn from_bytes(bytes: Cow<[u8]>) -> Result<Self, failure::Error> {
+                fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Result<Self, failure::Error> {
+                    use protobuf::Message;
                     let mut pb = Self::new();
                     pb.merge_from_bytes(bytes.as_ref())?;
                     Ok(pb)

--- a/exonum/src/proto/macros.rs
+++ b/exonum/src/proto/macros.rs
@@ -15,7 +15,7 @@
 
 /// Implement `BinaryValue` trait for type that implements `Protobuf::Message`.
 #[macro_export]
-macro_rules! impl_binary_value_for_message {
+macro_rules! impl_binary_value_for_pb_message {
     ($( $type:ty ),*) => {
         $(
             impl BinaryValue for $type {

--- a/exonum/src/proto/macros.rs
+++ b/exonum/src/proto/macros.rs
@@ -17,6 +17,9 @@
 #[macro_export]
 macro_rules! impl_binary_value_for_pb_message {
     ($( $type:ty ),*) => {
+        use std::borrow::Cow;
+        use protobuf::Message as PbMessage;
+
         $(
             impl BinaryValue for $type {
                 fn to_bytes(&self) -> Vec<u8> {

--- a/exonum/src/proto/mod.rs
+++ b/exonum/src/proto/mod.rs
@@ -67,6 +67,9 @@ pub use self::schema::protocol::{
 };
 
 pub mod schema;
+
+#[macro_use]
+mod macros;
 #[cfg(test)]
 mod tests;
 

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -24,7 +24,7 @@ use crate::crypto::{Hash, PublicKey, SecretKey};
 use crate::helpers::Height;
 use crate::messages::{Message, RawTransaction, Signed};
 use crate::proto::ProtobufConvert;
-use exonum_merkledb::{impl_binary_value_for_message, BinaryValue, Snapshot};
+use exonum_merkledb::{BinaryValue, Snapshot};
 use protobuf::Message as PbMessage;
 
 pub const CONFIG_SERVICE: u16 = 1;

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -68,7 +68,7 @@ impl Transaction for TxConfig {
     }
 }
 
-impl_binary_value_for_message! { TxConfig }
+impl_binary_value_for_pb_message! { TxConfig }
 
 impl Service for ConfigUpdateService {
     fn service_name(&self) -> &str {

--- a/exonum/src/sandbox/config_updater.rs
+++ b/exonum/src/sandbox/config_updater.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
-
 pub use crate::proto::schema::tests::TxConfig;
 
 use crate::blockchain::{
@@ -25,7 +23,6 @@ use crate::helpers::Height;
 use crate::messages::{Message, RawTransaction, Signed};
 use crate::proto::ProtobufConvert;
 use exonum_merkledb::{BinaryValue, Snapshot};
-use protobuf::Message as PbMessage;
 
 pub const CONFIG_SERVICE: u16 = 1;
 

--- a/exonum/src/sandbox/mod.rs
+++ b/exonum/src/sandbox/mod.rs
@@ -1178,8 +1178,6 @@ mod tests {
     use crate::proto::schema::tests::TxAfterCommit;
     use crate::sandbox::sandbox_tests_helper::{add_one_height, SandboxState};
     use exonum_merkledb::{BinaryValue, Snapshot};
-    use protobuf::Message as PbMessage;
-    use std::borrow::Cow;
 
     const SERVICE_ID: u16 = 1;
 

--- a/exonum/src/sandbox/mod.rs
+++ b/exonum/src/sandbox/mod.rs
@@ -1177,7 +1177,7 @@ mod tests {
     use crate::messages::RawTransaction;
     use crate::proto::schema::tests::TxAfterCommit;
     use crate::sandbox::sandbox_tests_helper::{add_one_height, SandboxState};
-    use exonum_merkledb::{impl_binary_value_for_message, BinaryValue, Snapshot};
+    use exonum_merkledb::{BinaryValue, Snapshot};
     use protobuf::Message as PbMessage;
     use std::borrow::Cow;
 

--- a/exonum/src/sandbox/mod.rs
+++ b/exonum/src/sandbox/mod.rs
@@ -1198,7 +1198,7 @@ mod tests {
         }
     }
 
-    impl_binary_value_for_message! { TxAfterCommit }
+    impl_binary_value_for_pb_message! { TxAfterCommit }
 
     impl Transaction for TxAfterCommit {
         fn execute(&self, _: TransactionContext) -> ExecutionResult {

--- a/exonum/src/sandbox/timestamping.rs
+++ b/exonum/src/sandbox/timestamping.rs
@@ -41,7 +41,7 @@ impl Transaction for TimestampTx {
     }
 }
 
-impl_binary_value_for_message! { TimestampTx }
+impl_binary_value_for_pb_message! { TimestampTx }
 
 #[derive(Default)]
 pub struct TimestampingService {}

--- a/exonum/src/sandbox/timestamping.rs
+++ b/exonum/src/sandbox/timestamping.rs
@@ -16,15 +16,12 @@ pub use crate::proto::schema::tests::TimestampTx;
 
 use rand::{rngs::ThreadRng, thread_rng, RngCore};
 
-use std::borrow::Cow;
-
 use crate::blockchain::{
     ExecutionResult, Service, Transaction, TransactionContext, TransactionSet,
 };
 use crate::crypto::{gen_keypair, Hash, PublicKey, SecretKey, HASH_SIZE};
 use crate::messages::{Message, RawTransaction, Signed};
 use exonum_merkledb::{BinaryValue, Snapshot};
-use protobuf::Message as PbMessage;
 
 pub const TIMESTAMPING_SERVICE: u16 = 129;
 pub const DATA_SIZE: usize = 64;

--- a/exonum/src/sandbox/timestamping.rs
+++ b/exonum/src/sandbox/timestamping.rs
@@ -23,7 +23,7 @@ use crate::blockchain::{
 };
 use crate::crypto::{gen_keypair, Hash, PublicKey, SecretKey, HASH_SIZE};
 use crate::messages::{Message, RawTransaction, Signed};
-use exonum_merkledb::{impl_binary_value_for_message, BinaryValue, Snapshot};
+use exonum_merkledb::{BinaryValue, Snapshot};
 use protobuf::Message as PbMessage;
 
 pub const TIMESTAMPING_SERVICE: u16 = 129;

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -16,8 +16,6 @@
 
 use futures::sync::mpsc;
 
-use std::borrow::Cow;
-
 use exonum::{
     blockchain::{
         Blockchain, ExecutionError, ExecutionResult, Schema, Service, Transaction,

--- a/exonum/tests/websocket/blockchain/mod.rs
+++ b/exonum/tests/websocket/blockchain/mod.rs
@@ -15,7 +15,6 @@
 //! Simplified node emulation for testing websockets.
 
 use std::{
-    borrow::Cow,
     net::SocketAddr,
     thread::{self, JoinHandle},
 };

--- a/services/configuration/src/transactions.rs
+++ b/services/configuration/src/transactions.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 //! Transaction definitions for the configuration service.
-use std::borrow::Cow;
-
 use exonum_merkledb::{Fork, ObjectHash, Snapshot};
 
 use exonum::{

--- a/services/time/examples/simple_service/main.rs
+++ b/services/time/examples/simple_service/main.rs
@@ -21,8 +21,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate exonum_derive;
 
-use std::borrow::Cow;
-
 use exonum_merkledb::{IndexAccess, ObjectHash, ProofMapIndex, Snapshot};
 
 use chrono::{DateTime, Duration, TimeZone, Utc};

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -18,8 +18,6 @@
 
 use chrono::{DateTime, Utc};
 
-use std::borrow::Cow;
-
 use exonum_merkledb::{Fork, Snapshot};
 
 use exonum::{

--- a/testkit/examples/timestamping/main.rs
+++ b/testkit/examples/timestamping/main.rs
@@ -19,8 +19,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate exonum_derive;
 
-use std::borrow::Cow;
-
 use exonum::{
     api::node::public::explorer::{BlocksQuery, BlocksRange, TransactionQuery},
     blockchain::{

--- a/testkit/src/server.rs
+++ b/testkit/src/server.rs
@@ -163,7 +163,6 @@ mod tests {
     use exonum::helpers::Height;
     use exonum::messages::{Message, RawTransaction, Signed};
     use exonum_merkledb::Snapshot;
-    use std::borrow::Cow;
 
     use super::{super::proto, *};
     use crate::{TestKitApi, TestKitBuilder};

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -30,7 +30,7 @@ use futures::{Future, IntoFuture};
 use log::trace;
 use serde_derive::*;
 
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use super::proto;
 

--- a/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::borrow::Cow;
-
 use exonum_merkledb::{IndexAccess, MapIndex, Snapshot};
 
 use exonum::{

--- a/testkit/tests/service_hooks/hooks.rs
+++ b/testkit/tests/service_hooks/hooks.rs
@@ -24,12 +24,9 @@ use exonum::{
 };
 use exonum_merkledb::Snapshot;
 
-use std::{
-    borrow::Cow,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
 pub const SERVICE_ID: u16 = 512;


### PR DESCRIPTION
Moving because this macro is used to implement `BinaryValue` trait for protobuf messages.