### PR TITLE
SimpleSupervisor: Verify that config proposal is sent by validator [ECR-3742]

### DIFF
--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -66,8 +66,8 @@ impl<'a> ApiImpl<'a> {
         &self,
         transaction: impl Transaction<dyn SupervisorInterface>,
     ) -> Result<Hash, failure::Error> {
-        let keypair = self.0.service_keypair;
-        let signed = transaction.sign(self.0.instance.id, keypair.0, &keypair.1);
+        let (pub_key, sec_key) = self.0.service_keypair;
+        let signed = transaction.sign(self.0.instance.id, *pub_key, &sec_key);
 
         let hash = signed.object_hash();
         self.0.sender().broadcast_transaction(signed)?;

--- a/services/supervisor/src/proto_structures.rs
+++ b/services/supervisor/src/proto_structures.rs
@@ -145,7 +145,7 @@ impl ConfigPropose {
             self,
             SUPERVISOR_INSTANCE_ID,
             public_key,
-            &secret_key,
+            secret_key,
         )
     }
 

--- a/services/supervisor/src/proto_structures.rs
+++ b/services/supervisor/src/proto_structures.rs
@@ -136,8 +136,11 @@ impl ConfigPropose {
     }
 
     /// Signs the proposal for a simple supervisor with a randomly generated keypair.
