### PR TITLE
Implement ProtobufConvert for ListProof

### DIFF
--- a/components/build/src/lib.rs
+++ b/components/build/src/lib.rs
@@ -114,6 +114,7 @@ fn include_proto_files(proto_files: HashSet<&PathBuf>, name: &str) -> impl ToTok
         /// Original proto files which were be used to generate this module.
         /// First element in tuple is file name, second is proto file content.
         #[allow(dead_code)]
+        #[allow(clippy::unseparated_literal_suffix)]
         pub const #name: [(&str, &str); #proto_files_len] = [
             #( #proto_files )*
         ];

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/exonum/exonum"
 documentation = "https://docs.rs/exonum-merkledb"
 readme = "README.md"
 license = "Apache-2.0"
+links = "exonum_protobuf_merkledb"
 
 keywords = ["exonum", "cryptography", "library", "database", "merkelize", "patricia"]
 categories = ["cryptography", "database", "data-structures"]
@@ -18,7 +19,8 @@ bincode = "1.1"
 byteorder = "1.3"
 chrono = "0.4.6"
 enum-primitive-derive = "0.1"
-exonum-crypto = { path="../crypto", version="0.12.0", features = ["with-protobuf", "with-serde"]}
+exonum-crypto = { path = "../crypto", version = "0.12.0", features = ["with-protobuf", "with-serde"]}
+exonum-proto = { path = "../proto", version = "0.12.0", optional = true }
 failure = "0.1"
 hex = "0.4"
 leb128 = "0.2"
@@ -32,7 +34,7 @@ smallvec = "0.6"
 tempfile = "3.0"
 uuid = { version="0.7", features = ["v4"] }
 rand = "0.7"
