### PR TITLE
Add the service interface name option to the proto files

### DIFF
--- a/examples/cryptocurrency-advanced/backend/src/proto/service.proto
+++ b/examples/cryptocurrency-advanced/backend/src/proto/service.proto
@@ -17,6 +17,10 @@ syntax = "proto3";
 package exonum.examples.cryptocurrency_advanced;
 
 import "helpers.proto";
+import "service_interface.proto";
+
+/// Service interface name for the transactions in this file.
+option (service_interface_name) = "CryptocurrencyInterface";
 
 /// Transfer `amount` of the currency from one wallet to another.
 message Transfer {

--- a/examples/cryptocurrency/src/proto/service.proto
+++ b/examples/cryptocurrency/src/proto/service.proto
@@ -17,6 +17,10 @@ syntax = "proto3";
 package exonum.examples.cryptocurrency;
 
 import "helpers.proto";
+import "service_interface.proto";
+
+/// Service interface name for the transactions in this file.
+option (service_interface_name) = "CryptocurrencyInterface";
 
 // Wallet struct used to persist data within the service.
 message Wallet {

--- a/examples/timestamping/backend/src/proto/service.proto
+++ b/examples/timestamping/backend/src/proto/service.proto
@@ -17,7 +17,11 @@ syntax = "proto3";
 package exonum.examples.timestamping;
 
 import "helpers.proto";
+import "service_interface.proto";
 import "google/protobuf/timestamp.proto";
+
+/// Service interface name for the transactions in this file.
+option (service_interface_name) = "TimestampingInterface";
 
 /// Timestamping transaction.
 message TxTimestamp { Timestamp content = 1; }

--- a/exonum/src/proto/schema/exonum/service_interface.proto
+++ b/exonum/src/proto/schema/exonum/service_interface.proto
@@ -14,16 +14,11 @@
 
 syntax = "proto3";
 
-package exonum.service.time.example;
+package exonum;
 
-import "service_interface.proto";
+import "google/protobuf/descriptor.proto";
 
-import "google/protobuf/timestamp.proto";
-
-/// Service interface name for the transactions in this file.
-option (service_interface_name) = "MarkerInterface";
-
-message TxMarker {
-  int32 mark = 1;
-  google.protobuf.Timestamp time = 2;
+extend google.protobuf.FileOptions {
+  // String denoting the interface name for the file.
+  string service_interface_name = 50000;
 }

--- a/services/time/build.rs
+++ b/services/time/build.rs
@@ -1,13 +1,15 @@
 extern crate exonum_build;
 
-use exonum_build::protobuf_generate;
+use exonum_build::{get_exonum_protobuf_files_path, protobuf_generate};
 
 fn main() {
-    protobuf_generate("src/proto", &["src/proto"], "protobuf_mod.rs");
+    let exonum_protos = get_exonum_protobuf_files_path();
+
+    protobuf_generate("src/proto", &["src/proto", &exonum_protos], "protobuf_mod.rs");
 
     protobuf_generate(
         "examples/simple_service/proto",
-        &["examples/simple_service/proto"],
+        &["src/proto", "examples/simple_service/proto", &exonum_protos],
         "simple_service_protobuf_mod.rs",
     );
 }

--- a/services/time/src/proto/service.proto
+++ b/services/time/src/proto/service.proto
@@ -16,7 +16,12 @@ syntax = "proto3";
 
 package exonum.service.time;
 
+import "service_interface.proto";
+
 import "google/protobuf/timestamp.proto";
+
+/// Service interface name for the transactions in this file.
+option (service_interface_name) = "TimeOracleInterface";
 
 // Transaction that is sent by the validator after the commit of the block.
 message TxTime {


### PR DESCRIPTION
This PR adds an 'option' entry to the proto files which contains service interface name.

It is supposed that 'service.proto' contains transactions for exactly one interface, and if there are more than one interface is implemented for a service, transactions will be splitted into several files.

This is needed for client-side code (e.g. for the python light client) to make easier calls to the interfaces.