-    pub fn sign_for_simple_supervisor(self) -> Verified<AnyTx> {
-        let (public_key, secret_key) = exonum_crypto::gen_keypair();
+    pub fn sign_for_simple_supervisor(
+        self,
+        public_key: PublicKey,
+        secret_key: &SecretKey,
+    ) -> Verified<AnyTx> {
         Transaction::<dyn SimpleSupervisorInterface>::sign(
             self,
             SUPERVISOR_INSTANCE_ID,

--- a/services/supervisor/src/simple/api.rs
+++ b/services/supervisor/src/simple/api.rs
@@ -41,8 +41,8 @@ impl<'a> ApiImpl<'a> {
         &self,
         transaction: impl Transaction<dyn SimpleSupervisorInterface>,
     ) -> Result<Hash, failure::Error> {
-        let keypair = self.0.service_keypair;
-        let signed = transaction.sign(self.0.instance.id, keypair.0, &keypair.1);
+        let (pub_key, sec_key) = self.0.service_keypair;
+        let signed = transaction.sign(self.0.instance.id, *pub_key, sec_key);
 
         let hash = signed.object_hash();
         self.0.sender().broadcast_transaction(signed)?;

--- a/services/supervisor/src/simple/api.rs
+++ b/services/supervisor/src/simple/api.rs
@@ -1,0 +1,67 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use exonum::{
+    crypto::Hash,
+    runtime::{
+        api::{self, ServiceApiBuilder, ServiceApiState},
+        rust::Transaction,
+    },
+};
+use exonum_merkledb::ObjectHash;
+use failure::Fail;
+
+use crate::{simple::SimpleSupervisorInterface, ConfigPropose};
+
+/// Private API specification of the simple supervisor service.
+pub trait PrivateApi {
+    /// Error type for the current API implementation.
+    type Error: Fail;
+
+    /// Creates and broadcasts the `ConfigPropose` transaction, which is signed
+    /// by the current node, and returns its hash.
+    fn propose_config(&self, proposal: ConfigPropose) -> Result<Hash, Self::Error>;
+}
+
+struct ApiImpl<'a>(&'a ServiceApiState<'a>);
+
+impl<'a> ApiImpl<'a> {
+    fn broadcast_transaction(
+        &self,
+        transaction: impl Transaction<dyn SimpleSupervisorInterface>,
+    ) -> Result<Hash, failure::Error> {
+        let keypair = self.0.service_keypair;
+        let signed = transaction.sign(self.0.instance.id, keypair.0, &keypair.1);
+
+        let hash = signed.object_hash();
+        self.0.sender().broadcast_transaction(signed)?;
+        Ok(hash)
+    }
+}
+
+impl PrivateApi for ApiImpl<'_> {
+    type Error = api::Error;
+
+    fn propose_config(&self, proposal: ConfigPropose) -> Result<Hash, Self::Error> {
+        self.broadcast_transaction(proposal).map_err(From::from)
+    }
+}
+
+pub fn wire(builder: &mut ServiceApiBuilder) {
+    builder
+        .private_scope()
+        .endpoint_mut("propose-config", |state, query| {
+            ApiImpl(state).propose_config(query)
+        });
+}

--- a/services/supervisor/src/simple/mod.rs
+++ b/services/supervisor/src/simple/mod.rs
@@ -22,7 +22,7 @@ use exonum::{
     runtime::{
         api::ServiceApiBuilder,
         rust::{CallContext, Service},
-        Caller, DispatcherError, ExecutionError, InstanceDescriptor, SUPERVISOR_INSTANCE_ID,
+        DispatcherError, ExecutionError, InstanceDescriptor, SUPERVISOR_INSTANCE_ID,
     },
 };
 use exonum_derive::{exonum_service, IntoExecutionError, ServiceFactory};
@@ -68,12 +68,11 @@ impl SimpleSupervisorInterface for SimpleSupervisor {
         mut context: CallContext,
         arg: ConfigPropose,
     ) -> Result<(), ExecutionError> {
-        context
-            .verify_caller(Caller::as_transaction)
-            .ok_or(DispatcherError::UnauthorizedCaller)?;
-
         // Verify that transaction author is validator.
-        let author = context.caller().author().unwrap();
+        let author = context
+            .caller()
+            .author()
+            .ok_or(DispatcherError::UnauthorizedCaller)?;;
         find_validator_id(context.fork().as_ref(), author).ok_or(Error::UnknownAuthor)?;
 
         // Check that the `actual_from` height is in the future.

--- a/services/supervisor/src/simple/mod.rs
+++ b/services/supervisor/src/simple/mod.rs
@@ -17,9 +17,10 @@
 use exonum::{
     blockchain::{self, InstanceCollection},
     crypto::Hash,
-    helpers::ValidateInput,
+    helpers::{validator::validator_id as find_validator_id, ValidateInput},
     merkledb::Snapshot,
     runtime::{
+        api::ServiceApiBuilder,
         rust::{CallContext, Service},
         Caller, DispatcherError, ExecutionError, InstanceDescriptor, SUPERVISOR_INSTANCE_ID,
     },
@@ -28,6 +29,7 @@ use exonum_derive::{exonum_service, IntoExecutionError, ServiceFactory};
 
 use crate::{update_configs, ConfigChange, ConfigPropose, ConfigureCall};
 
+mod api;
 mod schema;
 pub use self::schema::Schema;
 
@@ -50,6 +52,8 @@ pub enum Error {
     ConsensusConfigInvalid = 3,
     /// Actual height for config proposal is in the past.
     ActualFromIsPast = 4,
+    /// Transaction author is not a validator.
+    UnknownAuthor = 5,
 }
 
 #[exonum_service]
@@ -59,7 +63,6 @@ pub trait SimpleSupervisorInterface {
 }
 
 impl SimpleSupervisorInterface for SimpleSupervisor {
-    // TODO: check auth by one of validators [ECR-3742]
     fn change_config(
         &self,
         mut context: CallContext,
@@ -68,6 +71,10 @@ impl SimpleSupervisorInterface for SimpleSupervisor {
         context
             .verify_caller(Caller::as_transaction)
             .ok_or(DispatcherError::UnauthorizedCaller)?;
+
+        // Verify that transaction author is validator.
+        let author = context.caller().author().unwrap();
+        find_validator_id(context.fork().as_ref(), author).ok_or(Error::UnknownAuthor)?;
 
         // Check that the `actual_from` height is in the future.
         if blockchain::Schema::new(context.fork()).height() >= arg.actual_from {
@@ -127,6 +134,10 @@ impl Service for SimpleSupervisor {
         // Remove config from proposals.
         let schema = Schema::new(context.fork());
         schema.config_propose_entry().remove();
+    }
+
+    fn wire_api(&self, builder: &mut ServiceApiBuilder) {
+        api::wire(builder)
     }
 }
 

--- a/services/time/tests/test_exonum_time.rs
+++ b/services/time/tests/test_exonum_time.rs
@@ -371,7 +371,7 @@ fn test_selected_time_less_than_time_in_storage() {
 
     let validators = testkit.network().validators().to_vec();
 
-    let (pub_key_0, _) = validators[0].service_keypair();
+    let (pub_key_0, sec_key_0) = validators[0].service_keypair();
 
     let cfg_change_height = Height(5);
     let new_cfg = {
@@ -383,7 +383,7 @@ fn test_selected_time_less_than_time_in_storage() {
     testkit.create_block_with_transaction(
         ConfigPropose::actual_from(cfg_change_height)
             .consensus_config(new_cfg)
-            .sign_for_simple_supervisor(),
+            .sign_for_simple_supervisor(pub_key_0, &sec_key_0),
     );
     testkit.create_blocks_until(cfg_change_height);
 
@@ -597,7 +597,7 @@ fn test_endpoint_api() {
     assert_current_validators_times_eq(&mut api, &current_validators_times);
     assert_all_validators_times_eq(&mut api, &all_validators_times);
 
-    let public_key_0 = validators[0].service_keypair().0;
+    let (public_key_0, secret_key_0) = validators[0].service_keypair();
     let cfg_change_height = Height(10);
     let new_cfg = {
         let mut cfg = testkit.consensus_config();
@@ -611,7 +611,7 @@ fn test_endpoint_api() {
     testkit.create_block_with_transaction(
         ConfigPropose::actual_from(cfg_change_height)
             .consensus_config(new_cfg)
-            .sign_for_simple_supervisor(),
+            .sign_for_simple_supervisor(public_key_0, &secret_key_0),
     );
     testkit.create_blocks_until(cfg_change_height);
 


### PR DESCRIPTION
## Overview

This PR enhances the `SimpleSupervisor` with check for proposal author to be a validator (as in `Supervisor`). For node administrator workflow is not the same as for `Supervisor`: request with config proposal should be sent through private API endpoint.

However, this is the only check performed, there is no need to send request by all validators, and there is no need to send confirmations as well.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-3742
<!-- markdownlint-enable MD034 -->