-protobuf = { version = "2.8.1", features = ["with-serde"] }
+protobuf = { version = "2.8.1", features = ["with-serde"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -48,8 +50,9 @@ path = "benches/lib.rs"
 harness = false
 
 [features]
-default = ["rocksdb_snappy"]
+default = ["rocksdb_snappy", "with-protobuf"]
 long_benchmarks = []
+with-protobuf = ["protobuf", "exonum-proto"]
 rocksdb_snappy = ["rocksdb/snappy"]
 rocksdb_lz4 = ["rocksdb/lz4"]
 rocksdb_zlib = ["rocksdb/zlib"]

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -19,7 +19,7 @@ bincode = "1.1"
 byteorder = "1.3"
 chrono = "0.4.6"
 enum-primitive-derive = "0.1"
-exonum-crypto = { path = "../crypto", version = "0.12.0", features = ["with-protobuf", "with-serde"]}
+exonum-crypto = { path = "../crypto", version = "0.12.0", features = ["with-serde"]}
 exonum-proto = { path = "../proto", version = "0.12.0", optional = true }
 failure = "0.1"
 hex = "0.4"

--- a/components/merkledb/build.rs
+++ b/components/merkledb/build.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum_build::ProtobufGenerator;
-use std::env;
-
 fn main() {
     #[cfg(feature = "with-protobuf")]
     gen_proto_files();
@@ -22,6 +19,9 @@ fn main() {
 
 #[cfg(feature = "with-protobuf")]
 fn gen_proto_files() {
+    use exonum_build::ProtobufGenerator;
+    use std::env;
+
     let current_dir = env::current_dir().expect("Failed to get current dir.");
     let protos = current_dir.join("src/proto");
     println!("cargo:protos={}", protos.to_str().unwrap());

--- a/components/merkledb/build.rs
+++ b/components/merkledb/build.rs
@@ -1,0 +1,34 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use exonum_build::ProtobufGenerator;
+use std::env;
+
+fn main() {
+    #[cfg(feature = "with-protobuf")]
+    gen_proto_files();
+}
+
+#[cfg(feature = "with-protobuf")]
+fn gen_proto_files() {
+    let current_dir = env::current_dir().expect("Failed to get current dir.");
+    let protos = current_dir.join("src/proto");
+    println!("cargo:protos={}", protos.to_str().unwrap());
+
+    ProtobufGenerator::with_mod_name("protobuf_mod.rs")
+        .with_input_dir("src/proto")
+        .add_path("src/proto")
+        .with_crypto()
+        .generate();
+}

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -125,6 +125,7 @@
     // '... may panic' lints.
     clippy::indexing_slicing,
     clippy::use_self,
+    clippy::default_trait_access,
 )]
 
 pub use self::{

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -183,5 +183,11 @@ pub mod proof_map_index;
 pub mod sparse_list_index;
 pub mod value_set_index;
 
+#[cfg(feature = "with-protobuf")]
+pub mod proto;
+
+#[cfg(feature = "with-protobuf")]
+use exonum_proto::ProtobufConvert;
+
 #[cfg(test)]
 mod tests;

--- a/components/merkledb/src/proof_list_index/key.rs
+++ b/components/merkledb/src/proof_list_index/key.rs
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 use super::super::BinaryKey;
 
 const HEIGHT_SHIFT: u64 = 56;
-const MAX_INDEX: u64 = 0xFF_FFFF_FFFF_FFFF; // 2_u64.pow(56) - 1
+pub(crate) const MAX_INDEX: u64 = 0xFF_FFFF_FFFF_FFFF; // 2_u64.pow(56) - 1
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofListKey {

--- a/components/merkledb/src/proof_list_index/mod.rs
+++ b/components/merkledb/src/proof_list_index/mod.rs
@@ -826,8 +826,7 @@ where
 }
 
 #[cfg(feature = "with-protobuf")]
-#[doc(hidden)]
-pub mod proto {
+mod proto {
     pub use crate::proto::{self, *};
     use failure::Error;
     use protobuf::RepeatedField;

--- a/components/merkledb/src/proof_list_index/mod.rs
+++ b/components/merkledb/src/proof_list_index/mod.rs
@@ -851,7 +851,7 @@ pub mod proto {
             let index = pb.get_index();
             let height = pb.get_height();
 
-            // ProtobufConvert is implemented manually to add this checks.
+            // ProtobufConvert is implemented manually to add these checks.
             ensure!(index <= MAX_INDEX, "index is out of range");
             ensure!(height <= 58, "height is out of range");
 
@@ -892,11 +892,11 @@ pub mod proto {
             list_proof
         }
 
-        fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
+        fn from_pb(mut pb: Self::ProtoStruct) -> Result<Self, Error> {
             let proof = pb
-                .get_proof()
-                .iter()
-                .map(|entry| HashedEntry::from_pb(entry.clone()))
+                .take_proof()
+                .into_iter()
+                .map(HashedEntry::from_pb)
                 .collect::<Result<_, Error>>()?;
 
             let entries = pb

--- a/components/merkledb/src/proof_list_index/proof.rs
+++ b/components/merkledb/src/proof_list_index/proof.rs
@@ -542,7 +542,7 @@ impl<V: BinaryValue> ListProof<V> {
         length: u64,
     ) -> Self {
         Self {
-            proof: proof.to_vec(),
+            proof,
             entries,
             length,
         }

--- a/components/merkledb/src/proto/list_proof.proto
+++ b/components/merkledb/src/proto/list_proof.proto
@@ -1,0 +1,34 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+import "types.proto";
+
+package exonum.proof;
+
+message ListProof {
+    repeated HashedEntry proof = 1;
+    map<uint64, bytes> entries = 2;
+    uint64 length = 3;
+}
+
+message HashedEntry {
+    ProofListKey key = 1;
+    exonum.crypto.Hash hash = 2;
+}
+
+message ProofListKey {
+    uint64 index = 1;
+    uint32 height = 2;
+}

--- a/components/merkledb/src/proto/list_proof.proto
+++ b/components/merkledb/src/proto/list_proof.proto
@@ -18,7 +18,7 @@ import "types.proto";
 package exonum.proof;
 
 // Subset of ProofList elements coupled with a proof. ListProof` can assert existence of
-// certain and that the list is shorter than the requested range of indexes.
+// certain elements and that the list is shorter than the requested range of indexes.
 message ListProof {
     // Array of { ProofListKey, Hash } objects.
     repeated HashedEntry proof = 1;
@@ -28,11 +28,13 @@ message ListProof {
     uint64 length = 3;
 }
 
+// Represents list key and corresponding hash value.
 message HashedEntry {
     ProofListKey key = 1;
     exonum.crypto.Hash hash = 2;
 }
 
+// Index of the list element and its value.
 message ListProofEntry {
     uint64 index = 1;
     bytes value = 2;

--- a/components/merkledb/src/proto/list_proof.proto
+++ b/components/merkledb/src/proto/list_proof.proto
@@ -17,9 +17,14 @@ import "types.proto";
 
 package exonum.proof;
 
+// Subset of ProofList elements coupled with a proof. ListProof` can assert existence of
+// certain and that the list is shorter than the requested range of indexes.
 message ListProof {
+    // Array of { ProofListKey, Hash } objects.
     repeated HashedEntry proof = 1;
-    map<uint64, bytes> entries = 2;
+    // Array with list elements and their indexes.
+    repeated ListProofEntry entries = 2;
+    // Length of the underlying `ProofListIndex`.
     uint64 length = 3;
 }
 
@@ -28,6 +33,12 @@ message HashedEntry {
     exonum.crypto.Hash hash = 2;
 }
 
+message ListProofEntry {
+    uint64 index = 1;
+    bytes value = 2;
+}
+
+// Represents list node position in the merkle tree.
 message ProofListKey {
     uint64 index = 1;
     uint32 height = 2;

--- a/components/merkledb/src/proto/mod.rs
+++ b/components/merkledb/src/proto/mod.rs
@@ -35,20 +35,20 @@ mod tests {
         let mut table = ProofListIndex::new("index", &storage);
 
         let proof = table.get_proof(0);
-        assert_list_proof_roundtrip(proof);
+        assert_list_proof_roundtrip(&proof);
 
-        for i in 0..10 {
+        for i in 0..256 {
             table.push(i);
         }
 
         let proof = table.get_proof(5);
-        assert_list_proof_roundtrip(proof);
+        assert_list_proof_roundtrip(&proof);
 
-        let proof = table.get_range_proof(5..15);
-        assert_list_proof_roundtrip(proof);
+        let proof = table.get_range_proof(250..260);
+        assert_list_proof_roundtrip(&proof);
     }
 
-    fn assert_list_proof_roundtrip<V>(proof: ListProof<V>)
+    fn assert_list_proof_roundtrip<V>(proof: &ListProof<V>)
     where
         V: BinaryValue + ObjectHash + std::fmt::Debug,
         ListProof<V>: ProtobufConvert + PartialEq,
@@ -59,7 +59,7 @@ mod tests {
             .check()
             .expect("deserialized proof is not valid");
 
-        assert_eq!(proof, deserialized);
+        assert_eq!(proof, &deserialized);
         assert_eq!(
             checked_proof.index_hash(),
             proof.check().unwrap().index_hash()

--- a/components/merkledb/src/proto/mod.rs
+++ b/components/merkledb/src/proto/mod.rs
@@ -1,0 +1,68 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module of the rust-protobuf generated files.
+
+// For protobuf generated files.
+#![allow(bare_trait_objects)]
+
+pub use self::list_proof::*;
+use exonum_crypto::proto::*;
+
+include!(concat!(env!("OUT_DIR"), "/protobuf_mod.rs"));
+
+#[cfg(test)]
+mod tests {
+    use crate::{BinaryValue, Database, ListProof, ObjectHash, ProofListIndex, TemporaryDB};
+    use exonum_proto::ProtobufConvert;
+
+    #[test]
+    fn serialize_list_proof() {
+        let db = TemporaryDB::default();
+        let storage = db.fork();
+
+        let mut table = ProofListIndex::new("index", &storage);
+
+        let proof = table.get_proof(0);
+        assert_list_proof_roundtrip(proof);
+
+        for i in 0..10 {
+            table.push(i);
+        }
+
+        let proof = table.get_proof(5);
+        assert_list_proof_roundtrip(proof);
+
+        let proof = table.get_range_proof(5..15);
+        assert_list_proof_roundtrip(proof);
+    }
+
+    fn assert_list_proof_roundtrip<V>(proof: ListProof<V>)
+    where
+        V: BinaryValue + ObjectHash + std::fmt::Debug,
+        ListProof<V>: ProtobufConvert + PartialEq,
+    {
+        let pb = proof.to_pb();
+        let deserialized: ListProof<V> = ListProof::from_pb(pb).unwrap();
+        let checked_proof = deserialized
+            .check()
+            .expect("deserialized proof is not valid");
+
+        assert_eq!(proof, deserialized);
+        assert_eq!(
+            checked_proof.index_hash(),
+            proof.check().unwrap().index_hash()
+        );
+    }
+}

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -193,6 +193,7 @@ uint
 unboxed
 unflushed
 unreceived
+unseparated
 unsync
 untagged
 untrusted


### PR DESCRIPTION
Manual implementation of `ProtobufConvert` for `ListProof`. Derive will be implemented later in separate task.