### PR TITLE
Remove unused import

### DIFF
--- a/exonum/src/proto/schema/exonum/runtime.proto
+++ b/exonum/src/proto/schema/exonum/runtime.proto
@@ -18,7 +18,6 @@ package exonum.runtime;
 
 option java_package = "com.exonum.core.messages";
 
-import "blockchain.proto";
 import "google/protobuf/empty.proto";
 
 // Unique service transaction identifier.


### PR DESCRIPTION
## Overview

Resolves the compile warning:
[WARNING] PROTOC: runtime.proto:21:1: warning: Import blockchain.proto but not used.


<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
