### PR TITLE
Add clear_consensus_messages_cache function [ECR-3482]

### DIFF
--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -27,9 +27,9 @@ use log::SetLoggerError;
 
 use std::path::{Component, Path, PathBuf};
 
-use crate::blockchain::{GenesisConfig, ValidatorKeys, Schema};
-use crate::exonum_merkledb::Fork;
+use crate::blockchain::{GenesisConfig, Schema, ValidatorKeys};
 use crate::crypto::gen_keypair;
+use crate::exonum_merkledb::Fork;
 use crate::node::{ConnectListConfig, NodeConfig};
 
 mod types;

--- a/exonum/src/helpers/mod.rs
+++ b/exonum/src/helpers/mod.rs
@@ -27,7 +27,8 @@ use log::SetLoggerError;
 
 use std::path::{Component, Path, PathBuf};
 
-use crate::blockchain::{GenesisConfig, ValidatorKeys};
+use crate::blockchain::{GenesisConfig, ValidatorKeys, Schema};
+use crate::exonum_merkledb::Fork;
 use crate::crypto::gen_keypair;
 use crate::node::{ConnectListConfig, NodeConfig};
 
@@ -136,6 +137,13 @@ pub fn path_relative_from(path: impl AsRef<Path>, base: impl AsRef<Path>) -> Opt
         }
         Some(comps.iter().map(|c| c.as_os_str()).collect())
     }
+}
+
+/// Clears consensus messages cache.
+///
+/// Used in `exonum-cli` to implement `clear-cache` maintenance action.
+pub fn clear_consensus_messages_cache(fork: &Fork) {
+    Schema::new(fork).consensus_messages_cache().clear();
 }
 
 #[test]


### PR DESCRIPTION
## Overview

The new function is needed for implementing `clear-cache` action of the maintenance command. As the function is used for internal purposes, no changelog updates are made.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3482
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] Change is covered by automated tests
- [x] Benchmark results are attached (if applicable)
- [x] The [coding guidelines] are followed
- [x] Public API has proper documentation
- [x] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
