### PR TITLE
Explicit panic invocation in from_access

### DIFF
--- a/components/merkledb/src/access/extensions.rs
+++ b/components/merkledb/src/access/extensions.rs
@@ -46,7 +46,9 @@ pub trait AccessExt: Access {
         I: FromAccess<Self>,
     {
         // We know that `Group` implementation of `Restore` never fails
-        Group::from_access(self, IndexAddress::with_root(name)).unwrap()
+        Group::from_access(self, IndexAddress::with_root(name)).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets an entry index with the specified address.
@@ -59,7 +61,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        Entry::from_access(self, addr.into()).unwrap()
+        Entry::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a list index with the specified address.
@@ -72,7 +76,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ListIndex::from_access(self, addr.into()).unwrap()
+        ListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a map index with the specified address.
@@ -86,7 +92,9 @@ pub trait AccessExt: Access {
         K: BinaryKey,
         V: BinaryValue,
     {
-        MapIndex::from_access(self, addr.into()).unwrap()
+        MapIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a Merkelized list index with the specified address.
@@ -99,7 +107,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ProofListIndex::from_access(self, addr.into()).unwrap()
+        ProofListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a Merkelized map index with the specified address.
@@ -113,7 +123,9 @@ pub trait AccessExt: Access {
         K: BinaryKey + ObjectHash,
         V: BinaryValue,
     {
-        ProofMapIndex::from_access(self, addr.into()).unwrap()
+        ProofMapIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Variant of the proof map with keys that can be mapped directly to `ProofPath`.
@@ -128,7 +140,9 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         Raw: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into()).unwrap()
+        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a generic proof map. Requires explicit `KeyMode` to be specified.
@@ -162,7 +176,9 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         KeyMode: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into()).unwrap()
+        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a sparse list index with the specified address.
@@ -175,7 +191,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        SparseListIndex::from_access(self, addr.into()).unwrap()
+        SparseListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a key set index with the specified address.
@@ -188,7 +206,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryKey,
     {
-        KeySetIndex::from_access(self, addr.into()).unwrap()
+        KeySetIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Gets a value set index with the specified address.
@@ -201,7 +221,9 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue + ObjectHash,
     {
-        ValueSetIndex::from_access(self, addr.into()).unwrap()
+        ValueSetIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 
     /// Touches an index at the specified address, asserting that it has a specific type.

--- a/components/merkledb/src/access/extensions.rs
+++ b/components/merkledb/src/access/extensions.rs
@@ -46,9 +46,7 @@ pub trait AccessExt: Access {
         I: FromAccess<Self>,
     {
         // We know that `Group` implementation of `Restore` never fails
-        Group::from_access(self, IndexAddress::with_root(name)).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        Group::from_access(self, IndexAddress::with_root(name)).expect("MerkleDB error")
     }
 
     /// Gets an entry index with the specified address.
@@ -61,9 +59,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        Entry::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        Entry::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a list index with the specified address.
@@ -76,9 +72,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ListIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a map index with the specified address.
@@ -92,9 +86,7 @@ pub trait AccessExt: Access {
         K: BinaryKey,
         V: BinaryValue,
     {
-        MapIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        MapIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a Merkelized list index with the specified address.
@@ -107,9 +99,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ProofListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ProofListIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a Merkelized map index with the specified address.
@@ -123,9 +113,7 @@ pub trait AccessExt: Access {
         K: BinaryKey + ObjectHash,
         V: BinaryValue,
     {
-        ProofMapIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ProofMapIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Variant of the proof map with keys that can be mapped directly to `ProofPath`.
@@ -140,9 +128,7 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         Raw: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a generic proof map. Requires explicit `KeyMode` to be specified.
@@ -176,9 +162,7 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         KeyMode: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a sparse list index with the specified address.
@@ -191,9 +175,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        SparseListIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        SparseListIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a key set index with the specified address.
@@ -206,9 +188,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryKey,
     {
-        KeySetIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        KeySetIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Gets a value set index with the specified address.
@@ -221,9 +201,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue + ObjectHash,
     {
-        ValueSetIndex::from_access(self, addr.into()).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        ValueSetIndex::from_access(self, addr.into()).expect("MerkleDB error")
     }
 
     /// Touches an index at the specified address, asserting that it has a specific type.

--- a/components/merkledb/src/access/extensions.rs
+++ b/components/merkledb/src/access/extensions.rs
@@ -46,7 +46,8 @@ pub trait AccessExt: Access {
         I: FromAccess<Self>,
     {
         // We know that `Group` implementation of `Restore` never fails
-        Group::from_access(self, IndexAddress::with_root(name)).expect("MerkleDB error")
+        Group::from_access(self, IndexAddress::with_root(name))
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets an entry index with the specified address.
@@ -59,7 +60,7 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        Entry::from_access(self, addr.into()).expect("MerkleDB error")
+        Entry::from_access(self, addr.into()).unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a list index with the specified address.
@@ -72,7 +73,8 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ListIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        ListIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a map index with the specified address.
@@ -86,7 +88,7 @@ pub trait AccessExt: Access {
         K: BinaryKey,
         V: BinaryValue,
     {
-        MapIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        MapIndex::from_access(self, addr.into()).unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a Merkelized list index with the specified address.
@@ -99,7 +101,8 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        ProofListIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        ProofListIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a Merkelized map index with the specified address.
@@ -113,7 +116,8 @@ pub trait AccessExt: Access {
         K: BinaryKey + ObjectHash,
         V: BinaryValue,
     {
-        ProofMapIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        ProofMapIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Variant of the proof map with keys that can be mapped directly to `ProofPath`.
@@ -128,7 +132,8 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         Raw: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into()).expect("MerkleDB error")
+        ProofMapIndex::<_, _, _, Raw>::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a generic proof map. Requires explicit `KeyMode` to be specified.
@@ -162,7 +167,8 @@ pub trait AccessExt: Access {
         V: BinaryValue,
         KeyMode: ToProofPath<K>,
     {
-        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into()).expect("MerkleDB error")
+        ProofMapIndex::<_, _, _, KeyMode>::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a sparse list index with the specified address.
@@ -175,7 +181,8 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue,
     {
-        SparseListIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        SparseListIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a key set index with the specified address.
@@ -188,7 +195,8 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryKey,
     {
-        KeySetIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        KeySetIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Gets a value set index with the specified address.
@@ -201,7 +209,8 @@ pub trait AccessExt: Access {
         I: Into<IndexAddress>,
         V: BinaryValue + ObjectHash,
     {
-        ValueSetIndex::from_access(self, addr.into()).expect("MerkleDB error")
+        ValueSetIndex::from_access(self, addr.into())
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Touches an index at the specified address, asserting that it has a specific type.

--- a/components/merkledb/src/group.rs
+++ b/components/merkledb/src/group.rs
@@ -101,7 +101,8 @@ where
     /// If the index is present and has a wrong type.
     pub fn get(&self, key: &K) -> I {
         let addr = self.prefix.clone().append_bytes(key);
-        I::from_access(self.access.clone(), addr).expect("MerkleDB error")
+        I::from_access(self.access.clone(), addr)
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 }
 

--- a/components/merkledb/src/group.rs
+++ b/components/merkledb/src/group.rs
@@ -101,9 +101,7 @@ where
     /// If the index is present and has a wrong type.
     pub fn get(&self, key: &K) -> I {
         let addr = self.prefix.clone().append_bytes(key);
-        I::from_access(self.access.clone(), addr).unwrap_or_else(|e| {
-            panic!("MerkleDB error: {}", e);
-        })
+        I::from_access(self.access.clone(), addr).expect("MerkleDB error")
     }
 }
 

--- a/components/merkledb/src/group.rs
+++ b/components/merkledb/src/group.rs
@@ -101,7 +101,9 @@ where
     /// If the index is present and has a wrong type.
     pub fn get(&self, key: &K) -> I {
         let addr = self.prefix.clone().append_bytes(key);
-        I::from_access(self.access.clone(), addr).unwrap()
+        I::from_access(self.access.clone(), addr).unwrap_or_else(|e| {
+            panic!("MerkleDB error: {}", e);
+        })
     }
 }
 

--- a/components/merkledb/src/lazy.rs
+++ b/components/merkledb/src/lazy.rs
@@ -68,7 +68,8 @@ where
     ///
     /// Panics if the object cannot be restored.
     pub fn get(&self) -> I {
-        self.try_get().unwrap()
+        self.try_get()
+            .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
     }
 
     /// Tries to restore the object from the database.


### PR DESCRIPTION
Invoke `panic!` to make errors more verbose.