### PR TITLE
Extend responses for endpoints [ECR-3349]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - A channel for api requests has been changed to unbounded. (#1308)
 
 - Endpoints `explorer/v1/block` and `explorer/v1/transactions` were extended
-  with adding additional field `service_id` and `time`. (#1386)
+  with adding additional fields `service_id` and `time`. (#1386)
 
 #### exonum-merkledb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,9 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - A channel for api requests has been changed to unbounded. (#1308)
 
+- Endpoints `explorer/v1/block` and `explorer/v1/transactions` were extended
+  with adding additional field `service_id` and `time`. (#1386)
+
 #### exonum-merkledb
 
 - Updated `ProofMapIndex` data layout. (#1293)

--- a/exonum/examples/explorer.rs
+++ b/exonum/examples/explorer.rs
@@ -86,7 +86,7 @@ pub fn sample_blockchain() -> Blockchain {
     let fork = blockchain.fork();
     {
         let mut schema = Schema::new(&fork);
-        schema.add_transaction_into_pool(mempool_transaction().clone());
+        schema.add_transaction_into_pool(mempool_transaction());
     }
     blockchain.merge(fork.into_patch()).unwrap();
 
@@ -160,6 +160,7 @@ fn main() {
             "location_proof": tx.location_proof(),
             // Execution status
             "status": { "type": "success" },
+            "time": tx.time(),
         })
     );
 
@@ -177,6 +178,7 @@ fn main() {
             "content": serde_json::to_value(erroneous_tx.content()).unwrap(),
             "location": erroneous_tx.location(),
             "location_proof": erroneous_tx.location_proof(),
+            "time": erroneous_tx.time(),
         })
     );
 
@@ -190,6 +192,7 @@ fn main() {
             "content": serde_json::to_value(panicked_tx.content()).unwrap(),
             "location": panicked_tx.location(),
             "location_proof": panicked_tx.location_proof(),
+            "time": panicked_tx.time(),
         })
     );
 
@@ -212,6 +215,7 @@ fn main() {
             "status": { "type": "success" },
             "location": tx_ref.location(),
             "location_proof": tx_ref.location_proof(),
+            "time": tx_ref.time(),
         })
     );
 

--- a/exonum/src/blockchain/transaction.rs
+++ b/exonum/src/blockchain/transaction.rs
@@ -47,10 +47,10 @@ pub struct TransactionResult(pub Result<(), TransactionError>);
 /// and take some new transaction into pool from user input.
 #[derive(Serialize, Deserialize)]
 pub struct TransactionMessage {
+    service_id: u16,
     #[serde(skip_deserializing)]
     #[serde(rename = "debug")]
     transaction: Option<Box<dyn Transaction>>,
-
     #[serde(with = "HexStringRepresentation")]
     message: Signed<RawTransaction>,
 }
