### PR TITLE
Implement ObjectHash for SignedMessage

### DIFF
--- a/exonum/src/messages/types.rs
+++ b/exonum/src/messages/types.rs
@@ -16,14 +16,14 @@ pub use crate::runtime::AnyTx;
 
 use bit_vec::BitVec;
 use chrono::{DateTime, Utc};
+use exonum_merkledb::{BinaryValue, HashTag};
 
 use std::convert::TryFrom;
 
 use crate::{
     blockchain::Block,
-    crypto::{Hash, HashStream, PublicKey, Signature},
+    crypto::{Hash, PublicKey, Signature},
     helpers::{Height, Round, ValidatorId},
-    merkledb::{BinaryValue, HashTag, ObjectHash},
     proto::schema::consensus,
 };
 
@@ -32,7 +32,7 @@ use exonum_proto::ProtobufConvert;
 /// Protobuf based container for any signed messages.
 ///
 /// See module [documentation](index.html#examples) for examples.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "consensus::SignedMessage")]
 pub struct SignedMessage {
     /// Message payload.
@@ -41,16 +41,6 @@ pub struct SignedMessage {
     pub author: PublicKey,
     /// Digital signature.
     pub signature: Signature,
-}
-
-impl ObjectHash for SignedMessage {
-    fn object_hash(&self) -> Hash {
-        HashStream::new()
-            .update(&self.payload)
-            .update(&self.author.to_bytes())
-            .update(self.signature.as_ref())
-            .hash()
-    }
 }
 
 /// Connect to a node.

--- a/exonum/src/messages/types.rs
+++ b/exonum/src/messages/types.rs
@@ -16,14 +16,14 @@ pub use crate::runtime::AnyTx;
 
 use bit_vec::BitVec;
 use chrono::{DateTime, Utc};
-use exonum_merkledb::{BinaryValue, HashTag};
 
 use std::convert::TryFrom;
 
 use crate::{
     blockchain::Block,
-    crypto::{Hash, PublicKey, Signature},
+    crypto::{Hash, HashStream, PublicKey, Signature},
     helpers::{Height, Round, ValidatorId},
+    merkledb::{BinaryValue, HashTag, ObjectHash},
     proto::schema::consensus,
 };
 
@@ -32,7 +32,7 @@ use exonum_proto::ProtobufConvert;
 /// Protobuf based container for any signed messages.
 ///
 /// See module [documentation](index.html#examples) for examples.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue)]
 #[protobuf_convert(source = "consensus::SignedMessage")]
 pub struct SignedMessage {
     /// Message payload.
@@ -41,6 +41,16 @@ pub struct SignedMessage {
     pub author: PublicKey,
     /// Digital signature.
     pub signature: Signature,
+}
+
+impl ObjectHash for SignedMessage {
+    fn object_hash(&self) -> Hash {
+        HashStream::new()
+            .update(&self.payload)
+            .update(&self.author.to_bytes())
+            .update(self.signature.as_ref())
+            .hash()
+    }
 }
 
 /// Connect to a node.

--- a/exonum/src/proto/schema/exonum/consensus.proto
+++ b/exonum/src/proto/schema/exonum/consensus.proto
@@ -27,9 +27,6 @@ import "runtime.proto";
 import "google/protobuf/timestamp.proto";
 
 // Container for the signed messages.
-//
-// Keep in mind, that:
-// hash(SignedMessage) = hash(payload || key.bytes || sign.bytes)
 message SignedMessage {
   // Message payload.
   bytes payload = 1;


### PR DESCRIPTION
## Overview

Implement `hash(SignedMessage) = hash(payload || key.bytes || sign.bytes)` as specified in `consensus.proto`.

### Definition of Done

- [x] There are no TODOs left in the merged code
- [x] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
