### PR TITLE
Use strings for protobuf files

### DIFF
--- a/components/derive/src/service_factory.rs
+++ b/components/derive/src/service_factory.rs
@@ -140,7 +140,7 @@ impl ServiceFactory {
             .expect("`proto_sources` attribute is not set properly");
 
         quote! {
-            #cr::runtime::ArtifactProtobufSpec::from_str_list(
+            #cr::runtime::ArtifactProtobufSpec::from(
                 #proto_sources_mod::PROTO_SOURCES.as_ref(),
             )
         }

--- a/components/derive/src/service_factory.rs
+++ b/components/derive/src/service_factory.rs
@@ -140,9 +140,9 @@ impl ServiceFactory {
             .expect("`proto_sources` attribute is not set properly");
 
         quote! {
-            #cr::runtime::ArtifactProtobufSpec {
-                sources: #proto_sources_mod::PROTO_SOURCES.as_ref(),
-            }
+            #cr::runtime::ArtifactProtobufSpec::from_str_list(
+                #proto_sources_mod::PROTO_SOURCES.as_ref(),
+            )
         }
     }
 

--- a/exonum/src/api/node/mod.rs
+++ b/exonum/src/api/node/mod.rs
@@ -30,10 +30,10 @@ use crate::{
     events::network::ConnectedPeerAddr,
     helpers::Milliseconds,
     node::{ConnectInfo, NodeRole, State},
-    runtime::ArtifactId,
+    runtime::{ArtifactId, ProtoSourceFile},
 };
 
-use self::public::system::{DispatcherInfo, ProtoSource};
+use self::public::system::DispatcherInfo;
 
 pub mod private;
 pub mod public;
@@ -55,7 +55,7 @@ pub struct ApiNodeState {
 #[derive(Debug, Default)]
 pub struct DispatcherState {
     info: DispatcherInfo,
-    artifact_sources: HashMap<ArtifactId, Vec<ProtoSource>>,
+    artifact_sources: HashMap<ArtifactId, Vec<ProtoSourceFile>>,
 }
 
 impl DispatcherState {
@@ -69,12 +69,9 @@ impl DispatcherState {
             .clone()
             .into_iter()
             .filter_map(|artifact_id| {
-                dispatcher.artifact_protobuf_spec(&artifact_id).map(|info| {
-                    (
-                        artifact_id,
-                        info.sources.iter().map(ProtoSource::from).collect(),
-                    )
-                })
+                dispatcher
+                    .artifact_protobuf_spec(&artifact_id)
+                    .map(|info| (artifact_id, info.sources.clone()))
             })
             .collect();
 
@@ -207,7 +204,7 @@ impl SharedNodeState {
     }
 
     /// Returns the source files of the artifact with the specified identifier.
-    pub fn artifact_sources(&self, id: &ArtifactId) -> Option<Vec<ProtoSource>> {
+    pub fn artifact_sources(&self, id: &ArtifactId) -> Option<Vec<ProtoSourceFile>> {
         self.dispatcher
             .read()
             .expect("Expected read lock")

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -77,24 +77,6 @@ impl DispatcherInfo {
     }
 }
 
-/// Protobuf source file.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ProtoSource {
-    /// Source file name.
-    pub name: String,
-    /// Source file content.
-    pub content: String,
-}
-
-impl<'a> From<&'a (&'a str, &'a str)> for ProtoSource {
-    fn from(v: &'a (&'a str, &'a str)) -> Self {
-        Self {
-            name: v.0.to_owned(),
-            content: v.1.to_owned(),
-        }
-    }
-}
-
 /// Protobuf sources query parameters.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ProtoSourcesQuery {
@@ -172,7 +154,7 @@ impl SystemApi {
                     Ok(EXONUM_PROTO_SOURCES
                         .as_ref()
                         .iter()
-                        .map(ProtoSource::from)
+                        .map(From::from)
                         .collect::<Vec<_>>())
                 }
             }

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -352,8 +352,8 @@ pub struct ArtifactProtobufSpec {
 }
 
 impl ArtifactProtobufSpec {
-    pub fn from_str_list(sources_strs: &[(&str, &str)]) -> Self {
-        let sources = sources_strs.iter().map(From::from).collect();
+    pub fn from_str_list(sources_strings: &[(&str, &str)]) -> Self {
+        let sources = sources_strings.iter().map(From::from).collect();
 
         Self { sources }
     }

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -332,8 +332,8 @@ pub struct ProtoSourceFile {
     pub content: String,
 }
 
-impl<'a> From<&'a (&'a str, &'a str)> for ProtoSourceFile {
-    fn from(v: &'a (&'a str, &'a str)) -> Self {
+impl From<&(&str, &str)> for ProtoSourceFile {
+    fn from(v: &(&str, &str)) -> Self {
         Self {
             name: v.0.to_owned(),
             content: v.1.to_owned(),
@@ -342,7 +342,7 @@ impl<'a> From<&'a (&'a str, &'a str)> for ProtoSourceFile {
 }
 
 /// Artifact Protobuf specification for the Exonum clients.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ArtifactProtobufSpec {
     /// List of Protobuf files that make up the service interface. The first element in the tuple
     /// is the file name, the second one is its content.
@@ -351,18 +351,11 @@ pub struct ArtifactProtobufSpec {
     pub sources: Vec<ProtoSourceFile>,
 }
 
-impl ArtifactProtobufSpec {
-    pub fn from_str_list(sources_strings: &[(&str, &str)]) -> Self {
+impl From<&[(&str, &str)]> for ArtifactProtobufSpec {
+    fn from(sources_strings: &[(&str, &str)]) -> Self {
         let sources = sources_strings.iter().map(From::from).collect();
 
         Self { sources }
-    }
-}
-
-impl Default for ArtifactProtobufSpec {
-    /// Create blank artifact information without any proto sources.
-    fn default() -> Self {
-        Self { sources: vec![] }
     }
 }
 

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -323,24 +323,46 @@ where
     }
 }
 
+/// Artifact Protobuf file sources.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProtoSourceFile {
+    /// File name.
+    pub name: String,
+    /// File contents.
+    pub content: String,
+}
+
+impl<'a> From<&'a (&'a str, &'a str)> for ProtoSourceFile {
+    fn from(v: &'a (&'a str, &'a str)) -> Self {
+        Self {
+            name: v.0.to_owned(),
+            content: v.1.to_owned(),
+        }
+    }
+}
+
 /// Artifact Protobuf specification for the Exonum clients.
-#[derive(Debug, PartialEq)]
-pub struct ArtifactProtobufSpec<'a> {
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArtifactProtobufSpec {
     /// List of Protobuf files that make up the service interface. The first element in the tuple
     /// is the file name, the second one is its content.
     ///
     /// The common interface entry point is always in the `service.proto` file.
-    pub sources: &'a [(&'a str, &'a str)],
+    pub sources: Vec<ProtoSourceFile>,
 }
 
-impl<'a> Default for ArtifactProtobufSpec<'a> {
+impl ArtifactProtobufSpec {
+    pub fn from_str_list(sources_strs: &[(&str, &str)]) -> Self {
+        let sources = sources_strs.iter().map(From::from).collect();
+
+        Self { sources }
+    }
+}
+
+impl Default for ArtifactProtobufSpec {
     /// Create blank artifact information without any proto sources.
     fn default() -> Self {
-        const EMPTY_SOURCES: [(&str, &str); 0] = [];
-
-        Self {
-            sources: EMPTY_SOURCES.as_ref(),
-        }
+        Self { sources: vec![] }
     }
 }
 


### PR DESCRIPTION
Returning reference is not really handy.