### PR TITLE
Handle an error when we can't read an index state [ECR-3418]

### DIFF
--- a/components/merkledb/src/proof_map_index/mod.rs
+++ b/components/merkledb/src/proof_map_index/mod.rs
@@ -25,7 +25,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use std::{
     fmt,
-    io::{Read, Write},
+    io::{Error, Read, Write},
     marker::PhantomData,
     mem::size_of,
 };
@@ -196,17 +196,17 @@ impl BinaryAttribute for ProofMapState {
         }
     }
 
-    fn read<R: Read>(buffer: &mut R) -> Self {
+    fn read<R: Read>(buffer: &mut R) -> Result<Self, Error> {
         let mut tmp = [0_u8; PROOF_PATH_SIZE];
-        let len = buffer.read_u64::<LittleEndian>().unwrap();
+        let len = buffer.read_u64::<LittleEndian>()?;
 
-        let proof_path = match buffer.read(&mut tmp).unwrap() {
+        let proof_path = match buffer.read(&mut tmp)? {
             0 => None,
             PROOF_PATH_SIZE => Some(ProofPath::read(&tmp)),
             other => panic!("Unexpected attribute length: {}", other),
         };
 
-        Self { len, proof_path }
+        Ok(Self { len, proof_path })
     }
 }
 

--- a/components/merkledb/src/sparse_list_index.rs
+++ b/components/merkledb/src/sparse_list_index.rs
@@ -18,7 +18,7 @@
 //! over the items of this index.
 
 use std::{
-    io::{Read, Write},
+    io::{Error, Read, Write},
     marker::PhantomData,
 };
 
@@ -51,11 +51,11 @@ impl BinaryAttribute for SparseListSize {
         buffer.write_u64::<LittleEndian>(self.length).unwrap();
     }
 
-    fn read<R: Read>(buffer: &mut R) -> Self {
-        Self {
-            capacity: buffer.read_u64::<LittleEndian>().unwrap(),
-            length: buffer.read_u64::<LittleEndian>().unwrap(),
-        }
+    fn read<R: Read>(buffer: &mut R) -> Result<Self, Error> {
+        Ok(Self {
+            capacity: buffer.read_u64::<LittleEndian>()?,
+            length: buffer.read_u64::<LittleEndian>()?,
+        })
     }
 }
 


### PR DESCRIPTION
## Overview

Handle an error when we can't read an index state due different index types

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3418
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions