### PR TITLE
Fix couple of bugs in MerkleDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `Supervisor` service now can have initial configuration and implements
   `Configure` interface. (#1587)
 
+### Bug Fixes
+
+#### exonum-merkledb
+
+- `Snapshot` implementation for `Patch` has been fixed. The previous implementation
+  could lead to stale reads from a `Patch` or a `Fork`. (#1611)
+
 ## 0.13.0-rc.2 - 2019-12-04
 
 ### Breaking changes

--- a/components/merkledb/src/db.rs
+++ b/components/merkledb/src/db.rs
@@ -68,6 +68,8 @@ impl ViewChanges {
         self.data
     }
 
+    /// Returns a value for the specified key, or an `Err(_)` if the value should be determined
+    /// by the underlying snapshot.
     pub fn get(&self, key: &[u8]) -> StdResult<Option<Vec<u8>>, ()> {
         if let Some(change) = self.data.get(key) {
             return Ok(match *change {
@@ -81,6 +83,8 @@ impl ViewChanges {
         Err(())
     }
 
+    /// Returns whether the view contains the specified `key`. An `Err(_)` is returned if this
+    /// is determined by the underlying snapshot.
     pub fn contains(&self, key: &[u8]) -> StdResult<bool, ()> {
         if let Some(change) = self.data.get(key) {
             return Ok(match *change {

--- a/components/merkledb/src/db.rs
+++ b/components/merkledb/src/db.rs
@@ -20,15 +20,16 @@ use std::{
     mem,
     ops::{Bound, Deref, DerefMut},
     rc::Rc,
+    result::Result as StdResult,
 };
 
 use crate::{
-    views::{get_object_hash, AsReadonly, RawAccess, ResolvedAddress, View},
+    views::{get_object_hash, AsReadonly, ChangesIter, RawAccess, ResolvedAddress, View},
     Error, Result, SystemSchema,
 };
 
 /// Changes related to a specific `View`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ViewChanges {
     /// Changes within the view.
     pub(super) data: BTreeMap<Vec<u8>, Change>,
@@ -42,11 +43,7 @@ pub struct ViewChanges {
 
 impl ViewChanges {
     fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-            is_cleared: false,
-            is_aggregated: false,
-        }
+        Self::default()
     }
 
     pub fn is_cleared(&self) -> bool {
@@ -69,6 +66,33 @@ impl ViewChanges {
 
     pub fn into_data(self) -> BTreeMap<Vec<u8>, Change> {
         self.data
+    }
+
+    pub fn get(&self, key: &[u8]) -> StdResult<Option<Vec<u8>>, ()> {
+        if let Some(change) = self.data.get(key) {
+            return Ok(match *change {
+                Change::Put(ref v) => Some(v.clone()),
+                Change::Delete => None,
+            });
+        }
+        if self.is_cleared() {
+            return Ok(None);
+        }
+        Err(())
+    }
+
+    pub fn contains(&self, key: &[u8]) -> StdResult<bool, ()> {
+        if let Some(change) = self.data.get(key) {
+            return Ok(match *change {
+                Change::Put(..) => true,
+                Change::Delete => false,
+            });
+        }
+
+        if self.is_cleared() {
+            return Ok(false);
+        }
+        Err(())
     }
 }
 
@@ -546,40 +570,36 @@ impl Patch {
 
 impl Snapshot for Patch {
     fn get(&self, name: &ResolvedAddress, key: &[u8]) -> Option<Vec<u8>> {
-        if let Some(changes) = self.changes.get(name) {
-            if let Some(change) = changes.data.get(key) {
-                match *change {
-                    Change::Put(ref v) => return Some(v.clone()),
-                    Change::Delete => return None,
-                }
-            }
-        }
-        self.snapshot.get(name, key)
+        self.changes
+            .get(name)
+            .map_or(Err(()), |changes| changes.get(key))
+            // At this point, `Err(_)` signifies that we need to retrieve data from the snapshot.
+            .unwrap_or_else(|()| self.snapshot.get(name, key))
     }
 
     fn contains(&self, name: &ResolvedAddress, key: &[u8]) -> bool {
-        if let Some(changes) = self.changes.get(name) {
-            if let Some(change) = changes.data.get(key) {
-                match *change {
-                    Change::Put(..) => return true,
-                    Change::Delete => return false,
-                }
-            }
-        }
-        self.snapshot.contains(name, key)
+        self.changes
+            .get(name)
+            .map_or(Err(()), |changes| changes.contains(key))
+            // At this point, `Err(_)` signifies that we need to retrieve data from the snapshot.
+            .unwrap_or_else(|()| self.snapshot.contains(name, key))
     }
 
     fn iter(&self, name: &ResolvedAddress, from: &[u8]) -> Iter<'_> {
-        let range = (Bound::Included(from), Bound::Unbounded);
-        let changes = match self.changes.get(name) {
-            Some(changes) => Some(changes.data.range::<[u8], _>(range).peekable()),
-            None => None,
-        };
+        let maybe_changes = self.changes.get(name);
+        let changes_iter = maybe_changes.map(|changes| {
+            changes
+                .data
+                .range::<[u8], _>((Bound::Included(from), Bound::Unbounded))
+        });
 
-        Box::new(ForkIter {
-            snapshot: self.snapshot.iter(name, from),
-            changes,
-        })
+        let is_cleared = maybe_changes.map_or(false, ViewChanges::is_cleared);
+        if is_cleared {
+            // Ignore all changes from the snapshot.
+            Box::new(ChangesIter::new(changes_iter.unwrap()))
+        } else {
+            Box::new(ForkIter::new(self.snapshot.iter(name, from), changes_iter))
+        }
     }
 }
 

--- a/components/merkledb/src/key_set_index.rs
+++ b/components/merkledb/src/key_set_index.rs
@@ -295,4 +295,25 @@ mod tests {
         index.clear();
         assert!(!index.contains(&2_u8));
     }
+
+    #[test]
+    fn no_infinite_iteration_in_flushed_fork() {
+        let db = TemporaryDB::new();
+        let mut fork = db.fork();
+        {
+            let mut set = fork.get_key_set::<_, u8>(INDEX_NAME);
+            set.insert(4);
+            set.clear();
+        }
+        fork.flush();
+        {
+            let mut set = fork.get_key_set::<_, u8>(INDEX_NAME);
+            set.remove(&1);
+        }
+        fork.flush();
+
+        let set = fork.get_key_set::<_, u8>(INDEX_NAME);
+        let items: Vec<_> = set.iter().collect();
+        assert!(items.is_empty());
+    }
 }

--- a/components/merkledb/src/list_index.rs
+++ b/components/merkledb/src/list_index.rs
@@ -584,4 +584,29 @@ mod tests {
         let list: ListIndex<_, u32> = fork.readonly().get_list(IDX_NAME);
         assert!(list.is_empty());
     }
+
+    #[test]
+    fn after_clearing_and_flushing() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        {
+            let mut list = fork.get_list::<_, u32>(IDX_NAME);
+            list.extend(vec![1, 2]);
+        }
+        db.merge(fork.into_patch()).unwrap();
+
+        let mut fork = db.fork();
+        {
+            let mut list = fork.get_list::<_, u32>(IDX_NAME);
+            list.clear();
+            list.push(3);
+        }
+        fork.flush();
+
+        let list = fork.get_list::<_, u32>(IDX_NAME);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.get(0), Some(3));
+        assert_eq!(list.get(1), None);
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![3]);
+    }
 }

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -381,10 +381,14 @@ where
     fn peek(&mut self) -> Option<(&[u8], &[u8])> {
         loop {
             match self.inner.peek() {
-                Some((key, &Change::Put(ref value))) => {
+                Some((key, Change::Put(ref value))) => {
                     return Some((key.as_slice(), value.as_slice()));
                 }
-                Some((_, &Change::Delete)) => {}
+                Some((_, Change::Delete)) => {
+                    // Advance the iterator. Since we've already peeked the value,
+                    // we can safely drop it.
+                    self.inner.next();
+                }
                 None => {
                     return None;
                 }

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -183,37 +183,19 @@ impl<T: RawAccess> View<T> {
     }
 
     fn get_bytes(&self, key: &[u8]) -> Option<Vec<u8>> {
-        if let Some(ref changes) = self.changes.as_ref() {
-            if let Some(change) = changes.data.get(key) {
-                match *change {
-                    Change::Put(ref v) => return Some(v.clone()),
-                    Change::Delete => return None,
-                }
-            }
-
-            if changes.is_cleared() {
-                return None;
-            }
-        }
-
-        self.snapshot().get(&self.address, key)
+        self.changes
+            .as_ref()
+            .map_or(Err(()), |changes| changes.get(key))
+            // At this point, `Err(_)` signifies that we need to retrieve data from the snapshot.
+            .unwrap_or_else(|()| self.snapshot().get(&self.address, key))
     }
 
     fn contains_raw_key(&self, key: &[u8]) -> bool {
-        if let Some(ref changes) = self.changes.as_ref() {
-            if let Some(change) = changes.data.get(key) {
-                match *change {
-                    Change::Put(..) => return true,
-                    Change::Delete => return false,
-                }
-            }
-
-            if changes.is_cleared() {
-                return false;
-            }
-        }
-
-        self.snapshot().contains(&self.address, &key)
+        self.changes
+            .as_ref()
+            .map_or(Err(()), |changes| changes.contains(key))
+            // At this point, `Err(_)` signifies that we need to retrieve data from the snapshot.
+            .unwrap_or_else(|()| self.snapshot().contains(&self.address, key))
     }
 
     fn iter_bytes(&self, from: &[u8]) -> BytesIter<'_> {
@@ -360,7 +342,7 @@ impl<T: RawAccessMut> View<T> {
     }
 }
 
-struct ChangesIter<'a, T: Iterator + 'a> {
+pub(crate) struct ChangesIter<'a, T: Iterator + 'a> {
     inner: Peekable<T>,
     _lifetime: PhantomData<&'a ()>,
 }
@@ -370,7 +352,7 @@ impl<'a, T> ChangesIter<'a, T>
 where
     T: Iterator<Item = (&'a Vec<u8>, &'a Change)>,
 {
-    fn new(iterator: T) -> Self {
+    pub fn new(iterator: T) -> Self {
         ChangesIter {
             inner: iterator.peekable(),
             _lifetime: PhantomData,


### PR DESCRIPTION
## Overview

This PR fixes incorrect implementation of `Snapshot` for `Patch`. The previous implementation didn't take into account that indexes can be deleted within the `Patch`; this led to potential stale / inconsistent reads from `Patch`es or `Fork`s.

Independently, the byte iterator implementation for `ViewChanges` was incorrect; it entered an infinite loop in `peek()` once a `Delete` change was encountered. This bug was not previously exposed since the `peek` method was not used; but with the correction of `Patch` behavior, the situation has changed.