### PR TITLE
Fix websocket issue during different kind of WebSocket connect

### DIFF
--- a/exonum/src/api/node/mod.rs
+++ b/exonum/src/api/node/mod.rs
@@ -45,7 +45,7 @@ struct ApiNodeState {
     node_role: NodeRole,
     majority_count: usize,
     validators: Vec<ValidatorKeys>,
-    broadcast_server_address: Option<Addr<websocket::Server>>,
+    broadcast_server_addresses: Vec<Option<Addr<websocket::Server>>>,
     tx_cache_len: usize,
 }
 
@@ -232,27 +232,27 @@ impl SharedNodeState {
 
     pub(crate) fn set_broadcast_server_address(&self, address: Addr<websocket::Server>) {
         let mut node = self.node.write().expect("Expected write lock");
-        node.broadcast_server_address = Some(address);
+        node.broadcast_server_addresses.push(Some(address));
     }
 
     /// Broadcast message to all subscribers.
     pub(crate) fn broadcast(&self, block_hash: &Hash) {
-        if let Some(ref address) = self
-            .node
-            .read()
-            .expect("Expected read lock")
-            .broadcast_server_address
-        {
-            address.do_send(websocket::Broadcast {
-                block_hash: *block_hash,
-            })
+        let state = self.node.read().expect("Expected read lock");
+        for entry in state.broadcast_server_addresses.iter() {
+            if let Some(ref address) = entry {
+                address.do_send(websocket::Broadcast {
+                    block_hash: *block_hash,
+                })
+            }
         }
     }
 
     pub(crate) fn shutdown_broadcast_server(&self) {
         let state = self.node.read().expect("Expected read lock");
-        if let Some(server) = state.broadcast_server_address.as_ref() {
-            server.do_send(websocket::Terminate);
+        for entry in state.broadcast_server_addresses.iter() {
+            if let Some(server) = entry.as_ref() {
+                server.do_send(websocket::Terminate);
+            }
         }
     }
 

--- a/exonum/src/api/node/mod.rs
+++ b/exonum/src/api/node/mod.rs
@@ -247,8 +247,8 @@ impl SharedNodeState {
 
     pub(crate) fn shutdown_broadcast_server(&self) {
         let state = self.node.read().expect("Expected read lock");
-        for address in state.broadcast_server_addresses.iter() {
-            address.do_send(websocket::Terminate);
+        for server in state.broadcast_server_addresses.iter() {
+            server.do_send(websocket::Terminate);
         }
     }
 

--- a/exonum/src/api/node/mod.rs
+++ b/exonum/src/api/node/mod.rs
@@ -45,7 +45,7 @@ struct ApiNodeState {
     node_role: NodeRole,
     majority_count: usize,
     validators: Vec<ValidatorKeys>,
-    broadcast_server_addresses: Vec<Option<Addr<websocket::Server>>>,
+    broadcast_server_addresses: Vec<Addr<websocket::Server>>,
     tx_cache_len: usize,
 }
 
@@ -232,27 +232,23 @@ impl SharedNodeState {
 
     pub(crate) fn set_broadcast_server_address(&self, address: Addr<websocket::Server>) {
         let mut node = self.node.write().expect("Expected write lock");
-        node.broadcast_server_addresses.push(Some(address));
+        node.broadcast_server_addresses.push(address);
     }
 
     /// Broadcast message to all subscribers.
     pub(crate) fn broadcast(&self, block_hash: &Hash) {
         let state = self.node.read().expect("Expected read lock");
-        for entry in state.broadcast_server_addresses.iter() {
-            if let Some(ref address) = entry {
-                address.do_send(websocket::Broadcast {
-                    block_hash: *block_hash,
-                })
-            }
+        for address in state.broadcast_server_addresses.iter() {
+            address.do_send(websocket::Broadcast {
+                block_hash: *block_hash,
+            })
         }
     }
 
     pub(crate) fn shutdown_broadcast_server(&self) {
         let state = self.node.read().expect("Expected read lock");
-        for entry in state.broadcast_server_addresses.iter() {
-            if let Some(server) = entry.as_ref() {
-                server.do_send(websocket::Terminate);
-            }
+        for address in state.broadcast_server_addresses.iter() {
+            address.do_send(websocket::Terminate);
         }
     }
 

--- a/exonum/tests/websocket/main.rs
+++ b/exonum/tests/websocket/main.rs
@@ -449,3 +449,82 @@ fn test_node_shutdown_with_active_ws_client_should_not_wait_for_timeout() {
         let _ = client.shutdown();
     }
 }
+
+#[test]
+fn test_blocks_and_tx_both_subscribe() {
+    let node_handler = run_node(6338, 8087);
+
+    // Open block ws first
+    let mut block_client = create_ws_client("ws://localhost:8087/api/explorer/v1/blocks/subscribe")
+        .expect("Cannot connect to node");
+    block_client
+        .stream_ref()
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    // Get one message and check that it is text.
+    let block_resp_text = recv_text_msg(&mut block_client).unwrap();
+
+    let block_notification = serde_json::from_str::<Notification>(&block_resp_text).unwrap();
+    match block_notification {
+        Notification::Block(_) => (),
+        other => panic!("Incorrect notification type (expected Block): {:?}", other),
+    }
+    block_client.shutdown().unwrap();
+
+    // Open tx ws and test it
+    let mut tx_client =
+        create_ws_client("ws://localhost:8087/api/explorer/v1/transactions/subscribe")
+            .expect("Cannot connect to node");
+    tx_client
+        .stream_ref()
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let (pk, sk) = gen_keypair();
+    let tx = CreateWallet::new(pk, "Alice").sign(SERVICE_ID, pk, &sk);
+    let tx_json = json!({ "tx_body": tx });
+    let http_client = reqwest::Client::new();
+    let _res = http_client
+        .post("http://localhost:8087/api/explorer/v1/transactions")
+        .json(&tx_json)
+        .send()
+        .unwrap();
+
+    let tx_resp_text = recv_text_msg(&mut tx_client).unwrap();
+
+    let tx_notification = serde_json::from_str::<Notification>(&tx_resp_text).unwrap();
+    match tx_notification {
+        Notification::Transaction(_) => (),
+        other => panic!(
+            "Incorrect notification type (expected Transaction): {:?}",
+            other
+        ),
+    };
+    tx_client.shutdown().unwrap();
+
+    // Open block ws and check it receives data again
+    let mut block_again_client =
+        create_ws_client("ws://localhost:8087/api/explorer/v1/blocks/subscribe")
+            .expect("Cannot connect to node");
+    block_again_client
+        .stream_ref()
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    let block_again_resp_text = recv_text_msg(&mut block_again_client).unwrap();
+
+    let block_again_notification =
+        serde_json::from_str::<Notification>(&block_again_resp_text).unwrap();
+    match block_again_notification {
+        Notification::Block(_) => (),
+        other => panic!("Incorrect notification type (expected Block): {:?}", other),
+    }
+    block_again_client.shutdown().unwrap();
+
+    node_handler
+        .api_tx
+        .send_external_message(ExternalMessage::Shutdown)
+        .unwrap();
+    node_handler.node_thread.join().unwrap();
+}


### PR DESCRIPTION
## Overview

WebSocket could not receive any information if different kinds of WebSockets connected.
For example:
1. The block WebSocket is connected.
2. The tx WebSocket is connected.
3. The client of the block WebSocket cannot receive any block data.

The root cause is the ApiNodeState only has one address for WebSocket server's address, so I make the broadcast_server_address as a vector.
BTW, I didn't clean the address vector because the behavior of "shutdown_broadcast_server" only occurs during the node stops.