### PR TITLE
Use horizontal derives

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+merge_derives = false

--- a/examples/cryptocurrency-advanced/backend/src/transactions.rs
+++ b/examples/cryptocurrency-advanced/backend/src/transactions.rs
@@ -48,7 +48,8 @@ pub enum Error {
 }
 
 /// Transfer `amount` of the currency from one wallet to another.
-#[derive(Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Transfer", serde_pb_convert)]
 pub struct Transfer {
     /// `PublicKey` of receiver's wallet.
@@ -62,7 +63,9 @@ pub struct Transfer {
 }
 
 /// Issue `amount` of the currency to the `wallet`.
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Issue")]
 pub struct Issue {
     /// Issued amount of currency.
@@ -75,7 +78,9 @@ pub struct Issue {
 
 /// Create wallet with the given `name`.
 #[protobuf_convert(source = "proto::CreateWallet")]
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 pub struct CreateWallet {
     /// Name of the new wallet.
     pub name: String,

--- a/examples/cryptocurrency/src/lib.rs
+++ b/examples/cryptocurrency/src/lib.rs
@@ -50,7 +50,9 @@ pub mod schema {
     //
     // [1]: https://exonum.com/doc/version/latest/architecture/serialization
     /// Wallet struct used to persist data within the service.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::Wallet")]
     pub struct Wallet {
         /// Public key of the wallet owner.
@@ -102,7 +104,9 @@ pub mod transactions {
     use exonum_proto::ProtobufConvert;
 
     /// Service configuration parameters.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::Config")]
     pub struct Config;
 
@@ -110,7 +114,9 @@ pub mod transactions {
     ///
     /// See [the `Transaction` trait implementation](#impl-Transaction) for details how
     /// `TxCreateWallet` transactions are processed.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::TxCreateWallet")]
     pub struct CreateWallet {
         /// UTF-8 string with the owner's name.
@@ -122,7 +128,9 @@ pub mod transactions {
     /// See [the `Transaction` trait implementation](#impl-Transaction) for details how
     /// `TxTransfer` transactions are processed.
     #[protobuf_convert(source = "proto::TxTransfer")]
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     pub struct TxTransfer {
         /// Public key of the receiver.
         pub to: PublicKey,

--- a/examples/sample_runtime/src/main.rs
+++ b/examples/sample_runtime/src/main.rs
@@ -57,7 +57,8 @@ struct SampleRuntime {
 }
 
 // Define runtime specific errors.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ExecutionFail)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(ExecutionFail)]
 #[execution_fail(kind = "runtime")]
 enum SampleRuntimeError {
     /// Incorrect information to call transaction.

--- a/examples/timestamping/backend/src/schema.rs
+++ b/examples/timestamping/backend/src/schema.rs
@@ -25,9 +25,9 @@ use exonum_proto::ProtobufConvert;
 use crate::{proto, transactions::Config};
 
 /// Stores content's hash and some metadata about it.
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash,
-)]
+#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Timestamp")]
 pub struct Timestamp {
     /// Hash of the content.
@@ -48,7 +48,8 @@ impl Timestamp {
 
 /// Timestamp entry.
 #[protobuf_convert(source = "proto::TimestampEntry", serde_pb_convert)]
-#[derive(Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 pub struct TimestampEntry {
     /// Timestamp data.
     pub timestamp: Timestamp,

--- a/examples/timestamping/backend/src/transactions.rs
+++ b/examples/timestamping/backend/src/transactions.rs
@@ -34,7 +34,9 @@ pub enum Error {
 }
 
 /// Timestamping transaction.
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxTimestamp")]
 pub struct TxTimestamp {
     /// Timestamp content.
@@ -42,7 +44,9 @@ pub struct TxTimestamp {
 }
 
 /// Timestamping configuration parameters.
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Config")]
 pub struct Config {
     /// Time oracle service name.

--- a/exonum/benches/criterion/block.rs
+++ b/exonum/benches/criterion/block.rs
@@ -167,13 +167,17 @@ mod timestamping {
         }
     }
 
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::TimestampTx")]
     pub struct Tx {
         data: Hash,
     }
 
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::TimestampTx")]
     pub struct PanickingTx {
         data: Hash,
@@ -309,7 +313,9 @@ mod cryptocurrency {
     }
 
     /// Transfers one unit of currency from `from` to `to`.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::CurrencyTx")]
     pub struct Tx {
         to: PublicKey,
@@ -317,7 +323,9 @@ mod cryptocurrency {
     }
 
     /// Same as `Tx`, but without cryptographic proofs in `execute`.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::CurrencyTx")]
     pub struct SimpleTx {
         to: PublicKey,
@@ -325,7 +333,9 @@ mod cryptocurrency {
     }
 
     /// Same as `SimpleTx`, but signals an error 50% of the time.
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::CurrencyTx")]
     pub struct RollbackTx {
         to: PublicKey,
@@ -398,13 +408,17 @@ mod foreign_interface_call {
     const SELF_INTERFACE_SERVICE_ID: InstanceId = 254;
     const FOREIGN_INTERFACE_SERVICE_ID: InstanceId = 255;
 
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::TimestampTx")]
     pub struct SelfTx {
         data: Hash,
     }
 
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, ObjectHash, BinaryValue)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::TimestampTx")]
     pub struct ForeignTx {
         data: Hash,

--- a/exonum/src/api/websocket.rs
+++ b/exonum/src/api/websocket.rs
@@ -49,7 +49,8 @@ enum IncomingMessage {
 }
 
 /// Subscription type (new blocks or committed transactions).
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum SubscriptionType {
     /// Subscription to nothing.
@@ -65,7 +66,8 @@ pub enum SubscriptionType {
 
 /// Describe filter for transactions by ID of service and (optionally)
 /// transaction type in service.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize)]
 pub struct TransactionFilter {
     /// ID of service.
     pub service_id: u16,

--- a/exonum/src/blockchain/block.rs
+++ b/exonum/src/blockchain/block.rs
@@ -30,19 +30,9 @@ use crate::{
 ///
 /// The header only contains the amount of transactions and the transactions root hash as well as
 /// other information, but not the transactions themselves.
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Debug,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Block")]
 pub struct Block {
     /// Identifier of the leader node which has proposed the block.

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -36,7 +36,9 @@ use exonum_proto::ProtobufConvert;
 /// Public keys of a validator. Each validator has two public keys: the
 /// `consensus_key` is used for internal operations in the consensus process,
 /// while the `service_key` is used in services.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert)]
 #[protobuf_convert(source = "blockchain::ValidatorKeys")]
 pub struct ValidatorKeys {
     /// Consensus key is used for messages related to the consensus algorithm.
@@ -70,18 +72,9 @@ impl ValidateInput for ValidatorKeys {
 /// For additional information on the Exonum consensus algorithm, refer to
 /// [Consensus in Exonum](https://exonum.com/doc/version/latest/architecture/consensus/).
 #[protobuf_convert(source = "blockchain::Config")]
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 pub struct ConsensusConfig {
     /// List of validators public keys.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -298,18 +291,9 @@ impl ValidateInput for ConsensusConfig {
 /// Genesis config parameters.
 ///
 /// Information from this entity get saved to the genesis block.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "runtime::GenesisConfig")]
 pub struct GenesisConfig {
     /// Blockchain configuration used to create the genesis block.
@@ -323,18 +307,9 @@ pub struct GenesisConfig {
 }
 
 /// Represents data that is required for initialization of service instance.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "runtime::InstanceInitParams")]
 pub struct InstanceInitParams {
     /// Wrapped `InstanceSpec`.

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -62,9 +62,9 @@ define_names!(
 /// Transaction location in a block.
 /// The given entity defines the block where the transaction was
 /// included and the position of this transaction in that block.
-#[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, ProtobufConvert, BinaryValue, ObjectHash,
-)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxLocation")]
 pub struct TxLocation {
     /// Height of the block where the transaction was included.

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -41,25 +41,33 @@ const TEST_SERVICE_ID: InstanceId = SUPERVISOR_INSTANCE_ID;
 const TEST_SERVICE_NAME: &str = "test_service";
 const IDX_NAME: &str = "test_service.val";
 
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "TestServiceTx")]
 struct TestExecute {
     value: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "TestServiceTx")]
 struct TestDeploy {
     value: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "TestServiceTx")]
 struct TestAdd {
     value: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "TestServiceTx")]
 struct TestCallInitialize {
     value: u64,
@@ -241,7 +249,9 @@ lazy_static! {
 }
 
 #[protobuf_convert(source = "TestServiceTx")]
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 struct TxResult {
     value: u64,
 }

--- a/exonum/src/helpers/types.rs
+++ b/exonum/src/helpers/types.rs
@@ -115,7 +115,8 @@ impl Height {
 }
 
 /// Consensus round index.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct Round(pub u32);
 
 impl Round {
@@ -253,7 +254,8 @@ impl BinaryValue for Round {
 impl_object_hash_for_binary_value! { Round }
 
 /// Validators identifier.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Serialize, Deserialize)]
 pub struct ValidatorId(pub u16);
 
 impl ValidatorId {

--- a/exonum/src/messages/types.rs
+++ b/exonum/src/messages/types.rs
@@ -32,7 +32,8 @@ use exonum_proto::ProtobufConvert;
 /// Protobuf based container for any signed messages.
 ///
 /// See module [documentation](index.html#examples) for examples.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "consensus::SignedMessage")]
 pub struct SignedMessage {
     /// Payload of the message.
@@ -165,7 +166,8 @@ impl Status {
 /// A node broadcasts `Propose` if it is a leader and is not locked for a
 /// different proposal. Also `Propose` can be sent as response to
 /// `ProposeRequest`.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "consensus::Propose")]
 pub struct Propose {
     /// The validator id.
@@ -311,7 +313,9 @@ impl Prevote {
 /// ### Generation
 /// A node broadcasts `Precommit` in response to `Prevote` if there are +2/3
 /// pre-votes and no unknown transactions.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert)]
 #[protobuf_convert(source = "consensus::Precommit")]
 pub struct Precommit {
     /// The validator id.
@@ -722,7 +726,8 @@ impl BlockResponse {
 
 /// This type describes all possible types of Exonum messages
 /// which are used in p2p communications.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(
     source = "consensus::ExonumMessage",
     rename(case = "snake_case"),

--- a/exonum/src/proto/tests.rs
+++ b/exonum/src/proto/tests.rs
@@ -29,7 +29,8 @@ fn test_date_time_pb_convert() {
     assert_eq!(pb_round_trip, dt);
 }
 
-#[derive(Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::tests::Point")]
 struct Point {
     x: u32,
@@ -49,7 +50,8 @@ fn test_simple_struct_round_trip() {
     assert_eq!(point_encode_round_trip, point);
 }
 
-#[derive(Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::tests::TestProtobufConvert")]
 struct StructWithScalarTypes {
     key: PublicKey,
@@ -109,7 +111,8 @@ fn test_scalar_struct_round_trip() {
 }
 
 #[protobuf_convert(source = "schema::tests::TestProtobufConvertRepeated")]
-#[derive(Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 struct StructWithRepeatedTypes {
     keys: Vec<PublicKey>,
     bytes_array: Vec<Vec<u8>>,
@@ -138,7 +141,8 @@ fn test_repeated_struct_round_trip() {
     assert_eq!(struct_encode_round_trip, rep_struct);
 }
 
-#[derive(Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::tests::TestProtobufConvertMap")]
 struct StructWithMaps {
     num_map: HashMap<u32, u64>,
@@ -180,7 +184,8 @@ fn test_struct_with_maps_roundtrip() {
 }
 
 #[protobuf_convert(source = "schema::tests::TestFixedArrays")]
-#[derive(Clone, Copy, Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 struct StructWithFixedArrays {
     fixed_array_8: [u8; 8],
     fixed_array_16: [u8; 16],

--- a/exonum/src/runtime/dispatcher/error.rs
+++ b/exonum/src/runtime/dispatcher/error.rs
@@ -21,7 +21,8 @@ use std::fmt::Display;
 use crate::runtime::{ErrorKind, ExecutionError, ExecutionFail};
 
 /// List of possible dispatcher errors.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ExecutionFail)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(ExecutionFail)]
 #[execution_fail(crate = "crate", kind = "dispatcher")]
 pub enum Error {
     /// Runtime identifier is incorrect in this context.

--- a/exonum/src/runtime/rust/error.rs
+++ b/exonum/src/runtime/rust/error.rs
@@ -17,7 +17,8 @@
 use exonum_derive::ExecutionFail;
 
 /// List of possible Rust runtime errors.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ExecutionFail)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(ExecutionFail)]
 #[execution_fail(crate = "crate", kind = "runtime")]
 pub enum Error {
     /// Unable to parse artifact identifier or specified artifact has non-empty spec.

--- a/exonum/src/runtime/types.rs
+++ b/exonum/src/runtime/types.rs
@@ -36,9 +36,9 @@ pub type InstanceId = u32;
 pub type MethodId = u32;
 
 /// Information for calling the service method.
-#[derive(
-    Default, Clone, PartialEq, Eq, Ord, PartialOrd, Debug, ProtobufConvert, Serialize, Deserialize,
-)]
+#[derive(Default, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert)]
 #[protobuf_convert(source = "schema::runtime::CallInfo")]
 pub struct CallInfo {
     /// Unique service instance identifier. The dispatcher uses this identifier to find the
@@ -87,7 +87,9 @@ impl CallInfo {
 ///     &keypair.1
 /// );
 /// ```
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert)]
 #[protobuf_convert(source = "schema::runtime::AnyTx")]
 pub struct AnyTx {
     /// Information required for the call of the corresponding executor.
@@ -128,20 +130,9 @@ impl AnyTx {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::runtime::ArtifactId")]
 pub struct ArtifactId {
     /// Runtime identifier.
@@ -238,18 +229,9 @@ impl FromStr for ArtifactId {
 }
 
 /// Exhaustive artifact specification.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::runtime::ArtifactSpec")]
 pub struct ArtifactSpec {
     /// Information uniquely identifying the artifact.
@@ -269,18 +251,9 @@ impl ArtifactSpec {
 }
 
 /// Exhaustive service instance specification.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::runtime::InstanceSpec")]
 pub struct InstanceSpec {
     /// Unique numeric ID of the service instance.
@@ -448,7 +421,8 @@ impl ProtobufConvert for InstanceStatus {
 }
 
 /// Current state of artifact in dispatcher.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::runtime::ArtifactState")]
 pub struct ArtifactState {
     /// Artifact specification.
@@ -465,18 +439,9 @@ impl ArtifactState {
 }
 
 /// Current state of service instance in dispatcher.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-    Serialize,
-    Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "schema::runtime::InstanceState")]
 pub struct InstanceState {
     /// Service instance specification.

--- a/exonum/tests/explorer/blockchain/mod.rs
+++ b/exonum/tests/explorer/blockchain/mod.rs
@@ -37,7 +37,9 @@ pub const SERVICE_ID: InstanceId = 4;
 
 mod proto;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::CreateWallet")]
 pub struct CreateWallet {
     pub pubkey: PublicKey,
@@ -53,7 +55,9 @@ impl CreateWallet {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Transfer")]
 pub struct Transfer {
     pub from: PublicKey,

--- a/exonum/tests/websocket/blockchain/mod.rs
+++ b/exonum/tests/websocket/blockchain/mod.rs
@@ -37,7 +37,9 @@ mod proto;
 
 pub const SERVICE_ID: InstanceId = 118;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::CreateWallet")]
 pub struct CreateWallet {
     pub pubkey: PublicKey,
@@ -53,7 +55,9 @@ impl CreateWallet {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Transfer")]
 pub struct Transfer {
     pub from: PublicKey,

--- a/services/supervisor/src/errors.rs
+++ b/services/supervisor/src/errors.rs
@@ -15,7 +15,8 @@
 use exonum_derive::*;
 
 /// Common errors emitted by transactions during execution.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ExecutionFail)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(ExecutionFail)]
 pub enum Error {
     /// Artifact has been already deployed.
     AlreadyDeployed = 0,

--- a/services/supervisor/src/proto_structures.rs
+++ b/services/supervisor/src/proto_structures.rs
@@ -32,9 +32,9 @@ use super::{mode::Mode, proto, transactions::SupervisorInterface};
 
 /// Supervisor service configuration (not to be confused with `ConfigPropose`, which
 /// contains core/service configuration change proposal).
-#[derive(
-    Debug, Clone, PartialEq, ProtobufConvert, BinaryValue, ObjectHash, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Config")]
 pub struct SupervisorConfig {
     /// Supervisor operating mode.
@@ -63,7 +63,8 @@ pub struct DeployConfirmation {
 
 /// Request for the artifact deployment.
 #[protobuf_convert(source = "proto::StartService")]
-#[derive(Debug, Clone, PartialEq, Eq, ProtobufConvert, Hash, BinaryValue, ObjectHash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 pub struct StartService {
     /// Artifact identifier.
     pub artifact: ArtifactId,
@@ -88,18 +89,9 @@ impl StartService {
 }
 
 /// Configuration parameters of the certain service instance.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::ServiceConfig")]
 pub struct ServiceConfig {
     /// Corresponding service instance ID.
@@ -109,18 +101,9 @@ pub struct ServiceConfig {
 }
 
 /// Atomic configuration change.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ProtobufConvert,
-    BinaryValue,
-    ObjectHash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::ConfigChange", rename(case = "snake_case"))]
 pub enum ConfigChange {
     /// New consensus config.
@@ -132,7 +115,8 @@ pub enum ConfigChange {
 }
 
 /// Request for the configuration change
-#[derive(Debug, Clone, Eq, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::ConfigPropose")]
 pub struct ConfigPropose {
     /// The height until which the update configuration procedure should be completed.
@@ -203,9 +187,9 @@ pub struct ConfigVote {
 }
 
 /// Pending config change proposal entry
-#[derive(
-    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, ProtobufConvert, BinaryValue, ObjectHash,
-)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::ConfigProposalWithHash")]
 pub struct ConfigProposalWithHash {
     /// Hash of configuration proposition.

--- a/services/supervisor/tests/supervisor/inc.rs
+++ b/services/supervisor/tests/supervisor/inc.rs
@@ -65,9 +65,9 @@ where
     }
 }
 
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash,
-)]
+#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxInc")]
 pub struct Inc {
     pub seed: u64,

--- a/services/time/examples/simple_service/main.rs
+++ b/services/time/examples/simple_service/main.rs
@@ -41,7 +41,9 @@ use std::sync::Arc;
 mod proto;
 
 /// The argument of the `MarkerInterface::mark` method.
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxMarker")]
 pub struct TxMarker {
     mark: i32,

--- a/services/time/src/transactions.rs
+++ b/services/time/src/transactions.rs
@@ -28,7 +28,9 @@ pub enum Error {
 }
 
 /// Transaction that is sent by the validator after the commit of the block.
-#[derive(Serialize, Deserialize, Debug, Clone, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxTime")]
 pub struct TxTime {
     /// Time of the validator.

--- a/test-suite/testkit/examples/timestamping/main.rs
+++ b/test-suite/testkit/examples/timestamping/main.rs
@@ -36,7 +36,9 @@ mod proto;
 
 // Simple service implementation.
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxTimestamp")]
 struct TxTimestamp {
     message: String,

--- a/test-suite/testkit/src/server.rs
+++ b/test-suite/testkit/src/server.rs
@@ -192,7 +192,9 @@ mod tests {
     const TIMESTAMP_SERVICE_ID: u32 = 2;
     const TIMESTAMP_SERVICE_NAME: &str = "sample";
 
-    #[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+    #[derive(Clone, Debug)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(ProtobufConvert, BinaryValue, ObjectHash)]
     #[protobuf_convert(source = "proto::examples::TxTimestamp")]
     struct TxTimestamp {
         message: String,

--- a/test-suite/testkit/tests/counter/counter.rs
+++ b/test-suite/testkit/tests/counter/counter.rs
@@ -73,11 +73,15 @@ where
 
 // // // // Transactions // // // //
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxReset")]
 pub struct Reset;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxIncrement")]
 pub struct Increment {
     by: u64,

--- a/test-suite/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
+++ b/test-suite/testkit/tests/inflating_currency/inflating_cryptocurrency.rs
@@ -40,7 +40,9 @@ pub const INIT_BALANCE: u64 = 0;
 
 // // // // // // // // // // PERSISTENT DATA // // // // // // // // // //
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Wallet")]
 pub struct Wallet {
     pub pub_key: PublicKey,
@@ -92,14 +94,18 @@ impl<T: Access> CurrencySchema<T> {
 // // // // // // // // // // TRANSACTIONS // // // // // // // // // //
 
 /// Create a new wallet.
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxCreateWallet")]
 pub struct CreateWallet {
     pub name: String,
 }
 
 /// Transfer coins between the wallets.
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxTransfer")]
 pub struct Transfer {
     pub to: PublicKey,

--- a/test-suite/testkit/tests/interfaces/error.rs
+++ b/test-suite/testkit/tests/interfaces/error.rs
@@ -15,7 +15,8 @@
 use exonum_derive::ExecutionFail;
 
 /// Common errors emitted by transactions during execution.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ExecutionFail)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(ExecutionFail)]
 pub enum Error {
     WalletNotFound = 0,
     WalletAlreadyExists = 1,

--- a/test-suite/testkit/tests/interfaces/interface.rs
+++ b/test-suite/testkit/tests/interfaces/interface.rs
@@ -27,7 +27,9 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::proto;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Issue")]
 pub struct Issue {
     pub to: PublicKey,

--- a/test-suite/testkit/tests/interfaces/schema.rs
+++ b/test-suite/testkit/tests/interfaces/schema.rs
@@ -22,7 +22,9 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::proto;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::Wallet")]
 pub struct Wallet {
     pub name: String,

--- a/test-suite/testkit/tests/interfaces/services.rs
+++ b/test-suite/testkit/tests/interfaces/services.rs
@@ -35,7 +35,9 @@ use crate::{
     schema::{Wallet, WalletSchema},
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::CreateWallet")]
 pub struct TxCreateWallet {
     pub name: String,
@@ -107,7 +109,9 @@ impl DefaultInstance for WalletService {
 }
 
 #[protobuf_convert(source = "proto::Issue")]
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 pub struct TxIssue {
     pub to: PublicKey,
     pub amount: u64,
@@ -145,7 +149,9 @@ impl DefaultInstance for DepositService {
     const INSTANCE_NAME: &'static str = "deposit";
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::AnyCall")]
 pub struct TxAnyCall {
     pub call_info: CallInfo,
@@ -153,7 +159,9 @@ pub struct TxAnyCall {
     pub args: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ProtobufConvert, BinaryValue, ObjectHash)]
+#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::RecursiveCall")]
 pub struct TxRecursiveCall {
     pub depth: u64,

--- a/test-suite/testkit/tests/service_hooks/hooks.rs
+++ b/test-suite/testkit/tests/service_hooks/hooks.rs
@@ -33,9 +33,9 @@ use std::sync::{
 pub const SERVICE_ID: InstanceId = 512;
 pub const SERVICE_NAME: &str = "after-commit";
 
-#[derive(
-    Serialize, Deserialize, Clone, Debug, PartialEq, ProtobufConvert, BinaryValue, ObjectHash,
-)]
+#[derive(Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
 #[protobuf_convert(source = "proto::TxAfterCommit")]
 pub struct TxAfterCommit {
     pub height: Height,


### PR DESCRIPTION
This PR adds a `.rustfmt.toml` which overrides `merge_derives` to `false`.

Also this PR replaces all the vertical derive monster with grouped horizontal ones.

I used the following schema:

- Built-in traits (`Debug`, `Clone`, etc)
- `serde` derives
- `exonum` derives.

## Demo

Old approach:

```rust
#[derive(
    Clone,
    PartialEq,
    Eq,
    Ord,
    PartialOrd,
    Debug,
    Serialize,
    Deserialize,
    ProtobufConvert,
    BinaryValue,
    ObjectHash,
)]
```

New approach:

```rust

#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
#[derive(Serialize, Deserialize)]
#[derive(ProtobufConvert, BinaryValue, ObjectHash)]
```