### PR TITLE
Write proper examples for the Exonum traits derivation [ECR-3822]

### DIFF
--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -89,7 +89,7 @@ pub fn object_hash(input: TokenStream) -> TokenStream {
 ///
 /// * `#[service_dispatcher(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate (usually it's "crate" or "exonum").
+/// Prefix of the `exonum` crate (usually it's "crate" or "exonum"). By default is "exonum".
 #[proc_macro_derive(ServiceDispatcher, attributes(service_dispatcher))]
 pub fn service_dispatcher(input: TokenStream) -> TokenStream {
     service_dispatcher::impl_service_dispatcher(input)
@@ -114,7 +114,7 @@ pub fn service_dispatcher(input: TokenStream) -> TokenStream {
 ///
 /// * `#[service_factory(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate(usually "crate" or "exonum").
+/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
 ///
 /// * `#[service_factory(artifact_name = "string")]`
 ///   
@@ -138,19 +138,38 @@ pub fn service_factory(input: TokenStream) -> TokenStream {
     service_factory::impl_service_factory(input)
 }
 
-/// Mark trait as an Exonum service interface.
+/// Derives an Exonum service interface for the specified trait.
 ///
-/// TODO add more documentation.
+/// See the documentation of the Exonum crate for more information.
+///
+/// # Attributes:
+///
+/// ## Optional
+///
+/// * `#[exonum_interface(crate = "path")]`
+///
+/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
 #[proc_macro_attribute]
 pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)
 }
 
-/// Derives `From<MyError>` conversion to the `ExecutionError` for the given enum.
+/// Implements `From<MyError>` conversion to the `ExecutionError` for the given enum.
 ///
 /// Enumeration should have an explicit discriminant for each variant.
-/// Also this macro derives `Display` and `Fail` traits using documentation comments
-/// of each variant.
+/// Derives `Display` and `Fail` traits using documentation comments of each variant.
+///
+/// # Attributes:
+///
+/// ## Optional
+///
+/// * `#[execution_error(crate = "path")]`
+///
+/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
+///
+/// * `#[execution_error(kind = "runtime")]`
+///
+/// Error kind with possible values: `service`, `runtime`. By default is `service`.
 #[proc_macro_derive(IntoExecutionError, attributes(execution_error))]
 pub fn into_execution_error(input: TokenStream) -> TokenStream {
     execution_error::impl_execution_error(input)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -189,26 +189,10 @@ pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)
 }
 
-/// Derive `Into<ExecutionError>` conversion for the specified enumeration.
+/// Derives `From<MyError>` conversion to the `ExecutionError` for the given enum.
 ///
 /// Enumeration should have an explicit discriminant for each variant.
 /// Also this macro derives `Display` trait using documentation comments of each variant.
