### PR TITLE
Owning iterators & group key enumeration

### DIFF
--- a/components/merkledb/examples/migration.rs
+++ b/components/merkledb/examples/migration.rs
@@ -255,18 +255,20 @@ fn main() {
     fork.flush_migration("test");
     let patch = fork.into_patch();
 
-    // Now, the new indexes have replaced the old ones.
-    let new_schema = v2::Schema::new(Prefixed::new("test", &patch));
-    assert_eq!(new_schema.config.get().unwrap().divisibility, 8);
-    assert!(!patch.get_entry::<_, u8>("test.divisibility").exists());
+    {
+        // Now, the new indexes have replaced the old ones.
+        let new_schema = v2::Schema::new(Prefixed::new("test", &patch));
+        assert_eq!(new_schema.config.get().unwrap().divisibility, 8);
+        assert!(!patch.get_entry::<_, u8>("test.divisibility").exists());
 
-    // The indexes are now aggregated in the default namespace.
-    let system_schema = SystemSchema::new(&patch);
-    let state = system_schema.state_aggregator();
-    assert_eq!(
-        state.keys().collect::<Vec<_>>(),
-        vec!["test.config", "test.wallets", "unrelated.list"]
-    );
+        // The indexes are now aggregated in the default namespace.
+        let system_schema = SystemSchema::new(&patch);
+        let state = system_schema.state_aggregator();
+        assert_eq!(
+            state.keys().collect::<Vec<_>>(),
+            vec!["test.config", "test.wallets", "unrelated.list"]
+        );
+    }
 
     // When the patch is merged, the situation remains the same.
     db.merge(patch).unwrap();

--- a/components/merkledb/src/group.rs
+++ b/components/merkledb/src/group.rs
@@ -65,40 +65,6 @@ use crate::{
 /// group.get("bar").push(42);
 /// # assert_eq!(fork.readonly().get_list::<_, u64>(("unsized_group", "bar")).len(), 1);
 /// ```
-///
-/// This example shows incorrect use of the [`keys`] iterator:
-///
-/// ```should_panic
-/// # use exonum_merkledb::{access::AccessExt, Database, Group, ListIndex, TemporaryDB};
-/// let db = TemporaryDB::new();
-/// let fork = db.fork();
-/// let group: Group<_, str, ListIndex<_, String>> = fork.get_group("group");
-/// group.get("foo").push("foo".to_owned());
-/// group.get("bar").push("bar".to_owned());
-///
-/// for key in group.keys() {
-///     fork.get_list("list").push(key); // << will panic
-/// }
-/// ```
-///
-/// In this case, the fix is easy: move the index creation outside the `for` cycle.
-///
-/// ```
-/// # use exonum_merkledb::{access::AccessExt, Database, Group, ListIndex, TemporaryDB};
-/// # let db = TemporaryDB::new();
-/// # let fork = db.fork();
-/// # let group: Group<_, str, ListIndex<_, String>> = fork.get_group("group");
-/// # group.get("foo").push("foo".to_owned());
-/// # group.get("bar").push("bar".to_owned());
-/// let mut list = fork.get_list("list");
-/// for key in group.keys() {
-///     list.push(key);
-/// }
-/// // ...or, more idiomatically:
-/// list.extend(group.keys());
-/// ```
-///
-/// [`keys`]: #method.keys
 #[derive(Debug)]
 pub struct Group<T, K: ?Sized, I> {
     access: T,
@@ -160,7 +126,40 @@ where
     /// [`Fork`]: struct.Fork.html
     /// [`ReadonlyFork`]: struct.ReadonlyFork.html
     /// [`buffered_keys`]: #method.buffered_keys
-    #[doc(hidden)] // Has clunky user experience, error-prone
+    ///
+    /// # Examples
+    ///
+    /// This example shows incorrect use of the iterator:
+    ///
+    /// ```should_panic
+    /// # use exonum_merkledb::{access::AccessExt, Database, Group, ListIndex, TemporaryDB};
+    /// let db = TemporaryDB::new();
+    /// let fork = db.fork();
+    /// let group: Group<_, str, ListIndex<_, String>> = fork.get_group("group");
+    /// group.get("foo").push("foo".to_owned());
+    /// group.get("bar").push("bar".to_owned());
+    ///
+    /// for key in group.keys() {
+    ///     fork.get_list("list").push(key); // << will panic
+    /// }
+    /// ```
+    ///
+    /// In this case, the fix is easy: move the index creation outside the `for` cycle.
+    ///
+    /// ```
+    /// # use exonum_merkledb::{access::AccessExt, Database, Group, ListIndex, TemporaryDB};
+    /// # let db = TemporaryDB::new();
+    /// # let fork = db.fork();
+    /// # let group: Group<_, str, ListIndex<_, String>> = fork.get_group("group");
+    /// # group.get("foo").push("foo".to_owned());
+    /// # group.get("bar").push("bar".to_owned());
+    /// let mut list = fork.get_list("list");
+    /// for key in group.keys() {
+    ///     list.push(key);
+    /// }
+    /// // ...or, more idiomatically:
+    /// list.extend(group.keys());
+    /// ```
     pub fn keys(&self) -> Keys<T::Base, K> {
         let inner = self.access.clone().group_keys(self.prefix.clone());
         Keys {

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -121,7 +121,8 @@ use crate::{
     access::{Access, AccessError, Prefixed, RawAccess},
     validation::assert_valid_name_component,
     views::{
-        get_state_aggregator, AsReadonly, IndexAddress, IndexType, RawAccessMut, ViewWithMetadata,
+        get_state_aggregator, AsReadonly, GroupKeys, IndexAddress, IndexType, IndexesPool,
+        RawAccessMut, ViewWithMetadata,
     },
     Database, Fork, ObjectHash, ProofMapIndex, ReadonlyFork,
 };
@@ -215,6 +216,12 @@ impl<T: RawAccess> Access for Migration<'_, T> {
         let mut prefixed_addr = addr.prepend_name(self.namespace.as_ref());
         prefixed_addr.set_in_migration();
         self.access.get_or_create_view(prefixed_addr, index_type)
+    }
+
+    fn group_keys(self, base_addr: IndexAddress) -> GroupKeys<Self::Base> {
+        let mut prefixed_addr = base_addr.prepend_name(self.namespace.as_ref());
+        prefixed_addr.set_in_migration();
+        IndexesPool::new(self.access).group_keys(&prefixed_addr)
     }
 }
 

--- a/components/merkledb/src/views/address.rs
+++ b/components/merkledb/src/views/address.rs
@@ -165,6 +165,15 @@ impl IndexAddress {
         }
     }
 
+    /// Returns common prefix of fully qualified names for the child indexes.
+    pub(super) fn qualified_prefix(&self) -> Vec<u8> {
+        let mut prefix = self.fully_qualified_name();
+        if self.id_in_group.is_none() {
+            prefix.push(SEPARATOR_CHAR);
+        }
+        prefix
+    }
+
     /// Infers the name part of the fully qualified name that was obtained with
     /// `fully_qualified_name`. This is the part corresponding to `ResolvedAddress.name`.
     /// `min_name_len` specifies the minimum known length of the name part.

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -18,6 +18,7 @@ pub use self::{
         get_object_hash, BinaryAttribute, IndexMetadata, IndexState, IndexType, IndexesPool,
         ViewWithMetadata,
     },
+    owning_iter::OwningIter,
     system_schema::{get_state_aggregator, SystemSchema},
 };
 
@@ -31,6 +32,7 @@ use super::{
 
 mod address;
 mod metadata;
+mod owning_iter;
 mod system_schema;
 #[cfg(test)]
 mod tests;

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -15,8 +15,8 @@
 pub use self::{
     address::{IndexAddress, ResolvedAddress},
     metadata::{
-        get_object_hash, BinaryAttribute, IndexMetadata, IndexState, IndexType, IndexesPool,
-        ViewWithMetadata,
+        get_object_hash, BinaryAttribute, GroupKeys, IndexMetadata, IndexState, IndexType,
+        IndexesPool, ViewWithMetadata,
     },
     owning_iter::OwningIter,
     system_schema::{get_state_aggregator, SystemSchema},

--- a/components/merkledb/src/views/owning_iter.rs
+++ b/components/merkledb/src/views/owning_iter.rs
@@ -1,0 +1,337 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{marker::PhantomPinned, mem, pin::Pin};
+
+use crate::{
+    db::Iterator,
+    views::{RawAccess, View},
+};
+
+#[derive(Debug)]
+struct Inner<T: RawAccess> {
+    // Safety: Not accessed during iteration.
+    view: View<T>,
+    iter: Option<Box<dyn Iterator>>,
+    _pin: PhantomPinned,
+}
+
+impl<T: RawAccess> Inner<T> {
+    #[allow(unsafe_code)]
+    fn new(view: View<T>, from: &[u8]) -> Pin<Box<Self>> {
+        let mut boxed = Box::pin(Self {
+            view,
+            iter: None,
+            _pin: PhantomPinned,
+        });
+
+        unsafe {
+            // Elongate the iterator lifetime to `'static`.
+            //
+            // SAFETY:
+            // `T` may not have static lifetime (indeed, `T == &Fork` or `T == &dyn Snapshot`
+            // are two frequent use cases), but since `Inner` contains `T` as the type param,
+            // `iter` is always valid during the lifetime of the `Inner` instance.
+            let iter: Box<dyn Iterator> = mem::transmute(boxed.view.iter_bytes(from));
+
+            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed);
+            // SAFETY: The `iter` field is never considered pinned.
+            Pin::get_unchecked_mut(mut_ref).iter = Some(iter);
+        }
+        boxed
+    }
+
+    #[allow(unsafe_code, clippy::borrowed_box)]
+    fn iter(self: Pin<&mut Self>) -> &mut Box<dyn Iterator> {
+        // SAFETY: The `iter` field is never considered pinned.
+        let iter = unsafe { &mut self.get_unchecked_mut().iter };
+        // `unwrap()` is safe: Once the `Inner` instance is initialized, `iter` is
+        // always `Some(_)`.
+        iter.as_mut().unwrap()
+    }
+}
+
+/// Iterator over a view that owns the view together with the iterator.
+/// Thus, the iterator lifetime is only limited by the lifetime of access `T`.
+#[derive(Debug)]
+pub struct OwningIter<T: RawAccess> {
+    inner: Pin<Box<Inner<T>>>,
+}
+
+impl<T: RawAccess> OwningIter<T> {
+    pub fn new(view: View<T>, from: &[u8]) -> Self {
+        Self {
+            inner: Inner::new(view, from),
+        }
+    }
+}
+
+impl<T: RawAccess> Iterator for OwningIter<T> {
+    fn next(&mut self) -> Option<(&[u8], &[u8])> {
+        Pin::as_mut(&mut self.inner).iter().next()
+    }
+
+    fn peek(&mut self) -> Option<(&[u8], &[u8])> {
+        Pin::as_mut(&mut self.inner).iter().peek()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Database, Fork, TemporaryDB};
+
+    use std::{convert::TryInto, iter::Iterator as StdIterator, str};
+
+    #[test]
+    fn owning_iter_basics() {
+        let db = TemporaryDB::new();
+        let mut fork = db.fork();
+        let mut view = View::new(&fork, "test");
+        view.put(&1_u8, 2_u8);
+        view.put(&2_u8, 3_u8);
+        view.put(&3_u8, 4_u8);
+
+        {
+            let mut iter = OwningIter::new(view, &[]);
+            let mut entries = vec![];
+            while let Some((k, v)) = iter.next() {
+                entries.push((k[0], v[0]));
+            }
+            assert_eq!(entries, vec![(1, 2), (2, 3), (3, 4)]);
+        }
+
+        // Since iter is dropped, the view should be accessible again.
+        let mut view = View::new(&fork, "test");
+        view.put(&2_u8, 5_u8);
+        {
+            let mut iter = OwningIter::new(view, &[2]);
+            let mut entries = vec![];
+            while let Some((k, v)) = iter.next() {
+                entries.push((k[0], v[0]));
+            }
+            assert_eq!(entries, vec![(2, 5), (3, 4)]);
+        }
+
+        fork.flush();
+        let view = View::new(&fork, "test");
+        {
+            let mut iter = OwningIter::new(view, &[1]);
+            let mut entries = vec![];
+            while let Some((k, v)) = iter.next() {
+                entries.push((k[0], v[0]));
+            }
+            assert_eq!(entries, vec![(1, 2), (2, 5), (3, 4)]);
+        }
+
+        let mut view = View::new(&fork, "test");
+        view.put(&5_u8, 8_u8);
+        view.remove(&1_u8);
+        {
+            let mut iter = OwningIter::new(view, &[1]);
+            let mut entries = vec![];
+            while let Some((k, v)) = iter.next() {
+                entries.push((k[0], v[0]));
+            }
+            assert_eq!(entries, vec![(2, 5), (3, 4), (5, 8)]);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Multiple mutable borrows")]
+    fn concurrent_borrow_with_iter() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut view = View::new(&fork, "test");
+        view.put(&1_u8, 2_u8);
+        let _iter = OwningIter::new(view, &[]);
+        View::new(&fork, "test");
+        // ^-- The view is still borrowed within the iterator, so this should panic.
+    }
+
+    fn check_keys(mut iter: OwningIter<&Fork>, mut expected_keys: impl StdIterator<Item = u32>) {
+        while let Some((k, v)) = iter.next() {
+            let k = u32::from_be_bytes(k.try_into().unwrap());
+            let v: u32 = str::from_utf8(v).unwrap().parse().unwrap();
+            assert_eq!(k, v);
+            assert_eq!(Some(k), expected_keys.next());
+        }
+        assert_eq!(expected_keys.next(), None);
+    }
+
+    #[test]
+    fn owning_iter_large() {
+        let db = TemporaryDB::new();
+        let mut fork = db.fork();
+        let mut view = View::new(&fork, "test");
+        for i in 0_u32..10_000 {
+            view.put(&i, i.to_string());
+            view.remove(&(i / 3));
+        }
+
+        check_keys(OwningIter::new(view, &[]), (10_000_u32 / 3 + 1)..10_000);
+
+        fork.flush();
+        let mut view = View::new(&fork, "test");
+        for i in 10_000_u32..20_000 {
+            view.put(&i, i.to_string());
+            view.remove(&(i / 5));
+        }
+        for i in 0_u32..1000 {
+            view.put(&i, i.to_string());
+        }
+
+        check_keys(
+            OwningIter::new(view, &[]),
+            (0_u32..1000).chain(4_000..20_000),
+        );
+        let view = View::new(&fork, "test");
+        check_keys(
+            OwningIter::new(view, &6_000_u32.to_be_bytes()),
+            6_000_u32..20_000,
+        );
+    }
+}
+
+#[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use crate::{Database, TemporaryDB};
+
+    use proptest::{
+        collection::vec, prop_assert, prop_assert_eq, prop_oneof, proptest, strategy,
+        strategy::Strategy, test_runner::TestCaseResult,
+    };
+
+    use std::{
+        collections::{BTreeMap, HashSet},
+        ops::Bound,
+    };
+
+    const ACTIONS_MAX_LEN: usize = 50;
+    const VIEW_NAME: &str = "test";
+
+    #[derive(Debug, Clone)]
+    enum Action {
+        Put { key: Vec<u8>, value: Vec<u8> },
+        Remove(Vec<u8>),
+        FlushFork,
+        MergeFork,
+    }
+
+    fn generate_action() -> impl Strategy<Value = Action> {
+        prop_oneof![
+            4 => (vec(0_u8..4, 1..2), vec(0_u8..4, 1..5))
+                .prop_map(|(key, value)| Action::Put { key, value }),
+            4 => vec(0_u8..4, 1..2).prop_map(Action::Remove),
+            1 => strategy::Just(Action::FlushFork),
+            1 => strategy::Just(Action::MergeFork),
+        ]
+    }
+
+    fn check_view_range(
+        access: impl RawAccess,
+        reference: &BTreeMap<Vec<u8>, Vec<u8>>,
+        from: &[u8],
+    ) -> TestCaseResult {
+        let view = View::new(access, VIEW_NAME);
+        let mut iter = OwningIter::new(view, from);
+        let mut reference_iter =
+            reference.range::<[u8], _>((Bound::Included(from), Bound::Unbounded));
+        while let Some((key, value)) = iter.next() {
+            let (expected_key, expected_value) = if let Some((k, v)) = reference_iter.next() {
+                (k, v)
+            } else {
+                prop_assert!(false, "Reference iter ended before the checked one");
+                return Ok(()); // unreachable; needed for type inference
+            };
+            prop_assert_eq!(key, expected_key.as_slice());
+            prop_assert_eq!(value, expected_value.as_slice());
+        }
+        prop_assert_eq!(reference_iter.next(), None);
+        Ok(())
+    }
+
+    fn check_view(
+        access: impl RawAccess + Copy,
+        reference: &BTreeMap<Vec<u8>, Vec<u8>>,
+    ) -> TestCaseResult {
+        // Some fixed bounds.
+        check_view_range(access, reference, &[])?;
+        check_view_range(access, reference, &[1])?;
+        check_view_range(access, reference, &[1, 2])?;
+        check_view_range(access, reference, &[255; 8])?; // Guaranteed to be empty
+
+        // Bounds based on the reference.
+        let mut keys = HashSet::new();
+        let len = reference.len();
+        keys.insert(reference.keys().next());
+        keys.insert(reference.keys().nth(2));
+        keys.insert(reference.keys().nth(len / 4));
+        keys.insert(reference.keys().nth(len / 2));
+        keys.insert(reference.keys().nth(2 * len / 3));
+        keys.insert(reference.keys().rev().next());
+
+        for key in keys.into_iter().filter_map(|key| key) {
+            check_view_range(access, reference, key)?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_actions(db: &TemporaryDB, actions: Vec<Action>) -> TestCaseResult {
+        let mut fork = db.fork();
+        let mut reference = BTreeMap::new();
+        for action in actions {
+            match action {
+                Action::Put { key, value } => {
+                    View::new(&fork, VIEW_NAME).put(&key, value.clone());
+                    reference.insert(key, value);
+                }
+                Action::Remove(key) => {
+                    View::new(&fork, VIEW_NAME).remove(&key);
+                    reference.remove(&key);
+                }
+                Action::FlushFork => fork.flush(),
+                Action::MergeFork => {
+                    let patch = fork.into_patch();
+                    check_view(&patch, &reference)?;
+                    db.merge(patch).unwrap();
+                    check_view(&db.snapshot(), &reference)?;
+                    fork = db.fork();
+                }
+            }
+            check_view(&fork, &reference)?;
+        }
+        Ok(())
+    }
+
+    fn clear(db: &TemporaryDB) {
+        let fork = db.fork();
+        {
+            let mut view = View::new(&fork, VIEW_NAME);
+            view.clear();
+        }
+        db.merge(fork.into_patch()).unwrap();
+    }
+
+    #[test]
+    fn owning_iter() {
+        let db = TemporaryDB::new();
+        proptest!(|(actions in vec(generate_action(), 1..ACTIONS_MAX_LEN))| {
+            apply_actions(&db, actions)?;
+            clear(&db);
+        });
+    }
+}

--- a/components/merkledb/src/views/system_schema.rs
+++ b/components/merkledb/src/views/system_schema.rs
@@ -187,24 +187,26 @@ mod tests {
         further_changes(&fork);
 
         let patch = fork.into_patch();
-        let system_schema = SystemSchema::new(&patch);
-        let aggregator = system_schema.state_aggregator();
         let expected_index_names = vec![
             "another_map".to_owned(),
             "entry".to_owned(),
             "list".to_owned(),
             "map".to_owned(),
         ];
-        assert_eq!(aggregator.keys().collect::<Vec<_>>(), expected_index_names);
-        assert_eq!(
-            aggregator.get(&"list".to_owned()).unwrap(),
-            patch.get_proof_list::<_, u32>("list").object_hash()
-        );
-        assert_eq!(
-            aggregator.get(&"map".to_owned()).unwrap(),
-            patch.get_proof_map::<_, i32, String>("map").object_hash()
-        );
-        assert_eq!(aggregator.object_hash(), system_schema.state_hash());
+        {
+            let system_schema = SystemSchema::new(&patch);
+            let aggregator = system_schema.state_aggregator();
+            assert_eq!(aggregator.keys().collect::<Vec<_>>(), expected_index_names);
+            assert_eq!(
+                aggregator.get(&"list".to_owned()).unwrap(),
+                patch.get_proof_list::<_, u32>("list").object_hash()
+            );
+            assert_eq!(
+                aggregator.get(&"map".to_owned()).unwrap(),
+                patch.get_proof_map::<_, i32, String>("map").object_hash()
+            );
+            assert_eq!(aggregator.object_hash(), system_schema.state_hash());
+        }
         db.merge_sync(patch).unwrap();
 
         let snapshot = db.snapshot();

--- a/services/supervisor/tests/supervisor/utils.rs
+++ b/services/supervisor/tests/supervisor/utils.rs
@@ -41,7 +41,8 @@ pub const SECOND_SERVICE_NAME: &str = "change-service";
 pub fn config_propose_entry(testkit: &TestKit) -> Option<ConfigPropose> {
     let snapshot = testkit.snapshot();
     let snapshot = snapshot.for_service(supervisor_name()).unwrap();
-    Schema::new(snapshot)
+    let schema = Schema::new(snapshot);
+    schema
         .pending_proposal
         .get()
         .map(|entry| entry.config_propose)

--- a/test-suite/consensus-tests/src/lib.rs
+++ b/test-suite/consensus-tests/src/lib.rs
@@ -742,9 +742,8 @@ impl Sandbox {
 
     pub fn get_proof_to_index(&self, index_name: &str) -> MapProof<String, Hash> {
         let snapshot = self.blockchain().snapshot();
-        SystemSchema::new(&snapshot)
-            .state_aggregator()
-            .get_proof(index_name.to_owned())
+        let aggregator = SystemSchema::new(&snapshot).state_aggregator();
+        aggregator.get_proof(index_name.to_owned())
     }
 
     pub fn get_configs_merkle_root(&self) -> Hash {


### PR DESCRIPTION
## Overview

This is another approach to key enumeration within a group. It introduces *the owning iterator*. The owning iterator is implemented via a self-referential struct via pinning (I've tried to use [`rental`](https://docs.rs/rental/0.5.4/rental/index.html), but didn't get it to work; the crux of the issue is that the tail part of the struct - i.e., the iterator - needs to be taken by a *mutable* reference and return a *shared* reference to its data). The iteration over group keys is then implemented as a particular use case of the owning iterator over the metadata index.

The resulting API is still clunky; to slightly soften restrictions on it, I've changed the logic of writing metadata for indexes. Previously, the metadata was written eagerly on each change; now, it's written on index drop. There's still a plenty of situations where using an iterator will lead to a panic, so a `buffered_keys()` alternative is still implemented.

Owning iterators may be of separate interest; they make it possible to convert indexes into iterators, which may be useful, e.g., to return such an iterator from a function. The issue with owning iterators is that I'm not 100% sure they are memory-safe (there's some `unsafe` code involved).

See also #1614