### PR TITLE
Encapsulate Blockchain fields [ECR-3222]

### DIFF
--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -70,11 +70,9 @@ pub type TransactionMessage = Verified<AnyTx>;
 /// [`BlockchainMut`]: struct.BlockchainMut.html
 #[derive(Debug, Clone)]
 pub struct Blockchain {
-    pub(crate) db: Arc<dyn Database>,
-    // FIXME fix visibility [ECR-3222]
-    #[doc(hidden)]
-    pub service_keypair: (PublicKey, SecretKey),
     pub(crate) api_sender: ApiSender,
+    db: Arc<dyn Database>,
+    service_keypair: (PublicKey, SecretKey),
 }
 
 impl Blockchain {

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -19,12 +19,13 @@ use exonum::{
     crypto::{self, Hash, PublicKey, SecretKey},
     helpers::generate_testnet_config,
     messages::Verified,
+    node::ApiSender,
     runtime::{
         rust::{CallContext, Service},
         AnyTx, BlockchainData, InstanceId,
     },
 };
-use exonum_merkledb::{ObjectHash, Snapshot};
+use exonum_merkledb::{ObjectHash, Snapshot, TemporaryDB};
 use exonum_proto::ProtobufConvert;
 use futures::sync::mpsc;
 
@@ -118,9 +119,12 @@ pub fn consensus_keys() -> (PublicKey, SecretKey) {
 
 /// Creates a blockchain with no blocks.
 pub fn create_blockchain() -> BlockchainMut {
-    let mut blockchain = Blockchain::build_for_tests();
     let config = generate_testnet_config(1, 0)[0].clone();
-    blockchain.service_keypair = config.service_keypair();
+    let blockchain = Blockchain::new(
+        TemporaryDB::new(),
+        config.service_keypair(),
+        ApiSender::closed(),
+    );
 
     let services =
         vec![InstanceCollection::new(MyService).with_instance(SERVICE_ID, "my-service", ())];

--- a/test-suite/testkit/tests/service_hooks/main.rs
+++ b/test-suite/testkit/tests/service_hooks/main.rs
@@ -47,7 +47,8 @@ fn test_after_commit() {
 
         assert_eq!(service.counter() as u64, i);
 
-        let keypair = &testkit.blockchain().service_keypair;
+        let blockchain = testkit.blockchain();
+        let keypair = blockchain.service_keypair();
         let tx = TxAfterCommit::new(Height(i)).sign(SERVICE_ID, keypair.0, &keypair.1);
         assert!(testkit.is_tx_in_pool(&tx.object_hash()));
     }
@@ -89,7 +90,8 @@ fn restart_testkit() {
     assert_eq!(testkit.network().validators().len(), 3);
     let transactions_are_committed = (1..=8)
         .map(|i| {
-            let keypair = &testkit.blockchain().service_keypair;
+            let blockchain = testkit.blockchain();
+            let keypair = blockchain.service_keypair();
             TxAfterCommit::new(Height(i))
                 .sign(SERVICE_ID, keypair.0, &keypair.1)
                 .object_hash()
@@ -111,7 +113,8 @@ fn tx_pool_is_retained_on_restart() {
 
     let tx_hashes: Vec<_> = (100..105)
         .map(|i| {
-            let keypair = &testkit.blockchain().service_keypair;
+            let blockchain = testkit.blockchain();
+            let keypair = blockchain.service_keypair();
             let message = TxAfterCommit::new(Height(i)).sign(SERVICE_ID, keypair.0, &keypair.1);
             let tx_hash = message.object_hash();
             testkit.add_tx(message);


### PR DESCRIPTION
`api_sender` is used by `sandbox` and it seems that there is no easy way to make this field private too. However, the visibility is `pub(crate)` anyway, so I guess it's no big deal.