-///
-/// # Examples
-///
-/// ```ignore
-/// /// Error codes emitted by wallet transactions during execution.
-/// #[derive(Debug, IntoExecutionError)]
-/// pub enum Error {
-///     /// Content hash already exists.
-///     HashAlreadyExists = 0,
-///     /// Unable to parse service configuration.
-///     ConfigParseError = 1,
-///     /// Time service with the specified name doesn't exist.
-///     TimeServiceNotFound = 2,
-/// }
-/// ```
-///
 #[proc_macro_derive(IntoExecutionError, attributes(execution_error))]
 pub fn into_execution_error(input: TokenStream) -> TokenStream {
     execution_error::impl_execution_error(input)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -192,7 +192,8 @@ pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Derives `From<MyError>` conversion to the `ExecutionError` for the given enum.
 ///
 /// Enumeration should have an explicit discriminant for each variant.
-/// Also this macro derives `Display` trait using documentation comments of each variant.
+/// Also this macro derives `Display` and `Fail` traits using documentation comments
+/// of each variant.
 #[proc_macro_derive(IntoExecutionError, attributes(execution_error))]
 pub fn into_execution_error(input: TokenStream) -> TokenStream {
     execution_error::impl_execution_error(input)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -148,7 +148,7 @@ pub fn service_factory(input: TokenStream) -> TokenStream {
 ///
 /// * `#[exonum_interface(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate (usually "crate" or "exonum"). By default is "exonum".
+/// Prefix of the `exonum` crate has two main values - "crate" or "exonum". The default value is "exonum".
 #[proc_macro_attribute]
 pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -89,7 +89,7 @@ pub fn object_hash(input: TokenStream) -> TokenStream {
 ///
 /// * `#[service_dispatcher(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate (usually it's "crate" or "exonum"). By default is "exonum".
+/// Prefix of the `exonum` crate has two main values - "crate" or "exonum". The default value is "exonum".
 #[proc_macro_derive(ServiceDispatcher, attributes(service_dispatcher))]
 pub fn service_dispatcher(input: TokenStream) -> TokenStream {
     service_dispatcher::impl_service_dispatcher(input)
@@ -114,7 +114,7 @@ pub fn service_dispatcher(input: TokenStream) -> TokenStream {
 ///
 /// * `#[service_factory(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
+/// Prefix of the `exonum` crate has two main values - "crate" or "exonum". The default value is "exonum".
 ///
 /// * `#[service_factory(artifact_name = "string")]`
 ///   
@@ -154,10 +154,10 @@ pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)
 }
 
-/// Implements `From<MyError>` conversion to the `ExecutionError` for the given enum.
+/// Implements `From<MyError> for ExecutionError` conversion for the given enum.
 ///
-/// Enumeration should have an explicit discriminant for each variant.
-/// Derives `Display` and `Fail` traits using documentation comments of each variant.
+/// Enumeration should have an explicit discriminant for each error kind.
+/// Derives `Display` and `Fail` traits using documentation comments for each error kind.
 ///
 /// # Attributes:
 ///
@@ -165,11 +165,11 @@ pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `#[execution_error(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
+/// Prefix of the `exonum` crate has two main values - "crate" or "exonum". The default value is "exonum".
 ///
 /// * `#[execution_error(kind = "runtime")]`
 ///
-/// Error kind with possible values: `service`, `runtime`. By default is `service`.
+/// Error kind has the following values - `service`, `runtime`. The default value is `service`.
 #[proc_macro_derive(IntoExecutionError, attributes(execution_error))]
 pub fn into_execution_error(input: TokenStream) -> TokenStream {
     execution_error::impl_execution_error(input)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -133,57 +133,14 @@ pub fn service_dispatcher(input: TokenStream) -> TokenStream {
 /// * `#[service_factory(service_name = "string")]`
 ///
 /// Use the specified service name for the ServiceDispatcher derivation instead of the struct name.
-///
-///
-/// # Examples TODO Move to ServiceFactory documentation [ECR-3275]
-///
-/// Typical usage.
-/// ```ignore
-/// #[derive(ServiceFactory, ServiceDispatcher)]
-/// #[service_dispatcher(implements("MyServiceInterface"))]
-/// #[service_factory(proto_sources = "crate::proto")]
-/// pub struct MyService;
-/// ```
-///
-/// But if you have complex logic in service factory you can use custom constructor to create a
-/// new service instances.
-/// ```ignore
-/// // Imagine that you have a stateful service like this
-/// #[derive(Debug)]
-/// pub struct TimeService {
-///     /// Current time.
-///     time: Arc<dyn TimeProvider>,
-/// }
-///
-/// // You can implement service factory, but you cannot just derive `ServiceFactory`
-/// // like in example bellow.
-/// // To resolve this problem you can specify your own constructor for the service instance.
-/// #[derive(Debug, ServiceDispatcher, ServiceFactory)]
-/// #[service_dispatcher(implements("TimeServiceInterface"))]
-/// #[service_factory(
-///     proto_sources = "proto",
-///     service_constructor = "TimeServiceFactory::create_instance",
-///     service_name = "TimeService",
-/// )]
-/// pub struct TimeServiceFactory {
-///     time_provider: Arc<dyn TimeProvider>,
-/// }
-///
-/// // Arbitrary constructor implementation.
-/// impl TimeServiceFactory {
-///     fn create_instance(&self) -> Box<dyn Service> {
-///         Box::new(TimeService {
-///             time: self.time_provider.clone(),
-///         })
-///     }
-/// }
-/// ```
 #[proc_macro_derive(ServiceFactory, attributes(service_factory))]
 pub fn service_factory(input: TokenStream) -> TokenStream {
     service_factory::impl_service_factory(input)
 }
 
 /// Mark trait as an Exonum service interface.
+/// 
+/// TODO add more documentation.
 #[proc_macro_attribute]
 pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -148,7 +148,7 @@ pub fn service_factory(input: TokenStream) -> TokenStream {
 ///
 /// * `#[exonum_interface(crate = "path")]`
 ///
-/// Prefix of the `exonum` crate(usually "crate" or "exonum"). By default is "exonum".
+/// Prefix of the `exonum` crate (usually "crate" or "exonum"). By default is "exonum".
 #[proc_macro_attribute]
 pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     exonum_interface::impl_exonum_interface(attr, item)

--- a/components/derive/src/lib.rs
+++ b/components/derive/src/lib.rs
@@ -139,7 +139,7 @@ pub fn service_factory(input: TokenStream) -> TokenStream {
 }
 
 /// Mark trait as an Exonum service interface.
-/// 
+///
 /// TODO add more documentation.
 #[proc_macro_attribute]
 pub fn exonum_interface(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -119,8 +119,8 @@ impl Display for ErrorKind {
 /// deriving `IntoExecutionError` from `exonum-derive` crate.
 ///
 /// This macro implements `From<MyError>` conversion to the `ExecutionError` for the given enum.
-/// Enumeration should have an explicit discriminant for each variant.
-/// Derives `Display` and `Fail` traits using documentation comments of each variant.
+/// Enumeration should have an explicit discriminant for each error kind.
+/// Derives `Display` and `Fail` traits using documentation comments for each error kind.
 ///
 /// # Examples
 ///
@@ -129,14 +129,14 @@ impl Display for ErrorKind {
 /// ```
 /// use exonum_derive::IntoExecutionError;
 ///
-/// /// Error codes emitted by wallet transactions during execution.
+/// /// Error codes emitted by wallet transactions during execution:
 /// #[derive(Debug, IntoExecutionError)]
 /// pub enum Error {
 ///     /// Content hash already exists.
 ///     HashAlreadyExists = 0,
-///     /// Unable to parse service configuration.
+///     /// Unable to parse the service configuration.
 ///     ConfigParseError = 1,
-///     /// Time service with the specified name doesn't exist.
+///     /// Time service with the specified name does not exist.
 ///     TimeServiceNotFound = 2,
 /// }
 /// ```
@@ -150,7 +150,7 @@ impl Display for ErrorKind {
 /// #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, IntoExecutionError)]
 /// #[execution_error(kind = "runtime")]
 /// enum SampleRuntimeError {
-///     /// Incorrect information to call transaction.
+///     /// Incorrect information to call the transaction.
 ///     IncorrectCallInfo = 1,
 ///     /// Incorrect transaction payload.
 ///     IncorrectPayload = 2,

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -115,6 +115,47 @@ impl Display for ErrorKind {
 /// Therefore descriptions are mostly used for developer purposes, not for interaction of
 /// the system with users.
 ///
+/// In the most cases you may to derive conversion from your own error type into the 
+/// `ExecutionError` by using the `IntoExecutionError` macro from the `exonum-derive` crate.
+/// 
+/// This macro derives `From<MyErrorEnum>` trait for enums. Enumeration should have an explicit
+/// discriminant for each variant. Also this macro derives `Display` trait using documentation
+/// comments of each variant.
+/// 
+/// # Examples
+/// 
+/// Deriving errors in service transactions:
+/// 
+/// ```
+/// use exonum_derive::IntoExecutionError;
+///
+/// /// Error codes emitted by wallet transactions during execution.
+/// #[derive(Debug, IntoExecutionError)]
+/// pub enum Error {
+///     /// Content hash already exists.
+///     HashAlreadyExists = 0,
+///     /// Unable to parse service configuration.
+///     ConfigParseError = 1,
+///     /// Time service with the specified name doesn't exist.
+///     TimeServiceNotFound = 2,
+/// }
+/// ```
+/// 
+/// Deriving errors in runtimes:
+/// 
+/// ```
+/// use exonum_derive::IntoExecutionError;
+///
+/// // Define runtime specific errors.
+/// #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, IntoExecutionError)]
+/// #[execution_error(kind = "runtime")]
+/// enum SampleRuntimeError {
+///     /// Incorrect information to call transaction.
+///     IncorrectCallInfo = 1,
+///     /// Incorrect transaction payload.
+///     IncorrectPayload = 2,
+/// }
+/// ```
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Fail)]
 pub struct ExecutionError {
     /// The kind of error that indicates in which module and with which code the error occurred.

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -115,17 +115,17 @@ impl Display for ErrorKind {
 /// Therefore descriptions are mostly used for developer purposes, not for interaction of
 /// the system with users.
 ///
-/// In the most cases you may to derive conversion from your own error type into the 
+/// In the most cases you may to derive conversion from your own error type into the
 /// `ExecutionError` by using the `IntoExecutionError` macro from the `exonum-derive` crate.
-/// 
+///
 /// This macro derives `From<MyErrorEnum>` trait for enums. Enumeration should have an explicit
-/// discriminant for each variant. Also this macro derives `Display` trait using documentation
-/// comments of each variant.
-/// 
+/// discriminant for each variant. Also this macro derives `Display` and `Fail` traits using 
+/// documentation comments of each variant.
+///
 /// # Examples
-/// 
+///
 /// Deriving errors in service transactions:
-/// 
+///
 /// ```
 /// use exonum_derive::IntoExecutionError;
 ///
@@ -140,9 +140,9 @@ impl Display for ErrorKind {
 ///     TimeServiceNotFound = 2,
 /// }
 /// ```
-/// 
+///
 /// Deriving errors in runtimes:
-/// 
+///
 /// ```
 /// use exonum_derive::IntoExecutionError;
 ///

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -118,7 +118,7 @@ impl Display for ErrorKind {
 /// Usually you can implement conversion from your own error type to the `ExecutionError` via
 /// deriving `IntoExecutionError` from `exonum-derive` crate.
 ///
-/// This macro implements `From<MyError>` conversion to the `ExecutionError` for the given enum.
+/// This macro implements `From<MyError> for ExecutionError` conversion for the given enum.
 /// Enumeration should have an explicit discriminant for each error kind.
 /// Derives `Display` and `Fail` traits using documentation comments for each error kind.
 ///

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -115,12 +115,12 @@ impl Display for ErrorKind {
 /// Therefore descriptions are mostly used for developer purposes, not for interaction of
 /// the system with users.
 ///
-/// In the most cases you may to derive conversion from your own error type into the
-/// `ExecutionError` by using the `IntoExecutionError` macro from the `exonum-derive` crate.
+/// Usually you can implement conversion from your own error type to the `ExecutionError` via
+/// deriving `IntoExecutionError` from `exonum-derive` crate.
 ///
-/// This macro derives `From<MyErrorEnum>` trait for enums. Enumeration should have an explicit
-/// discriminant for each variant. Also this macro derives `Display` and `Fail` traits using
-/// documentation comments of each variant.
+/// This macro implements `From<MyError>` conversion to the `ExecutionError` for the given enum.
+/// Enumeration should have an explicit discriminant for each variant.
+/// Derives `Display` and `Fail` traits using documentation comments of each variant.
 ///
 /// # Examples
 ///

--- a/exonum/src/runtime/error.rs
+++ b/exonum/src/runtime/error.rs
@@ -119,7 +119,7 @@ impl Display for ErrorKind {
 /// `ExecutionError` by using the `IntoExecutionError` macro from the `exonum-derive` crate.
 ///
 /// This macro derives `From<MyErrorEnum>` trait for enums. Enumeration should have an explicit
-/// discriminant for each variant. Also this macro derives `Display` and `Fail` traits using 
+/// discriminant for each variant. Also this macro derives `Display` and `Fail` traits using
 /// documentation comments of each variant.
 ///
 /// # Examples

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -77,12 +77,13 @@
 //! // trait for each arg.
 //! #[exonum_interface]
 //! pub trait Transactions {
-//!     // You may use `ExecutionError` directly.
+//!     // Each method of trait should have signature like the following. Argument
+//!     // should implement `BinaryValue` trait.
 //!     fn create_wallet(
 //!         &self,
 //!         context: CallContext<'_>,
 //!         arg: CreateWallet,
-//!     ) -> Result<(), ExecutionError>;
+//!     ) -> Result<(), ExecutionError>; // You may use `ExecutionError` directly.
 //!     // Also you can use for error any type which implements `Into<ExecutionError>`.
 //!     fn add_point(
 //!         &self,

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -41,7 +41,8 @@
 //!     },
 //! };
 //! use exonum_derive::{
-//!     exonum_interface, BinaryValue, IntoExecutionError, ObjectHash, ServiceDispatcher, ServiceFactory
+//!     exonum_interface, BinaryValue, IntoExecutionError,
+//!     ObjectHash, ServiceDispatcher, ServiceFactory
 //! };
 //! use exonum_merkledb::Snapshot;
 //! use exonum_proto::ProtobufConvert;
@@ -64,17 +65,14 @@
 //!
 //! // You may create service-specific error types.
 //!
-//! /// Error codes emitted by wallet transactions during execution.
 //! #[derive(Debug, IntoExecutionError)]
 //! pub enum Error {
-//!     /// Point already exists.
 //!     PointAlreadyExists = 0,
-//!     /// Wallet already exists.
 //!     WalletAlreadyExists = 1,
 //! }
 //!
-//! // Define the transactions interface for your service by creating a trait with the following
-//! // attribute and method signatures.
+//! // Define the transactions interface for your service by creating a trait with
+//! // the following attribute and method signatures.
 //! #[exonum_interface]
 //! pub trait Transactions {
 //!     // You may use `ExecutionError` directly.
@@ -84,20 +82,22 @@
 //!         arg: CreateWallet,
 //!     ) -> Result<(), ExecutionError>;
 //!     // Also you can use for error any type which implements `Into<ExecutionError>`.
-//!     fn add_point(&self, context: CallContext<'_>, arg: Point) -> Result<(), Error>;
+//!     fn add_point(
+//!         &self,
+//!         context: CallContext<'_>,
+//!         arg: Point,
+//!     ) -> Result<(), Error>;
 //! }
 //!
 //! // In order for a service to process transactions, you have to implement the
 //! // `ServiceDispatcher` trait, which can be derived using the corresponding macro.
-//! //
 //! // To explain runtime how to create instances of this service you have to implement
 //! // `ServiceFactory` trait by using the `ServiceFactory` derive macro.
-//! //
 //! #[derive(Debug, ServiceDispatcher, ServiceFactory)]
 //! // Declare that a service implements a `Transactions` interface that was presented above.
 //! #[service_dispatcher(implements("Transactions"))]
-//! // By default macro uses crate name and version to provide artifact ID for this service factory.
-//! // You should only provide path to the generated Protobuf schema.
+//! // By default macro uses crate name and version to provide artifact ID for this
+//! // service factory. You should only provide path to the generated Protobuf schema.
 //! #[service_factory(proto_sources = "exonum::proto::schema")]
 //! pub struct PointService;
 //!
@@ -113,7 +113,11 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn add_point(&self, _context: CallContext<'_>, _arg: Point) -> Result<(), Error> {
+//!     fn add_point(
+//!         &self,
+//!         _context: CallContext<'_>,
+//!         _arg: Point
+//!     ) -> Result<(), Error> {
 //!         // Some business logic...
 //!         Ok(())
 //!     }

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -30,7 +30,7 @@
 //!
 //! # Examples
 //!
-//! ## Minimum complete example of an Exonum service definition.
+//! ## Minimal complete example of an Exonum service definition.
 //!
 //! ```
 //! use exonum::{
@@ -128,6 +128,56 @@
 //!         Vec::new()
 //!     }
 //! }
+//! ```
+//!
+//! ## Stateful service definition
+//!
+//! Beware of stateful services in production, use this functionality only for debugging and
+//! prototyping.
+//!
+//! ```
+//! use exonum::runtime::{rust::Service, BlockchainData};
+//! use exonum_crypto::Hash;
+//! use exonum_derive::{exonum_interface, ServiceDispatcher, ServiceFactory};
+//! use exonum_merkledb::Snapshot;
+//!
+//! #  #[exonum_interface]
+//! #  pub trait Transactions {}
+//!
+//! // If your service has a state, for example for debugging purposes, then you can
+//! // use a separate structure for the service.
+//!
+//! #[derive(Debug, Default, ServiceDispatcher)]
+//! #[service_dispatcher(implements("Transactions"))]
+//! pub struct StatefulService {
+//!     state: u64,
+//! }
+//!
+//! #[derive(Debug, ServiceFactory)]
+//! #[service_factory(
+//!     // In this case you have to specify service constructor explicitly.
+//!     service_constructor = "Self::new_instance",
+//!     proto_sources = "exonum::proto::schema",
+//!     // To specify artifact name and/or version explicitly you have to use the
+//!     // following attributes.
+//!     artifact_name = "stateful",
+//!     artifact_version = "1.0.0",
+//! )]
+//! pub struct StatefulServiceFactory;
+//!
+//! impl StatefulServiceFactory {
+//!     fn new_instance(&self) -> Box<dyn Service> {
+//!         Box::new(StatefulService::default())
+//!     }
+//! }
+//!
+//! # impl Transactions for StatefulService {}
+//! #
+//! #  impl Service for StatefulService {
+//! #      fn state_hash(&self, _data: BlockchainData<&dyn Snapshot>) -> Vec<Hash> {
+//! #          Vec::new()
+//! #      }
+//! #  }
 //! ```
 //!
 //! [ServiceFactory]: trait.ServiceFactory.html

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -71,20 +71,20 @@
 //!     WalletAlreadyExists = 1,
 //! }
 //!
-//! // Define the transactions interface for your service by creating a trait with
+//! // Define the transaction interface for your service by creating a trait with
 //! // the following attribute and method signatures.
 //! // This attribute implements `Interface` trait for this trait and `Transaction`
-//! // trait for each arg.
+//! // trait for each argument.
 //! #[exonum_interface]
 //! pub trait Transactions {
-//!     // Each method of trait should have signature like the following. Argument
-//!     // should implement `BinaryValue` trait.
+//!     // Each method of the trait should have a signature of the following format. The argument
+//!     // should implement the `BinaryValue` trait.
 //!     fn create_wallet(
 //!         &self,
 //!         context: CallContext<'_>,
 //!         arg: CreateWallet,
 //!     ) -> Result<(), ExecutionError>; // You may use `ExecutionError` directly.
-//!     // Also you can use for error any type which implements `Into<ExecutionError>`.
+//!     // Also you can use any type which implements `Into<ExecutionError>` for the error.
 //!     fn add_point(
 //!         &self,
 //!         context: CallContext<'_>,
@@ -92,19 +92,19 @@
 //!     ) -> Result<(), Error>;
 //! }
 //!
-//! // In order for a service to process transactions, you have to implement the
+//! // In order a service could process transactions, you have to implement the
 //! // `ServiceDispatcher` trait, which can be derived using the corresponding macro.
-//! // To explain runtime how to create instances of this service you have to implement
-//! // `ServiceFactory` trait by using the `ServiceFactory` derive macro.
+//! // To explain to the runtime how to create instances of this service, you have to implement
+//! // the `ServiceFactory` trait by using the `ServiceFactory` derive macro.
 //! #[derive(Debug, ServiceDispatcher, ServiceFactory)]
-//! // Declare that a service implements a `Transactions` interface that was presented above.
+//! // Declare that the service implements the `Transactions` interface that was presented above.
 //! #[service_dispatcher(implements("Transactions"))]
-//! // By default macro uses crate name and version to provide artifact ID for this
-//! // service factory. You should only provide path to the generated Protobuf schema.
+//! // By default the macro uses the crate name and version to provide an artifact ID for this
+//! // service factory. You should only provide a path to the generated Protobuf schema.
 //! #[service_factory(proto_sources = "exonum::proto::schema")]
 //! pub struct PointService;
 //!
-//! // Don't forget to implement the `Transactions` and `Service` traits for our service.
+//! // Do not forget to implement the `Transactions` and `Service` traits for the service.
 //!
 //! impl Transactions for PointService {
 //!     fn create_wallet(
@@ -133,7 +133,7 @@
 //! }
 //! ```
 //!
-//! ## Stateful service definition
+//! ## Stateful Service Definition
 //!
 //! Beware of stateful services in production, use this functionality only for debugging and
 //! prototyping.
@@ -147,7 +147,7 @@
 //! #  #[exonum_interface]
 //! #  pub trait Transactions {}
 //!
-//! // If your service has a state, for example for debugging purposes, then you can
+//! // If your service has a state, for example, for debugging purposes, then you can
 //! // use a separate structure for the service.
 //!
 //! #[derive(Debug, Default, ServiceDispatcher)]
@@ -158,10 +158,10 @@
 //!
 //! #[derive(Debug, ServiceFactory)]
 //! #[service_factory(
-//!     // In this case you have to specify service constructor explicitly.
+//!     // In this case you have to specify the service constructor explicitly.
 //!     service_constructor = "Self::new_instance",
 //!     proto_sources = "exonum::proto::schema",
-//!     // To specify artifact name and/or version explicitly you have to use the
+//!     // To specify the artifact name and/or version explicitly you have to use the
 //!     // following attributes.
 //!     artifact_name = "stateful",
 //!     artifact_version = "1.0.0",

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -73,6 +73,8 @@
 //!
 //! // Define the transactions interface for your service by creating a trait with
 //! // the following attribute and method signatures.
+//! // This attribute implements `Interface` trait for this trait and `Transaction`
+//! // trait for each arg.
 //! #[exonum_interface]
 //! pub trait Transactions {
 //!     // You may use `ExecutionError` directly.

--- a/exonum/src/runtime/rust/service.rs
+++ b/exonum/src/runtime/rust/service.rs
@@ -34,7 +34,8 @@ use super::{ArtifactProtobufSpec, BlockchainData, CallContext, RustArtifactId};
 /// Describes how the service instance should dispatch specific method calls
 /// with consideration of the interface where the method belongs.
 ///
-/// Usually, `ServiceDispatcher` can be derived using the `ServiceDispatcher` macro.
+/// Usually, `ServiceDispatcher` can be derived using the
+/// [`ServiceDispatcher`](index.html#examples) macro.
 pub trait ServiceDispatcher: Send {
     /// Dispatches the interface method call within the specified context.
     fn call(
@@ -111,7 +112,8 @@ pub trait Service: ServiceDispatcher + Debug + 'static {
 
 /// Describes a service instance factory for the specific Rust artifact.
 ///
-/// Usually, `ServiceFactory` can be derived using the `ServiceFactory` macro.
+/// Usually, `ServiceFactory` can be derived using the
+/// [`ServiceFactory`](index.html#examples) macro.
 pub trait ServiceFactory: Send + Debug + 'static {
     /// Returns the unique artifact identifier corresponding to the factory.
     fn artifact_id(&self) -> RustArtifactId;
@@ -130,7 +132,7 @@ where
     }
 }
 
-/// Transaction specification for a specific service interface.
+/// Transaction specification for a specific service interface method.
 pub trait Transaction<Svc: ?Sized>: BinaryValue {
     /// Identifier of the service interface required for the call.
     #[doc(hidden)]


### PR DESCRIPTION
At the moment, examples are situated in the `exonum-derive` crate, therefore there is no way to test them. This PR moves examples to the documentations of the corresponding traits: 

- [x] Example for `IntoExecutionError` now is part of `ExecutionError` documentation.
- [x] Example for `ServiceFactory`.
- [x] Example for the `exonum_interface`.
- [x] Example for the `ServiceDispatcher`.