@@ -62,6 +62,7 @@ impl ::std::fmt::Debug for TransactionMessage {
             .write_hex(&mut signed_message_debug)?;
 
         let mut debug = fmt.debug_struct("TransactionMessage");
+        debug.field("service_id", &self.service_id);
         debug.field("message", &signed_message_debug);
         if let Some(ref tx) = self.transaction {
             debug.field("debug", tx);
@@ -88,12 +89,19 @@ impl TransactionMessage {
         use std::ops::Deref;
         self.transaction.as_ref().map(Deref::deref)
     }
+    /// Returns a service id of the transaction.
+    pub fn service_id(&self) -> u16 {
+        self.service_id
+    }
+
     /// Create new `TransactionMessage` from raw message.
     pub(crate) fn new(
         message: Signed<RawTransaction>,
         transaction: Box<dyn Transaction>,
     ) -> TransactionMessage {
+        let service_id = message.service_id();
         TransactionMessage {
+            service_id,
             transaction: Some(transaction),
             message,
         }

--- a/exonum/src/explorer/mod.rs
+++ b/exonum/src/explorer/mod.rs
@@ -34,7 +34,9 @@ use crate::blockchain::{
 use crate::crypto::{CryptoHash, Hash};
 use crate::helpers::Height;
 use crate::messages::{Precommit, RawTransaction, Signed};
+use chrono::{DateTime, Utc};
 use exonum_merkledb::{ListProof, Snapshot};
+use std::time::UNIX_EPOCH;
 
 /// Transaction parsing result.
 type ParseResult = Result<TransactionMessage, failure::Error>;
@@ -384,11 +386,13 @@ impl<'a> IntoIterator for &'a BlockWithTransactions {
 ///     "content": {
 ///         "message": //...
 /// #                    message,
+///         "service_id": 0
 ///     },
 ///     "location": { "block_height": 1, "position_in_block": 0 },
 ///     "location_proof": // ...
 /// #                     { "val": Hash::zero() },
-///     "status": { "type": "success" }
+///     "status": { "type": "success" },
+///     "time": "2019-07-16T15:26:43.502696Z"
 /// });
 ///
 /// let parsed: CommittedTransaction =
@@ -403,6 +407,7 @@ pub struct CommittedTransaction {
     location_proof: ListProof<Hash>,
     #[serde(with = "TxStatus")]
     status: TransactionResult,
+    time: DateTime<Utc>,
 }
 
 /// Transaction execution status. Simplified version of `TransactionResult`.
@@ -489,6 +494,11 @@ impl CommittedTransaction {
     pub fn status(&self) -> Result<(), &TransactionError> {
         self.status.0.as_ref().map(|_| ())
     }
+
+    /// Returns a commit time of the block which includes this transaction.
+    pub fn time(&self) -> &DateTime<Utc> {
+        &self.time
+    }
 }
 
 /// Information about the transaction.
@@ -559,7 +569,8 @@ impl CommittedTransaction {
 ///     "type": "in-pool",
 ///     "content": {
 ///         "message": // ...
-/// #                    message
+/// #                    message,
+///         "service_id": 0
 ///     }
 /// });
 ///
@@ -651,11 +662,11 @@ impl<'a> BlockchainExplorer<'a> {
         let schema = Schema::new(&self.snapshot);
         let content = self.transaction_without_proof(tx_hash)?;
         if schema.transactions_pool().contains(tx_hash) {
-            return Some(TransactionInfo::InPool { content });
+            Some(TransactionInfo::InPool { content })
+        } else {
+            let tx = self.committed_transaction(tx_hash, Some(content));
+            Some(TransactionInfo::Committed(tx))
         }
-
-        let tx = self.committed_transaction(tx_hash, Some(content));
-        Some(TransactionInfo::Committed(tx))
     }
 
     /// Returns transaction message without proof.
@@ -705,6 +716,11 @@ impl<'a> BlockchainExplorer<'a> {
             .block_transactions(location.block_height())
             .get_proof(location.position_in_block());
 
+        let block_precommits = schema
+            .block_and_precommits(location.block_height())
+            .unwrap();
+        let time = median_precommits_time(&block_precommits.precommits);
+
         // Unwrap is OK here, because we already know that transaction is committed.
         let status = schema.transaction_results().get(tx_hash).unwrap();
 
@@ -717,6 +733,7 @@ impl<'a> BlockchainExplorer<'a> {
             location,
             location_proof,
             status,
+            time,
         }
     }
 
@@ -832,5 +849,16 @@ impl<'a> DoubleEndedIterator for Blocks<'a> {
 
         self.back = self.back.previous();
         Some(BlockInfo::new(self.explorer, self.back))
+    }
+}
+
+/// Calculates a median time from precommits.
+pub fn median_precommits_time(precommits: &[Signed<Precommit>]) -> DateTime<Utc> {
+    if precommits.is_empty() {
+        UNIX_EPOCH.into()
+    } else {
+        let mut times: Vec<_> = precommits.iter().map(|p| p.time()).collect();
+        times.sort();
+        times[times.len() / 2]
     }
 }

--- a/exonum/tests/explorer/main.rs
+++ b/exonum/tests/explorer/main.rs
@@ -104,7 +104,8 @@ fn test_explorer_basics() {
             json!({
                 "content": {
                     "debug": payload_alice,
-                    "message": messages::to_hex_string(&tx_alice)
+                    "message": messages::to_hex_string(&tx_alice),
+                    "service_id": SERVICE_ID,
                 },
                 "location": {
                     "block_height": 1,
@@ -112,6 +113,7 @@ fn test_explorer_basics() {
                 },
                 "location_proof": tx_info.location_proof(), // too complicated to check
                 "status": { "type": "success" },
+                "time": tx_info.time(),
             })
         );
     }
@@ -137,7 +139,8 @@ fn test_explorer_basics() {
         json!({
             "content": {
                     "debug": payload_bob,
-                    "message": messages::to_hex_string(&tx_bob)
+                    "message": messages::to_hex_string(&tx_bob),
+                    "service_id": SERVICE_ID,
             },
             "location": {
                 "block_height": 2,
@@ -149,6 +152,7 @@ fn test_explorer_basics() {
                 "code": 1,
                 "description": "Not allowed",
             },
+            "time": tx_info.time(),
         })
     );
 
@@ -161,7 +165,8 @@ fn test_explorer_basics() {
         json!({
             "content": {
                     "debug": payload_transfer,
-                    "message": messages::to_hex_string(&tx_transfer)
+                    "message": messages::to_hex_string(&tx_transfer),
+                    "service_id": SERVICE_ID,
             },
             "location": {
                 "block_height": 2,
@@ -172,6 +177,7 @@ fn test_explorer_basics() {
                 "type": "panic",
                 "description": "oops",
             },
+            "time": tx_info.time(),
         })
     );
 }

--- a/testkit/tests/counter/counter.rs
+++ b/testkit/tests/counter/counter.rs
@@ -223,16 +223,16 @@ impl CounterApi {
 pub struct CounterService;
 
 impl Service for CounterService {
+    fn service_id(&self) -> u16 {
+        SERVICE_ID
+    }
+
     fn service_name(&self) -> &str {
         "counter"
     }
 
     fn state_hash(&self, _: &dyn Snapshot) -> Vec<Hash> {
         Vec::new()
-    }
-
-    fn service_id(&self) -> u16 {
-        SERVICE_ID
     }
 
     /// Implement a method to deserialize transactions coming to the node.

--- a/testkit/tests/counter/main.rs
+++ b/testkit/tests/counter/main.rs
@@ -26,7 +26,7 @@ use hex::FromHex;
 use serde_json::{json, Value};
 
 use crate::counter::{
-    CounterSchema, CounterService, TransactionResponse, TxIncrement, TxReset, ADMIN_KEY,
+    CounterSchema, CounterService, TransactionResponse, TxIncrement, TxReset, ADMIN_KEY, SERVICE_ID,
 };
 
 mod counter;
@@ -779,7 +779,8 @@ fn test_explorer_transaction_info() {
             "type": "in-pool",
             "content": {
                 "debug": TxIncrement::new(5),
-                "message": messages::to_hex_string(&tx)
+                "message": messages::to_hex_string(&tx),
+                "service_id": SERVICE_ID,
             },
         })
     );
@@ -881,10 +882,7 @@ fn test_boxed_tx() {
     api.send(tx);
     let block = testkit.create_block();
     assert_eq!(block.len(), 1);
-    assert_eq!(
-        block[0].content().message().service_id(),
-        counter::SERVICE_ID
-    );
+    assert_eq!(block[0].content().message().service_id(), SERVICE_ID);
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Endpoints: `/api/explorer/v1/block` and `/api/explorer/v1/transactions` 

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3349
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions