### PR TITLE
Update travis config to use exonum-launcher from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,12 +146,17 @@ jobs:
   # Integration tests.
   - name: integration-tests
     install:
-    - python3 -m venv env
-    - source env/bin/activate
+    - python3 -m venv .venv
+    - source .venv/bin/activate
     - pip3 install pip --upgrade
-    - pip3 install -e $TRAVIS_BUILD_DIR/test-suite/exonum-py-tests
-    - pip3 uninstall -y protobuf
-    - pip3 install --no-binary=protobuf protobuf
+    # Clone exonum-launcher to get a current master instead of release version.
+    - git clone https://github.com/exonum/exonum-launcher.git .venv/exonum-launcher
+    # Install dependencies from github-provided exonum-launcher (so we can get latest changes without release).
+    - pip3 install -r .venv/exonum-launcher/requirements.txt
+    # Install exonum-launcher itself from the cloned repo as well.
+    - pip3 install -e .venv/exonum-launcher
+    # Install integration tests.
+    - pip3 install -e $TRAVIS_BUILD_DIR/test-suite/exonum-py-tests --no-binary=protobuf protobuf
     - nvm install 8 && nvm use 8
     - cd $TRAVIS_BUILD_DIR/test-suite/testkit/server && npm install && cd $TRAVIS_BUILD_DIR
     - cargo install --path $TRAVIS_BUILD_DIR/examples/cryptocurrency-advanced/backend --force
@@ -159,7 +164,7 @@ jobs:
     - python3 -m exonum_tests -v
     after_script:
     - deactivate
-    - rm -rf env
+    - rm -rf .venv
     # TODO Add stage for integration tests instead of this ad-hoc implementation. [ECR-3308]
     # - cd $TRAVIS_BUILD_DIR/examples/cryptocurrency/examples && ./test.sh
     # - cd $TRAVIS_BUILD_DIR/examples/cryptocurrency/examples && ./test.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
     - pkg-config
     - powershell
     - protobuf-compiler
+    - python3-venv
     - unzip
     - zlib1g-dev
 
@@ -144,24 +145,18 @@ jobs:
 
   # Integration tests.
   - name: integration-tests
-    before_install:
-    - sudo add-apt-repository -y ppa:deadsnakes/ppa
-    - sudo apt-get update
-    - sudo apt-get install -y python3.6 python3-pip python3-venv
-    - sccache -V | grep $SCCACHE_VERS || cargo install sccache --vers $SCCACHE_VERS --force
-    - export RUSTC_WRAPPER=sccache
     install:
-    - python3.6 -m venv env
+    - python3 -m venv env
     - source env/bin/activate
-    - pip install pip --upgrade
-    - pip install -e $TRAVIS_BUILD_DIR/test-suite/exonum-py-tests
-    - pip uninstall -y protobuf
-    - pip install --no-binary=protobuf protobuf
+    - pip3 install pip --upgrade
+    - pip3 install -e $TRAVIS_BUILD_DIR/test-suite/exonum-py-tests
+    - pip3 uninstall -y protobuf
+    - pip3 install --no-binary=protobuf protobuf
     - nvm install 8 && nvm use 8
     - cd $TRAVIS_BUILD_DIR/test-suite/testkit/server && npm install && cd $TRAVIS_BUILD_DIR
     - cargo install --path $TRAVIS_BUILD_DIR/examples/cryptocurrency-advanced/backend --force
     script:
-    - python3.6 -m exonum_tests
+    - python3 -m exonum_tests -v
     after_script:
     - deactivate
     - rm -rf env

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -208,6 +208,7 @@ uuids
 validator
 validator's
 validators
+venv
 walkdir
 websockets
 whitelisted

--- a/exonum/src/runtime/rust/api.rs
+++ b/exonum/src/runtime/rust/api.rs
@@ -16,6 +16,7 @@
 
 pub use crate::api::{Error, FutureResult, Result};
 
+use exonum_crypto::{PublicKey, SecretKey};
 use exonum_merkledb::{access::Prefixed, Snapshot};
 use futures::IntoFuture;
 use serde::{de::DeserializeOwned, Serialize};
@@ -60,6 +61,11 @@ impl<'a> ServiceApiState<'a> {
     /// Returns readonly access to the data of the executing service.
     pub fn service_data(&'a self) -> Prefixed<&dyn Snapshot> {
         self.data().for_executing_service()
+    }
+
+    /// Returns the service keypair of the node.
+    pub fn service_keypair(&self) -> &(PublicKey, SecretKey) {
+        self.broadcaster.keypair()
     }
 
     /// Returns information about the executing service.

--- a/test-suite/exonum-py-tests/README.md
+++ b/test-suite/exonum-py-tests/README.md
@@ -16,7 +16,8 @@ python3 -m venv .venv
 source .venv/bin/activate
 git clone https://github.com/exonum/exonum-launcher.git .venv/exonum-launcher
 pip install pip --upgrade
-# Install dependencies from github-provided exonum-launcher (so we can get latest changes without release).
+# Install dependencies from github-provided exonum-launcher
+# (so we can get latest changes without release).
 pip install -r .venv/exonum-launcher/requirements.txt
 # Install exonum-launcher itself from the cloned repository as well.
 pip install -e .venv/exonum-launcher

--- a/test-suite/exonum-py-tests/README.md
+++ b/test-suite/exonum-py-tests/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/exonum/exonum-launcher.git .venv/exonum-launcher
 pip install pip --upgrade
 # Install dependencies from github-provided exonum-launcher (so we can get latest changes without release).
 pip install -r .venv/exonum-launcher/requirements.txt
-# Install exonum-launcher itself from the cloned repo as well.
+# Install exonum-launcher itself from the cloned repository as well.
 pip install -e .venv/exonum-launcher
 # Install integration tests.
 pip install -e test-suite/exonum-py-tests --no-binary=protobuf protobuf

--- a/test-suite/exonum-py-tests/README.md
+++ b/test-suite/exonum-py-tests/README.md
@@ -8,12 +8,23 @@ and tests can be found in [`exonum_tests`](exonum_tests) directory.
 
 ## Usage
 
-Install the package (`exonum-py-tests` here stands for path
+Install the package (`test-suite/exonum-py-tests` here stands for path
 to the `exonum-py-tests` directory, not the package name):
 
 ```sh
-pip install -e exonum-py-tests
+python3 -m venv .venv
+source .venv/bin/activate
+git clone https://github.com/exonum/exonum-launcher.git .venv/exonum-launcher
+pip install pip --upgrade
+# Install dependencies from github-provided exonum-launcher (so we can get latest changes without release).
+pip install -r .venv/exonum-launcher/requirements.txt
+# Install exonum-launcher itself from the cloned repo as well.
+pip install -e .venv/exonum-launcher
+# Install integration tests.
+pip install -e test-suite/exonum-py-tests --no-binary=protobuf protobuf
 ```
+
+Also ensure that you have freshly installed `cryptocurrency-advanced` example.
 
 Run tests:
 


### PR DESCRIPTION
This PR makes dependencies for `exonum-py-tests` be installed on `travis` from `github` (so we can easily update them without releases).

**Note:** Integrational tests will probably fail until https://github.com/exonum/exonum-python-client/pull/45 and https://github.com/exonum/exonum-launcher/pull/32 will be merged.