### PR TITLE
Allow to use `Arc<dyn Snapshot>` as IndexAccess

### DIFF
--- a/components/merkledb/src/hash.rs
+++ b/components/merkledb/src/hash.rs
@@ -267,5 +267,4 @@ mod tests {
 
         assert_eq!(empty_map_hash, HashTag::empty_map_hash());
     }
-
 }

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     refs::{AnyObject, ObjectAccess, Ref, RefMut},
 };
 
-use std::{borrow::Cow, fmt, iter::Peekable, marker::PhantomData, ops::Deref};
+use std::{borrow::Cow, fmt, iter::Peekable, marker::PhantomData, ops::Deref, rc::Rc, sync::Arc};
 
 use super::{
     db::{Change, ChangesRef, ForkIter, ViewChanges},
@@ -367,20 +367,57 @@ impl<'a, K: BinaryKey + ?Sized> From<(&'a str, &'a K)> for IndexAddress {
     }
 }
 
-impl<T> IndexAccess for T
-where
-    T: Deref<Target = dyn Snapshot> + Clone,
-{
+impl<'a> IndexAccess for &'a dyn Snapshot {
     type Changes = ();
 
     fn snapshot(&self) -> &dyn Snapshot {
-        self.deref()
+        self.as_ref()
     }
 
-    fn changes(&self, _address: &IndexAddress) -> Self::Changes {}
+    fn changes(&self, _: &IndexAddress) -> Self::Changes {}
 }
 
 impl<'a> IndexAccess for &'a Box<dyn Snapshot> {
+    type Changes = ();
+
+    fn snapshot(&self) -> &dyn Snapshot {
+        self.as_ref()
+    }
+
+    fn changes(&self, _: &IndexAddress) -> Self::Changes {}
+}
+
+impl<'a> IndexAccess for &'a Arc<dyn Snapshot> {
+    type Changes = ();
+
+    fn snapshot(&self) -> &dyn Snapshot {
+        self.as_ref()
+    }
+
+    fn changes(&self, _: &IndexAddress) -> Self::Changes {}
+}
+
+impl<'a> IndexAccess for &'a Rc<dyn Snapshot> {
+    type Changes = ();
+
+    fn snapshot(&self) -> &dyn Snapshot {
+        self.as_ref()
+    }
+
+    fn changes(&self, _: &IndexAddress) -> Self::Changes {}
+}
+
+impl IndexAccess for Arc<dyn Snapshot> {
+    type Changes = ();
+
+    fn snapshot(&self) -> &dyn Snapshot {
+        self.as_ref()
+    }
+
+    fn changes(&self, _: &IndexAddress) -> Self::Changes {}
+}
+
+impl IndexAccess for Rc<dyn Snapshot> {
     type Changes = ();
 
     fn snapshot(&self) -> &dyn Snapshot {

--- a/components/merkledb/src/views/refs.rs
+++ b/components/merkledb/src/views/refs.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    rc::Rc,
+    sync::Arc,
+};
 
 use crate::{
     views::{IndexAddress, IndexType, View},
@@ -218,11 +222,13 @@ pub trait ObjectAccess: IndexAccess {
     }
 }
 
+impl ObjectAccess for &dyn Snapshot {}
 impl ObjectAccess for &Box<dyn Snapshot> {}
-
+impl ObjectAccess for &Arc<dyn Snapshot> {}
+impl ObjectAccess for &Rc<dyn Snapshot> {}
+impl ObjectAccess for Arc<dyn Snapshot> {}
+impl ObjectAccess for Rc<dyn Snapshot> {}
 impl ObjectAccess for &Fork {}
-
-impl<T> ObjectAccess for T where T: Deref<Target = dyn Snapshot> + Clone {}
 
 impl Fork {
     /// See: [ObjectAccess::get_object][1].

--- a/exonum/src/node/connect_list.rs
+++ b/exonum/src/node/connect_list.rs
@@ -193,5 +193,4 @@ mod test {
         });
         assert!(connect_list.is_address_allowed(&address));
     }
-
 }

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -402,7 +402,6 @@ mod execution_result {
     {
         ExecutionStatus::deserialize(deserializer).map(From::from)
     }
-
 }
 
 #[cfg(test)]
@@ -543,5 +542,4 @@ mod tests {
         let panic = make_panic(1);
         assert_eq!(ExecutionError::from_panic(panic).description, "");
     }
-
 }

--- a/testkit/src/api.rs
+++ b/testkit/src/api.rs
@@ -84,7 +84,7 @@ impl TestKitApi {
         Self::from_raw_parts(
             ApiAggregator::new(
                 testkit.blockchain().clone(),
-                SharedNodeState::new(testkit.blockchain(), 10_000),
+                SharedNodeState::new(&testkit.blockchain(), 10_000),
             ),
             testkit.api_sender.clone(),
         )


### PR DESCRIPTION
This change allows to write code like following:

```rust
fn schema(&self) -> FooSchema<Arc<dyn Snapshot>> {
    let snapshot = Arc::new(self.snapshot());
    FooSchema::new(snapshot)
}
```