### PR TITLE
Remove isolate method [ECR-3820]

### DIFF
--- a/exonum/src/runtime/rust/call_context.rs
+++ b/exonum/src/runtime/rust/call_context.rs
@@ -3,7 +3,6 @@ use exonum_merkledb::{access::Prefixed, BinaryValue, Fork};
 use crate::blockchain::Schema as CoreSchema;
 use crate::runtime::{
     dispatcher::{Dispatcher, Error as DispatcherError},
-    error::catch_panic,
     ArtifactId, BlockchainData, CallInfo, Caller, ExecutionContext, ExecutionError,
     InstanceDescriptor, InstanceId, InstanceQuery, InstanceSpec, MethodId, SUPERVISOR_INSTANCE_ID,
 };
@@ -92,47 +91,6 @@ impl<'a> CallContext<'a> {
             inner: self.inner.child_context(self.instance.id),
             instance: descriptor,
         })
-    }
-
-    /// Isolates execution of the provided closure.
-    ///
-    /// This method should be used with extreme care, since it subverts the usual rules
-    /// of transaction roll-back provided by Exonum. Namely:
-    ///
-    /// - If the execution of the closure is successful, all changes to the blockchain state
-    ///   preceding the `isolate()` call are permanently committed. These changes **will not**
-    ///   be rolled back if the following transaction code exits with an error.
-    /// - If the execution of the closure errors, all changes to the blockchain state
-    ///   preceding the `isolate()` call are rolled back right away. That is, they are not
-    ///   persisted even if the following transaction code executes successfully.
-    ///
-    /// If there are several `isolate()` calls within the same execution context,
-    /// commitment / rollback rules are applied to changes since the last call.
-    ///
-    /// For these reasons, it is strongly advised to:
-    ///
-    /// - Make `isolate()` call(s) the last logic executed by a transaction, or at least
-    ///   not have failure cases after the call(s).
-    /// - Propagate errors returned by this method as a result of the transaction execution.
-    // TODO: Finalize interface and test [ECR-3740]
-    #[doc(hidden)]
-    pub fn isolate(
-        &mut self,
-        f: impl FnOnce(CallContext<'_>) -> Result<(), ExecutionError>,
-    ) -> Result<(), ExecutionError> {
-        let result = catch_panic(|| f(self.reborrow()));
-        match result {
-            Ok(()) => self.inner.fork.flush(),
-            Err(_) => self.inner.fork.rollback(),
-        }
-        result
-    }
-
-    fn reborrow(&mut self) -> CallContext<'_> {
-        CallContext {
-            inner: self.inner.reborrow(),
-            instance: self.instance,
-        }
     }
 
     /// Provides writeable access to core schema.

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -82,18 +82,16 @@ fn update_configs(context: &mut CallContext<'_>, changes: Vec<ConfigChange>) -> 
 
                 // `ConfigureCall` interface was checked during the config verifying
                 // so panic on `expect` here is unlikely and means a bug in the implementation.
-                let configure_result = context
+                context
                     .interface::<ConfigureCall<'_>>(config.instance_id)
                     .expect("Obtaining Configure interface failed")
-                    .apply_config(config.params.clone());
-
-                if let Err(e) = configure_result {
-                    log::error!(
-                        "An error occurred while applying service configuration. {}",
-                        e
-                    );
-                    return Err(());
-                }
+                    .apply_config(config.params.clone())
+                    .map_err(|e| {
+                        log::error!(
+                            "An error occurred while applying service configuration. {}",
+                            e
+                        );
+                    })?;
             }
 
             ConfigChange::StartService(start_service) => {

--- a/services/supervisor/tests/supervisor/inc.rs
+++ b/services/supervisor/tests/supervisor/inc.rs
@@ -147,8 +147,12 @@ impl Configure for IncService {
             .ok_or(DispatcherError::UnauthorizedCaller)?;
 
         match params.as_ref() {
-            "error" => Err(DispatcherError::malformed_arguments("Error!")).map_err(From::from),
-            "panic" => panic!("Aaaa!"),
+            "error" => {
+                let error =
+                    DispatcherError::malformed_arguments("IncService: Configure error request");
+                return Err(error.into());
+            }
+            "panic" => panic!("IncService: Configure panic request"),
             _ => Ok(()),
         }
     }
@@ -169,9 +173,11 @@ impl Configure for IncService {
 
         match params.as_str() {
             "apply_error" => {
-                Err(DispatcherError::malformed_arguments("Error!")).map_err(From::from)
+                let error =
+                    DispatcherError::malformed_arguments("IncService: Configure error request");
+                return Err(error.into());
             }
-            "apply_panic" => panic!("Aaaa!"),
+            "apply_panic" => panic!("IncService: Configure panic request"),
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
We either apply the config with all the changes, or don't apply it at all.
So the `isolate` method is not required anymore.

Slippery moments:
- We still have to panic to rollback changes (will be fixed once we'll be able to return an error in `before_commit`).
- If panic/error occurs during config applying, the proposal is not removed (well, in fact it's removed but then rolled back). However I've added a check in the config proposal tx for it, so it's not a big problem I guess.