### PR TITLE
Add support of external runtimes to exonum-cli

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -111,7 +111,6 @@ pub mod password;
 #[derive(Debug, Default)]
 pub struct NodeBuilder {
     services: Vec<Box<dyn ServiceFactory>>,
-    instances: Vec<InstanceCollection>,
     external_runtimes: Vec<(u32, Box<dyn Runtime>)>,
 }
 
@@ -140,18 +139,6 @@ impl NodeBuilder {
         self
     }
 
-    /// Adds a new InstanceCollection to the list of available services.
-    ///
-    /// With that method you can start Exonum with already deployed & running service
-    /// instances.
-    ///
-    /// Note that if you add the `InstanceCollection` manually, you don't need to call
-    /// `with_service`, since `InstanceCollection` already contains a service inside.
-    pub fn with_instance_collection(mut self, instance_collection: InstanceCollection) -> Self {
-        self.instances.push(instance_collection);
-        self
-    }
-
     /// Configures the node using parameters provided by user from stdin and then runs it.
     ///
     /// Only Rust runtime is enabled.
@@ -161,7 +148,6 @@ impl NodeBuilder {
         let services = self
             .builtin_services()
             .into_iter()
-            .chain(self.instances.into_iter())
             .chain(self.services.into_iter().map(InstanceCollection::new));
 
         let runtimes = self.external_runtimes;

--- a/examples/cryptocurrency/examples/demo.rs
+++ b/examples/cryptocurrency/examples/demo.rs
@@ -64,10 +64,14 @@ fn node_config() -> NodeConfig {
 fn main() {
     exonum::helpers::init_logger().unwrap();
 
+    let external_runtimes: Vec<(u32, Box<dyn exonum::runtime::Runtime>)> = vec![];
+    let services = vec![InstanceCollection::new(CryptocurrencyService)];
+
     println!("Creating database in temporary dir...");
     let node = Node::new(
         TemporaryDB::new(),
-        vec![InstanceCollection::new(CryptocurrencyService)],
+        external_runtimes,
+        services,
         node_config(),
         None,
     );

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -76,6 +76,8 @@ fn create_blockchain(
     db: impl Into<Arc<dyn Database>>,
     services: Vec<InstanceCollection>,
 ) -> Blockchain {
+    let external_runtimes: Vec<(u32, Box<dyn exonum::runtime::Runtime>)> = vec![];
+
     let service_keypair = (PublicKey::zero(), SecretKey::zero());
     let consensus_keypair = crypto::gen_keypair();
     let genesis_config = ConsensusConfig {
@@ -88,6 +90,7 @@ fn create_blockchain(
 
     Blockchain::new(
         db,
+        external_runtimes,
         services,
         genesis_config,
         service_keypair,

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     helpers::{Height, Round, ValidateInput, ValidatorId},
     messages::{AnyTx, Connect, Message, Precommit, Verified},
     node::ApiSender,
-    runtime::{dispatcher::Dispatcher, error::catch_panic},
+    runtime::{dispatcher::Dispatcher, error::catch_panic, Runtime},
 };
 
 mod block;
@@ -81,6 +81,7 @@ impl Blockchain {
     // TODO Write proper doc string. [ECR-3275]
     pub fn new(
         database: impl Into<Arc<dyn Database>>,
+        external_runtimes: impl IntoIterator<Item = impl Into<(u32, Box<dyn Runtime>)>>,
         services: impl IntoIterator<Item = InstanceCollection>,
         genesis_config: ConsensusConfig,
         service_keypair: (PublicKey, SecretKey),
@@ -89,6 +90,7 @@ impl Blockchain {
     ) -> Self {
         BlockchainBuilder::new(database, genesis_config, service_keypair)
             .with_default_runtime(services)
+            .with_external_runtimes(external_runtimes)
             .finalize(api_sender, internal_requests)
             .expect("Unable to create blockchain instance")
     }

--- a/exonum/src/sandbox/mod.rs
+++ b/exonum/src/sandbox/mod.rs
@@ -1133,9 +1133,11 @@ fn sandbox_with_services_uninitialized(
     let connect_list_config =
         ConnectListConfig::from_validator_keys(&genesis.validator_keys, &str_addresses);
 
+    let external_runtimes: Vec<(u32, Box<dyn crate::runtime::Runtime>)> = vec![];
     let api_channel = mpsc::channel(100);
     let blockchain = Blockchain::new(
         TemporaryDB::new(),
+        external_runtimes,
         services,
         genesis,
         service_keys[0].clone(),

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -22,7 +22,7 @@ use exonum::{
     node::ApiSender,
     runtime::{
         rust::{Service, TransactionContext},
-        AnyTx, InstanceDescriptor, InstanceId,
+        AnyTx, InstanceDescriptor, InstanceId, Runtime,
     },
 };
 use exonum_merkledb::{ObjectHash, Snapshot, TemporaryDB};
@@ -120,9 +120,15 @@ pub fn consensus_keys() -> (PublicKey, SecretKey) {
 pub fn create_blockchain() -> Blockchain {
     let config = generate_testnet_config(1, 0)[0].clone();
     let service_keypair = config.service_keypair();
+
+    let external_runtimes: Vec<(u32, Box<dyn Runtime>)> = vec![];
+    let services =
+        vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())];
+
     Blockchain::new(
         TemporaryDB::new(),
-        vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())],
+        external_runtimes,
+        services,
         config.consensus,
         service_keypair,
         ApiSender(mpsc::channel(0).0),

--- a/exonum/tests/websocket/blockchain/mod.rs
+++ b/exonum/tests/websocket/blockchain/mod.rs
@@ -21,7 +21,7 @@ use exonum::{
     node::{ApiSender, Node},
     runtime::{
         rust::{Service, TransactionContext},
-        InstanceDescriptor, InstanceId,
+        InstanceDescriptor, InstanceId, Runtime,
     },
 };
 use exonum_merkledb::{Snapshot, TemporaryDB};
@@ -117,9 +117,14 @@ pub fn run_node(listen_port: u16, pub_api_port: u16) -> RunHandle {
             .unwrap(),
     );
 
+    let external_runtimes: Vec<(u32, Box<dyn Runtime>)> = vec![];
+    let services =
+        vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())];
+
     let node = Node::new(
         TemporaryDB::new(),
-        vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())],
+        external_runtimes,
+        services,
         node_cfg,
         None,
     );


### PR DESCRIPTION
Currently we aren't able to create a node with additional runtimes with `exonum-cli`.