### PR TITLE
Try to re deploy artifact before registration.

### DIFF
--- a/exonum/examples/sample_runtime.rs
+++ b/exonum/examples/sample_runtime.rs
@@ -93,6 +93,10 @@ impl Runtime for SampleRuntime {
         )
     }
 
+    fn is_artifact_deployed(&self, id: &ArtifactId) -> bool {
+        self.deployed_artifacts.contains_key(id)
+    }
+
     /// `start_service` request creates a new `SampleService` instance with the specified ID.
     fn start_service(&mut self, spec: &InstanceSpec) -> Result<(), ExecutionError> {
         if !self.deployed_artifacts.contains_key(&spec.artifact) {

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -66,7 +66,7 @@ impl std::fmt::Debug for Dispatcher {
 }
 
 impl Dispatcher {
-    /// Creates a new dispatcher with the specified runtimes.
+    /// Create a new dispatcher with the specified runtimes.
     pub(crate) fn with_runtimes(
         runtimes: impl IntoIterator<Item = (u32, Box<dyn Runtime>)>,
     ) -> Self {
@@ -94,7 +94,7 @@ impl Dispatcher {
         Ok(())
     }
 
-    /// Adds built-in service with predefined identifier.
+    /// Add a built-in service with the predefined identifier.
     ///
     /// # Panics
     ///
@@ -196,13 +196,23 @@ impl Dispatcher {
         spec: impl Into<Any>,
     ) -> Result<(), ExecutionError> {
         debug_assert!(artifact.validate().is_ok(), "{:?}", artifact.validate());
-        debug_assert!(
-            self.is_deployed(&artifact),
-            "An attempt to register artifact which is not be deployed: {:?}",
-            artifact
-        );
 
-        Schema::new(fork).add_artifact(artifact, spec.into())?;
+        // If for some reasons the artifact is not deployed, deploy it again.
+        let spec = spec.into();
+        if !self.is_artifact_deployed(&artifact) {
+            self.deploy_artifact(artifact.clone(), spec.clone())
+                .wait()
+                .unwrap_or_else(|e| {
+                    // In this case artifact deployment error is fatal because there are
+                    // confirmation that this node can deploy this artifact.
+                    panic!(FatalError::new(format!(
+                        "Unable to deploy registered artifact. {}",
+                        e
+                    )))
+                });
+        }
+
+        Schema::new(fork).add_artifact(artifact, spec)?;
         info!(
             "Registered artifact {} in runtime with id {}",
             artifact.name, artifact.runtime_id
@@ -358,8 +368,12 @@ impl Dispatcher {
     }
 
     /// Return true if the artifact with the given identifier is deployed.
-    pub(crate) fn is_deployed(&self, id: &ArtifactId) -> bool {
-        self.artifact_protobuf_spec(id).is_some()
+    pub(crate) fn is_artifact_deployed(&self, id: &ArtifactId) -> bool {
+        if let Some(runtime) = self.runtimes.get(&id.runtime_id) {
+            runtime.is_artifact_deployed(id)
+        } else {
+            false
+        }
     }
 
     /// Notify the runtime about API changes and return true if there are such changes.
@@ -603,6 +617,10 @@ mod tests {
                 }
                 .into_future(),
             )
+        }
+
+        fn is_artifact_deployed(&self, id: &ArtifactId) -> bool {
+            id.runtime_id == self.runtime_type
         }
 
         fn start_service(&mut self, spec: &InstanceSpec) -> Result<(), ExecutionError> {

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -165,6 +165,9 @@ pub trait Runtime: Send + Debug + 'static {
         deploy_spec: Any,
     ) -> Box<dyn Future<Item = (), Error = ExecutionError>>;
 
+    /// Return true if the specified artifact is deployed in this runtime.
+    fn is_artifact_deployed(&self, id: &ArtifactId) -> bool;
+
     /// Return Protobuf description of the deployed artifact with the specified identifier.
     /// If the artifact is not deployed, return `None`.
     ///

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -223,6 +223,14 @@ impl Runtime for RustRuntime {
         Box::new(self.deploy(&artifact).into_future())
     }
 
+    fn is_artifact_deployed(&self, id: &ArtifactId) -> bool {
+        if let Ok(artifact) = self.parse_artifact(id) {
+            self.deployed_artifacts.contains(&artifact)
+        } else {
+            false
+        }
+    }
+
     fn artifact_protobuf_spec(&self, id: &ArtifactId) -> Option<ArtifactProtobufSpec> {
         let id = self.parse_artifact(id).ok()?;
         self.deployed_artifact(&id)


### PR DESCRIPTION
In some cases runtime forgets about deployed but not registered artifacts, for example after restart between artifact confirmation and registration.

To fix this issue we have to add `is_artifact_deployed` to runtime trait and mark artifact deploy error during the registration as fatal.