### PR TITLE
Use enum to represent ErrorKind [ECR-3717]

### DIFF
--- a/exonum/src/proto/schema/exonum/runtime.proto
+++ b/exonum/src/proto/schema/exonum/runtime.proto
@@ -44,10 +44,17 @@ message InstanceSpec {
   ArtifactId artifact = 3;
 }
 
+enum ErrorKind {
+  PANIC = 0;
+  DISPATCHER = 1;
+  RUNTIME = 2;
+  SERVICE = 3;
+}
+
 /// Result of unsuccessful runtime execution.
 message ExecutionError {
   /// The kind of error that indicates in which module the error occurred.
-  uint32 kind = 1;
+  ErrorKind kind = 1;
   /// User defined error code that can have different meanings for the different
   /// error kinds.
   uint32 code = 2;

--- a/exonum/src/proto/schema/exonum/runtime.proto
+++ b/exonum/src/proto/schema/exonum/runtime.proto
@@ -44,7 +44,7 @@ message InstanceSpec {
   ArtifactId artifact = 3;
 }
 
-/// The kind of ExecutionError.
+// The kind of ExecutionError.
 enum ErrorKind {
   PANIC = 0;
   DISPATCHER = 1;
@@ -52,18 +52,18 @@ enum ErrorKind {
   SERVICE = 3;
 }
 
-/// Result of unsuccessful runtime execution.
+// Result of unsuccessful runtime execution.
 message ExecutionError {
-  /// The kind of error that indicates in which module the error occurred.
+  // The kind of error that indicates in which module the error occurred.
   ErrorKind kind = 1;
-  /// User defined error code that can have different meanings for the different
-  /// error kinds.
+  // User defined error code that can have different meanings for the different
+  // error kinds.
   uint32 code = 2;
-  /// Optional description which doesn't affect `object_hash`.
+  // Optional description which doesn't affect `object_hash`.
   string description = 3;
 }
 
-/// Result of runtime execution.
+// Result of runtime execution.
 message ExecutionStatus {
   oneof result {
     google.protobuf.Empty ok = 1;

--- a/exonum/src/proto/schema/exonum/runtime.proto
+++ b/exonum/src/proto/schema/exonum/runtime.proto
@@ -44,6 +44,7 @@ message InstanceSpec {
   ArtifactId artifact = 3;
 }
 
+/// The kind of ExecutionError.
 enum ErrorKind {
   PANIC = 0;
   DISPATCHER = 1;

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -84,15 +84,16 @@ impl ErrorKind {
     }
 
     fn from_raw(kind: runtime::ErrorKind, code: u8) -> Result<Self, failure::Error> {
-        match kind {
+        let kind = match kind {
             runtime::ErrorKind::PANIC => {
                 ensure!(code == 0, "Error code for panic should be zero");
-                Ok(ErrorKind::Panic)
+                ErrorKind::Panic
             }
-            runtime::ErrorKind::DISPATCHER => Ok(ErrorKind::Dispatcher { code }),
-            runtime::ErrorKind::RUNTIME => Ok(ErrorKind::Runtime { code }),
-            runtime::ErrorKind::SERVICE => Ok(ErrorKind::Service { code }),
-        }
+            runtime::ErrorKind::DISPATCHER => ErrorKind::Dispatcher { code },
+            runtime::ErrorKind::RUNTIME => ErrorKind::Runtime { code },
+            runtime::ErrorKind::SERVICE => ErrorKind::Service { code },
+        };
+        Ok(kind)
     }
 }
 

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -437,23 +437,6 @@ mod tests {
     }
 
     #[test]
-    fn execution_error_binary_value_wrong_kind() {
-        let bytes = {
-            let mut inner = runtime::ExecutionError::default();
-            inner.set_kind(117);
-            inner.set_code(2);
-            inner.write_to_bytes().unwrap()
-        };
-
-        assert_eq!(
-            ExecutionError::from_bytes(bytes.into())
-                .unwrap_err()
-                .to_string(),
-            "Unknown error kind"
-        )
-    }
-
-    #[test]
     fn execution_error_binary_value_panic_with_code() {
         let bytes = {
             let mut inner = runtime::ExecutionError::default();

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -441,7 +441,7 @@ mod tests {
     fn execution_error_binary_value_panic_with_code() {
         let bytes = {
             let mut inner = runtime_proto::ExecutionError::default();
-            inner.set_kind(0);
+            inner.set_kind(runtime_proto::ErrorKind::PANIC);
             inner.set_code(2);
             inner.write_to_bytes().unwrap()
         };

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -23,7 +23,7 @@ use std::{any::Any, convert::TryFrom, fmt::Display, panic};
 use crate::{
     blockchain::FatalError,
     crypto::{self, Hash},
-    proto::schema::runtime,
+    proto::schema::runtime as runtime_proto,
 };
 
 /// Kind of execution error, indicates in which module error occurred.
@@ -74,24 +74,24 @@ impl ErrorKind {
         ErrorKind::Service { code: code.into() }
     }
 
-    fn into_raw(self) -> (runtime::ErrorKind, u8) {
+    fn into_raw(self) -> (runtime_proto::ErrorKind, u8) {
         match self {
-            ErrorKind::Panic => (runtime::ErrorKind::PANIC, 0),
-            ErrorKind::Dispatcher { code } => (runtime::ErrorKind::DISPATCHER, code),
-            ErrorKind::Runtime { code } => (runtime::ErrorKind::RUNTIME, code),
-            ErrorKind::Service { code } => (runtime::ErrorKind::SERVICE, code),
+            ErrorKind::Panic => (runtime_proto::ErrorKind::PANIC, 0),
+            ErrorKind::Dispatcher { code } => (runtime_proto::ErrorKind::DISPATCHER, code),
+            ErrorKind::Runtime { code } => (runtime_proto::ErrorKind::RUNTIME, code),
+            ErrorKind::Service { code } => (runtime_proto::ErrorKind::SERVICE, code),
         }
     }
 
-    fn from_raw(kind: runtime::ErrorKind, code: u8) -> Result<Self, failure::Error> {
+    fn from_raw(kind: runtime_proto::ErrorKind, code: u8) -> Result<Self, failure::Error> {
         let kind = match kind {
-            runtime::ErrorKind::PANIC => {
+            runtime_proto::ErrorKind::PANIC => {
                 ensure!(code == 0, "Error code for panic should be zero");
                 ErrorKind::Panic
             }
-            runtime::ErrorKind::DISPATCHER => ErrorKind::Dispatcher { code },
-            runtime::ErrorKind::RUNTIME => ErrorKind::Runtime { code },
-            runtime::ErrorKind::SERVICE => ErrorKind::Service { code },
+            runtime_proto::ErrorKind::DISPATCHER => ErrorKind::Dispatcher { code },
+            runtime_proto::ErrorKind::RUNTIME => ErrorKind::Runtime { code },
+            runtime_proto::ErrorKind::SERVICE => ErrorKind::Service { code },
         };
         Ok(kind)
     }
@@ -210,7 +210,7 @@ where
 }
 
 impl ProtobufConvert for ExecutionError {
-    type ProtoStruct = runtime::ExecutionError;
+    type ProtoStruct = runtime_proto::ExecutionError;
 
     fn to_pb(&self) -> Self::ProtoStruct {
         let mut inner = Self::ProtoStruct::default();
@@ -281,7 +281,7 @@ impl From<Result<(), ExecutionError>> for ExecutionStatus {
 }
 
 impl ProtobufConvert for ExecutionStatus {
-    type ProtoStruct = runtime::ExecutionStatus;
+    type ProtoStruct = runtime_proto::ExecutionStatus;
 
     fn to_pb(&self) -> Self::ProtoStruct {
         let mut inner = Self::ProtoStruct::default();
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn execution_error_binary_value_panic_with_code() {
         let bytes = {
-            let mut inner = runtime::ExecutionError::default();
+            let mut inner = runtime_proto::ExecutionError::default();
             inner.set_kind(0);
             inner.set_code(2);
             inner.write_to_bytes().unwrap()


### PR DESCRIPTION
## Overview

Use an enum in the proto files to avoid the manual bookkeeping of constants in java/python.

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3717
<!-- markdownlint-enable MD034 -->

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
