### PR TITLE
Remove ApiContext structure [ECR-3745]

### DIFF
--- a/examples/sample_runtime/src/main.rs
+++ b/examples/sample_runtime/src/main.rs
@@ -16,7 +16,9 @@
 //! increment and reset counter in the service instance.
 
 use exonum::{
-    blockchain::{Blockchain, ConsensusConfig, InstanceCollection, ValidatorKeys},
+    blockchain::{
+        Blockchain, BlockchainBuilder, ConsensusConfig, InstanceCollection, ValidatorKeys,
+    },
     helpers::Height,
     keys::Keys,
     merkledb::{BinaryValue, Snapshot, TemporaryDB},
@@ -273,8 +275,8 @@ fn main() {
 
     println!("Creating blockchain with additional runtime...");
     // Create a blockchain with the Rust runtime and our additional runtime.
-    let blockchain = Blockchain::new(db, service_keypair.clone(), api_sender.clone())
-        .into_mut(genesis)
+    let blockchain_base = Blockchain::new(db, service_keypair.clone(), api_sender.clone());
+    let blockchain = BlockchainBuilder::new(blockchain_base, genesis)
         .with_rust_runtime(
             channel.endpoints.0.clone(),
             vec![InstanceCollection::from(Supervisor)],

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -40,7 +40,8 @@
 use criterion::{Criterion, ParameterizedBenchmark, Throughput};
 use exonum::{
     blockchain::{
-        Blockchain, BlockchainMut, ConsensusConfig, InstanceCollection, Schema, ValidatorKeys,
+        Blockchain, BlockchainBuilder, BlockchainMut, ConsensusConfig, InstanceCollection, Schema,
+        ValidatorKeys,
     },
     crypto::{self, Hash, PublicKey, SecretKey},
     helpers::{Height, ValidatorId},
@@ -89,8 +90,8 @@ fn create_blockchain(
     };
 
     let api_sender = ApiSender::new(mpsc::channel(0).0);
-    Blockchain::new(db, service_keypair, api_sender)
-        .into_mut(genesis_config)
+    let blockchain_base = Blockchain::new(db, service_keypair, api_sender);
+    BlockchainBuilder::new(blockchain_base, genesis_config)
         .with_rust_runtime(mpsc::channel(0).0, services)
         .build()
         .unwrap()

--- a/exonum/src/api/node/public/system.rs
+++ b/exonum/src/api/node/public/system.rs
@@ -18,8 +18,8 @@ use exonum_merkledb::IndexAccess;
 
 use crate::runtime::ProtoSourceFile;
 use crate::{
-    api::{self, node::SharedNodeState, ApiContext, ApiScope},
-    blockchain::Schema,
+    api::{self, node::SharedNodeState, ApiScope},
+    blockchain::{Blockchain, Schema},
     helpers::user_agent,
     proto::schema::{INCLUDES as EXONUM_INCLUDES, PROTO_SOURCES as EXONUM_PROTO_SOURCES},
     runtime::{ArtifactId, DispatcherSchema, InstanceSpec},
@@ -93,15 +93,15 @@ pub struct ProtoSourcesQuery {
 /// Public system API.
 #[derive(Clone, Debug)]
 pub struct SystemApi {
-    context: ApiContext,
+    blockchain: Blockchain,
     node_state: SharedNodeState,
 }
 
 impl SystemApi {
     /// Create a new `public::SystemApi` instance.
-    pub fn new(context: ApiContext, node_state: SharedNodeState) -> Self {
+    pub fn new(blockchain: Blockchain, node_state: SharedNodeState) -> Self {
         Self {
-            context,
+            blockchain,
             node_state,
         }
     }
@@ -109,7 +109,7 @@ impl SystemApi {
     fn handle_stats_info(self, name: &'static str, api_scope: &mut ApiScope) -> Self {
         let self_ = self.clone();
         api_scope.endpoint(name, move |_query: ()| {
-            let snapshot = self.context.snapshot();
+            let snapshot = self.blockchain.snapshot();
             let schema = Schema::new(&snapshot);
             Ok(StatsInfo {
                 tx_pool_size: schema.transactions_pool_len(),
@@ -139,7 +139,7 @@ impl SystemApi {
     fn handle_list_services_info(self, name: &'static str, api_scope: &mut ApiScope) -> Self {
         let self_ = self.clone();
         api_scope.endpoint(name, move |_query: ()| {
-            Ok(DispatcherInfo::load(&self_.context.snapshot()))
+            Ok(DispatcherInfo::load(&self_.blockchain.snapshot()))
         });
         self
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -145,7 +145,8 @@ impl Blockchain {
 
     /// Starts promotion into a mutable blockchain instance that can be used to process
     /// transactions and create blocks.
-    pub(crate) fn into_mut(self, genesis_config: ConsensusConfig) -> BlockchainBuilder {
+    #[cfg(test)]
+    pub fn into_mut(self, genesis_config: ConsensusConfig) -> BlockchainBuilder {
         BlockchainBuilder::new(self, genesis_config)
     }
 

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -161,12 +161,12 @@ impl Blockchain {
         self.into_mut(config.consensus)
     }
 
-    /// Return reference to the transactions sender.
+    /// Returns reference to the transactions sender.
     pub fn sender(&self) -> &ApiSender {
         &self.api_sender
     }
 
-    /// Return reference to the service key pair of the current node.
+    /// Returns reference to the service key pair of the current node.
     pub fn service_keypair(&self) -> &(PublicKey, SecretKey) {
         &self.service_keypair
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -145,7 +145,7 @@ impl Blockchain {
 
     /// Starts promotion into a mutable blockchain instance that can be used to process
     /// transactions and create blocks.
-    pub fn into_mut(self, genesis_config: ConsensusConfig) -> BlockchainBuilder {
+    pub(crate) fn into_mut(self, genesis_config: ConsensusConfig) -> BlockchainBuilder {
         BlockchainBuilder::new(self, genesis_config)
     }
 
@@ -159,6 +159,16 @@ impl Blockchain {
         let mut config = generate_testnet_config(1, 0).pop().unwrap();
         config.keys.service = KeyPair::from(self.service_keypair.clone());
         self.into_mut(config.consensus)
+    }
+
+    /// Return reference to the transactions sender.
+    pub fn sender(&self) -> &ApiSender {
+        &self.api_sender
+    }
+
+    /// Return reference to the service key pair of the current node.
+    pub fn service_keypair(&self) -> &(PublicKey, SecretKey) {
+        &self.service_keypair
     }
 }
 
@@ -190,6 +200,11 @@ impl BlockchainMut {
     #[cfg(test)]
     pub(crate) fn dispatcher(&mut self) -> &mut Dispatcher {
         &mut self.dispatcher
+    }
+
+    /// Returns a copy of immutable blockchain view.
+    pub fn immutable_view(&self) -> Blockchain {
+        self.inner.clone()
     }
 
     /// Creates a read-only snapshot of the current storage state.

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -54,7 +54,8 @@ use crate::{
         ApiAccess, ApiAggregator,
     },
     blockchain::{
-        Blockchain, BlockchainMut, ConsensusConfig, InstanceCollection, Schema, ValidatorKeys,
+        Blockchain, BlockchainBuilder, BlockchainMut, ConsensusConfig, InstanceCollection, Schema,
+        ValidatorKeys,
     },
     crypto::{self, Hash, PublicKey, SecretKey},
     events::{
@@ -937,8 +938,7 @@ impl Node {
             node_cfg.service_keypair(),
             ApiSender::new(channel.api_requests.0.clone()),
         );
-        let blockchain = blockchain
-            .into_mut(node_cfg.consensus.clone())
+        let blockchain = BlockchainBuilder::new(blockchain, node_cfg.consensus.clone())
             .with_rust_runtime(channel.endpoints.0.clone(), services)
             .with_external_runtimes(external_runtimes)
             .build()

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -1006,7 +1006,7 @@ impl Node {
                     .chain(private_api_handler)
                     .collect::<Vec<_>>()
             },
-            api_aggregator: ApiAggregator::new(blockchain.as_ref(), api_state.clone()),
+            api_aggregator: ApiAggregator::new(blockchain.immutable_view(), api_state.clone()),
         };
 
         let handler = NodeHandler::new(

--- a/exonum/src/runtime/api.rs
+++ b/exonum/src/runtime/api.rs
@@ -14,7 +14,7 @@
 
 //! Building blocks for creating API of services.
 
-pub use crate::api::{ApiContext, Error, FutureResult, Result};
+pub use crate::api::{Error, FutureResult, Result};
 
 use exonum_merkledb::Snapshot;
 use futures::IntoFuture;
@@ -22,6 +22,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     api::{ApiBuilder, ApiScope},
+    blockchain::Blockchain,
     crypto::{PublicKey, SecretKey},
     node::ApiSender,
     runtime::{InstanceDescriptor, InstanceId},
@@ -43,13 +44,13 @@ pub struct ServiceApiState<'a> {
 }
 
 impl<'a> ServiceApiState<'a> {
-    /// Create service API state snapshot from the given context and instance descriptor.
-    pub fn from_api_context(context: &'a ApiContext, instance: InstanceDescriptor<'a>) -> Self {
+    /// Create service API state snapshot from the given blockchain and instance descriptor.
+    pub fn from_api_context(blockchain: &'a Blockchain, instance: InstanceDescriptor<'a>) -> Self {
         Self {
-            service_keypair: context.service_keypair(),
+            service_keypair: blockchain.service_keypair(),
             instance,
-            api_sender: context.sender(),
-            snapshot: context.snapshot(),
+            api_sender: blockchain.sender(),
+            snapshot: blockchain.snapshot(),
         }
     }
 
@@ -70,16 +71,16 @@ impl<'a> ServiceApiState<'a> {
 #[derive(Debug, Clone)]
 pub struct ServiceApiScope {
     inner: ApiScope,
-    context: ApiContext,
+    blockchain: Blockchain,
     descriptor: (InstanceId, String),
 }
 
 impl ServiceApiScope {
     /// Create a new service API scope for the specified service instance.
-    pub fn new(context: ApiContext, instance: InstanceDescriptor) -> Self {
+    pub fn new(blockchain: Blockchain, instance: InstanceDescriptor) -> Self {
         Self {
             inner: ApiScope::new(),
-            context,
+            blockchain,
             descriptor: instance.into(),
         }
     }
@@ -95,12 +96,12 @@ impl ServiceApiScope {
         F: Fn(&ServiceApiState, Q) -> R + 'static + Clone + Send + Sync,
         R: IntoFuture<Item = I, Error = crate::api::Error> + 'static,
     {
-        let context = self.context.clone();
+        let blockchain = self.blockchain.clone();
         let descriptor = self.descriptor.clone();
         self.inner
             .endpoint(name, move |query: Q| -> crate::api::FutureResult<I> {
                 let state = ServiceApiState::from_api_context(
-                    &context,
+                    &blockchain,
                     InstanceDescriptor {
                         id: descriptor.0,
                         name: descriptor.1.as_ref(),
@@ -123,12 +124,12 @@ impl ServiceApiScope {
         F: Fn(&ServiceApiState, Q) -> R + 'static + Clone + Send + Sync,
         R: IntoFuture<Item = I, Error = crate::api::Error> + 'static,
     {
-        let context = self.context.clone();
+        let blockchain = self.blockchain.clone();
         let descriptor = self.descriptor.clone();
         self.inner
             .endpoint_mut(name, move |query: Q| -> crate::api::FutureResult<I> {
                 let state = ServiceApiState::from_api_context(
-                    &context,
+                    &blockchain,
                     InstanceDescriptor {
                         id: descriptor.0,
                         name: descriptor.1.as_ref(),
@@ -230,17 +231,17 @@ impl ServiceApiScope {
 /// }
 ///
 /// # fn main() {
-/// #     use exonum::{api::ApiContext, node::ApiSender, runtime::InstanceDescriptor};
+/// #     use exonum::{blockchain::Blockchain, node::ApiSender, runtime::InstanceDescriptor};
 /// #     use exonum_merkledb::TemporaryDB;
 /// #     use futures::sync::mpsc;
 /// #
-/// #     let context = ApiContext::new(
-/// #         TemporaryDB::new().into(),
+/// #     let blockchain = Blockchain::new(
+/// #         TemporaryDB::new(),
 /// #         crypto::gen_keypair(),
 /// #         ApiSender::new(mpsc::channel(0).0),
 /// #     );
 /// #     let mut builder = ServiceApiBuilder::new(
-/// #         context,
+/// #         blockchain,
 /// #         InstanceDescriptor {
 /// #             id: 1100,
 /// #             name: "example",
@@ -251,7 +252,7 @@ impl ServiceApiScope {
 /// ```
 #[derive(Debug)]
 pub struct ServiceApiBuilder {
-    context: ApiContext,
+    blockchain: Blockchain,
     public_scope: ServiceApiScope,
     private_scope: ServiceApiScope,
 }
@@ -259,11 +260,11 @@ pub struct ServiceApiBuilder {
 impl ServiceApiBuilder {
     /// Create a new service API builder for the specified service instance.
     #[doc(hidden)]
-    pub fn new(context: ApiContext, instance: InstanceDescriptor) -> Self {
+    pub fn new(blockchain: Blockchain, instance: InstanceDescriptor) -> Self {
         Self {
-            context: context.clone(),
-            public_scope: ServiceApiScope::new(context.clone(), instance),
-            private_scope: ServiceApiScope::new(context, instance),
+            blockchain: blockchain.clone(),
+            public_scope: ServiceApiScope::new(blockchain.clone(), instance),
+            private_scope: ServiceApiScope::new(blockchain, instance),
         }
     }
 
@@ -277,9 +278,9 @@ impl ServiceApiBuilder {
         &mut self.private_scope
     }
 
-    /// Return a reference to the underlying API context.
-    pub fn context(&self) -> &ApiContext {
-        &self.context
+    /// Return a reference to the blockchain.
+    pub fn blockchain(&self) -> &Blockchain {
+        &self.blockchain
     }
 }
 

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 use super::{
-    api::{ApiContext, ServiceApiBuilder},
+    api::ServiceApiBuilder,
     dispatcher::{self, Mailbox},
     error::{catch_panic, ExecutionError},
     ArtifactId, ArtifactProtobufSpec, CallInfo, ExecutionContext, InstanceDescriptor, InstanceId,
@@ -56,7 +56,7 @@ mod tests;
 
 #[derive(Debug)]
 pub struct RustRuntime {
-    api_context: Option<ApiContext>,
+    blockchain: Option<Blockchain>,
     api_notifier: mpsc::Sender<UpdateEndpoints>,
     available_artifacts: HashMap<RustArtifactId, Box<dyn ServiceFactory>>,
     deployed_artifacts: HashSet<RustArtifactId>,
@@ -105,7 +105,7 @@ impl RustRuntime {
     /// Creates a new Rust runtime instance.
     pub fn new(api_notifier: mpsc::Sender<UpdateEndpoints>) -> Self {
         Self {
-            api_context: None,
+            blockchain: None,
             api_notifier,
             available_artifacts: Default::default(),
             deployed_artifacts: Default::default(),
@@ -115,8 +115,8 @@ impl RustRuntime {
         }
     }
 
-    fn api_context(&self) -> &ApiContext {
-        self.api_context
+    fn blockchain(&self) -> &Blockchain {
+        self.blockchain
             .as_ref()
             .expect("Method called before Rust runtime is initialized")
     }
@@ -184,7 +184,7 @@ impl RustRuntime {
             .values()
             .map(|instance| {
                 let mut builder = ServiceApiBuilder::new(
-                    self.api_context().clone(),
+                    self.blockchain().clone(),
                     InstanceDescriptor {
                         id: instance.id,
                         name: instance.name.as_ref(),
@@ -281,7 +281,7 @@ impl FromStr for RustArtifactId {
 
 impl Runtime for RustRuntime {
     fn initialize(&mut self, blockchain: &Blockchain) {
-        self.api_context = Some(ApiContext::with_blockchain(blockchain));
+        self.blockchain = Some(blockchain.clone());
     }
 
     // We need to propagate changes in the services immediately after initialization.
@@ -407,14 +407,14 @@ impl Runtime for RustRuntime {
             return;
         }
 
-        let api_context = self.api_context();
+        let blockchain = self.blockchain();
         for service in self.started_services.values() {
             service.as_ref().after_commit(AfterCommitContext::new(
                 mailbox,
                 service.descriptor(),
                 snapshot,
-                api_context.service_keypair(),
-                api_context.sender(),
+                blockchain.service_keypair(),
+                blockchain.sender(),
             ));
         }
     }

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -15,7 +15,7 @@
 //! Simplified blockchain emulation for the `BlockchainExplorer`.
 
 use exonum::{
-    blockchain::{Blockchain, BlockchainMut, InstanceCollection, Schema},
+    blockchain::{Blockchain, BlockchainBuilder, BlockchainMut, InstanceCollection, Schema},
     crypto::{self, Hash, PublicKey, SecretKey},
     helpers::generate_testnet_config,
     messages::Verified,
@@ -124,8 +124,7 @@ pub fn create_blockchain() -> BlockchainMut {
 
     let services =
         vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())];
-    blockchain
-        .into_mut(config.consensus)
+    BlockchainBuilder::new(blockchain, config.consensus)
         .with_rust_runtime(mpsc::channel(1).0, services)
         .build()
         .unwrap()

--- a/test-suite/testkit/tests/counter/counter.rs
+++ b/test-suite/testkit/tests/counter/counter.rs
@@ -181,7 +181,7 @@ impl CounterApi {
         // Check processing of custom HTTP headers. We test this using simple authorization
         // with a fixed bearer token; for practical apps, the tokens might
         // be [JSON Web Tokens](https://jwt.io/).
-        let context = builder.context().clone();
+        let blockchain = builder.blockchain().clone();
         let handler = move |request: HttpRequest| -> api::Result<u64> {
             let auth_header = request
                 .headers()
@@ -193,7 +193,7 @@ impl CounterApi {
                 return Err(api::Error::Unauthorized);
             }
 
-            let snapshot = context.snapshot();
+            let snapshot = blockchain.snapshot();
             Self::count(snapshot.as_ref())
         };
         let handler: Arc<RawHandler> = Arc::new(move |request| {


### PR DESCRIPTION
## Overview

This method removes `ApiContext` structure and replaces its usage with `Blockchain`, since their layout became the same.

**Also**, this PR reduces the visibility of the `Blockchain::into_mut` method, since it's not really clear that this method should be called only once, and it's easy to misuse it (e.g. one can try to obtain the `Fork` with that method, which is completely incorrect).
However, that doesn't affect the public interface, since this method is just a sugar for (also public) `BlockchainBuilder`.