### PR TITLE
Set address name in index_metadata [ECR-3578]

### DIFF
--- a/components/merkledb/src/views/metadata.rs
+++ b/components/merkledb/src/views/metadata.rs
@@ -172,21 +172,30 @@ where
     T: IndexAccess,
     V: BinaryAttribute + Copy + Default,
 {
-    let index_name = index_address.fully_qualified_name();
+    // Actual name.
+    let index_name = index_address.name.clone();
+    // Full name for internal usage.
+    let index_full_name = index_address.fully_qualified_name();
 
     let mut pool = IndexesPool::new(index_access.clone());
-    let (metadata, is_new) = if let Some(metadata) = pool.index_metadata(&index_name) {
+    let (metadata, is_new) = if let Some(metadata) = pool.index_metadata(&index_full_name) {
         assert_eq!(
             metadata.index_type, index_type,
             "Index type does not match specified one"
         );
         (metadata, false)
     } else {
-        (pool.create_index_metadata(&index_name, index_type), true)
+        (
+            pool.create_index_metadata(&index_full_name, index_type),
+            true,
+        )
     };
 
-    let index_address = metadata.index_address();
-    let index_state = IndexState::new(index_access, index_name, metadata, is_new);
+    let mut index_address = metadata.index_address();
+    // Set index adress name, since metadata itself doesn't know it.
+    index_address.name = index_name;
+
+    let index_state = IndexState::new(index_access, index_full_name, metadata, is_new);
     (index_address, index_state)
 }
 

--- a/components/merkledb/src/views/tests.rs
+++ b/components/merkledb/src/views/tests.rs
@@ -726,7 +726,12 @@ fn test_metadata_index_identifiers() {
             .family_id("family")
             .index_type(IndexType::ProofMap)
             .build::<()>();
-        assert_eq!(view.address, IndexAddress::new().append_bytes(&0_u64));
+        assert_eq!(
+            view.address,
+            IndexAddress::new()
+                .append_name("simple")
+                .append_bytes(&0_u64)
+        );
     }
 
     // Creates the second index metadata.
@@ -736,7 +741,12 @@ fn test_metadata_index_identifiers() {
             .family_id("family")
             .index_type(IndexType::ProofMap)
             .build::<()>();
-        assert_eq!(view.address, IndexAddress::new().append_bytes(&1_u64));
+        assert_eq!(
+            view.address,
+            IndexAddress::new()
+                .append_name("second")
+                .append_bytes(&1_u64)
+        );
     }
 
     // Tries to create the first index instance.
@@ -746,7 +756,12 @@ fn test_metadata_index_identifiers() {
             .family_id("family")
             .index_type(IndexType::ProofMap)
             .build::<()>();
-        assert_eq!(view.address, IndexAddress::new().append_bytes(&0_u64));
+        assert_eq!(
+            view.address,
+            IndexAddress::new()
+                .append_name("simple")
+                .append_bytes(&0_u64)
+        );
     }
 }
 
@@ -985,4 +1000,15 @@ fn fork_from_patch() {
 
     db.merge(fork.into_patch())
         .expect("Fork created from patch should be merged successfully");
+}
+
+//#[should_panic(expected = "Index name must not be empty")]
+#[test]
+fn test_index_builder_index_address() {
+    let db = TemporaryDB::new();
+    // Creates the index metadata.
+    let fork = db.fork();
+    let (view, _) = IndexBuilder::new(&fork).index_name("test").build::<()>();
+
+    assert_eq!(view.address.name, "test");
 }

--- a/components/merkledb/src/views/tests.rs
+++ b/components/merkledb/src/views/tests.rs
@@ -1002,7 +1002,6 @@ fn fork_from_patch() {
         .expect("Fork created from patch should be merged successfully");
 }
 
-//#[should_panic(expected = "Index name must not be empty")]
 #[test]
 fn test_index_builder_index_address() {
     let db = TemporaryDB::new();


### PR DESCRIPTION
Somehow it turned out that provided index address name was lost on the `index_metadata` call step.

This PR fixes it and adds a test so it won't happen anymore.