### PR TITLE
Use code coverage util from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,16 +111,16 @@ jobs:
     install:
     - |
       if [ ! -f "$HOME/.kcov/bin/kcov" ]; then
-        wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz
-        tar xzf v36.tar.gz
-        cd kcov-36
+        wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
+        tar xzf master.tar.gz
+        cd kcov-master
         mkdir build
         cd build
         cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.kcov -DCMAKE_BUILD_TYPE=Release
         make -j2
         make install
         cd ../..
-        rm -rf kcov-36
+        rm -rf kcov-master
       fi
     script:
     - cargo test --no-run


### PR DESCRIPTION
## Overview

For using latest version of kcov.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
