### PR TITLE
Reexport RocksDB features and disable default ones [ECR-3382]

### DIFF
--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -48,6 +48,7 @@ path = "benches/lib.rs"
 harness = false
 
 [features]
+default = ["rocksdb_snappy"]
 long_benchmarks = []
 rocksdb_snappy = ["rocksdb/snappy"]
 rocksdb_lz4 = ["rocksdb/lz4"]

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -23,7 +23,7 @@ failure = "0.1"
 hex = "0.3.2"
 leb128 = "0.2"
 num-traits = "0.2"
-rocksdb = "0.12.3"
+rocksdb = { version = "0.12.3", default-features = false }
 rust_decimal = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
@@ -49,6 +49,11 @@ harness = false
 
 [features]
 long_benchmarks = []
+rocksdb_snappy = ["rocksdb/snappy"]
+rocksdb_lz4 = ["rocksdb/lz4"]
+rocksdb_zlib = ["rocksdb/zlib"]
+rocksdb_zstd = ["rocksdb/zstd"]
+rocksdb_bzip2 = ["rocksdb/bzip2"]
 
 [[example]]
 name = "blockchain"

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -85,6 +85,11 @@ long_benchmarks = []
 metrics-log = []
 sodiumoxide-crypto = ["exonum_sodiumoxide"]
 with-serde = []
+rocksdb_snappy = ["exonum-merkledb/rocksdb_snappy"]
+rocksdb_lz4 = ["exonum-merkledb/rocksdb_lz4"]
+rocksdb_zlib = ["exonum-merkledb/rocksdb_zlib"]
+rocksdb_zstd = ["exonum-merkledb/rocksdb_zstd"]
+rocksdb_bzip2 = ["exonum-merkledb/rocksdb_bzip2"]
 
 [build-dependencies]
 exonum-build = { version = "0.11.0", path = "../components/build" }

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -79,7 +79,7 @@ harness = false
 path = "benches/criterion/lib.rs"
 
 [features]
-default = ["sodiumoxide-crypto", "with-serde"]
+default = ["sodiumoxide-crypto", "with-serde", "rocksdb_snappy"]
 float_serialize = []
 long_benchmarks = []
 metrics-log = []

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -53,7 +53,7 @@ extern crate exonum_derive;
 #[cfg(feature = "sodiumoxide-crypto")]
 extern crate exonum_sodiumoxide as sodiumoxide;
 #[macro_use]
-extern crate exonum_merkledb;
+pub extern crate exonum_merkledb;
 #[macro_use]
 extern crate failure;
 #[macro_use]


### PR DESCRIPTION
## Overview

EJB needs to control what features are enabled. It can also be useful for some of the users in the future (when they will be able to change rocksdb compression algorithm via options).
Also reexported merkledb crate

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
