### PR TITLE
Remove extern crate exonum_derive in exonum [ECR-4004]

### DIFF
--- a/exonum/src/blockchain/block.rs
+++ b/exonum/src/blockchain/block.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use exonum_derive::{BinaryValue, ObjectHash};
+use exonum_merkledb::{BinaryValue, MapProof};
+use exonum_proto::ProtobufConvert;
 use failure::Error;
 
-use exonum_merkledb::MapProof;
-use exonum_proto::ProtobufConvert;
+use std::{borrow::Cow, fmt};
 
 use crate::{
     crypto::Hash,
@@ -23,8 +25,6 @@ use crate::{
     messages::{Precommit, Verified},
     proto::{self, OrderedMap},
 };
-use exonum_merkledb::BinaryValue;
-use std::{borrow::Cow, fmt};
 
 /// Trait that represents key in block header entry map. Provide
 /// mapping between `NAME` of the entry and its value.

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -21,6 +21,9 @@
 //! validators, consensus related parameters, hash of the previous configuration,
 //! etc.
 
+use exonum_derive::{BinaryValue, ObjectHash};
+use exonum_proto::ProtobufConvert;
+
 use std::collections::{HashMap, HashSet};
 
 use crate::{
@@ -31,8 +34,6 @@ use crate::{
     proto::schema::{blockchain, runtime},
     runtime::{ArtifactId, ArtifactSpec, InstanceId, InstanceSpec},
 };
-
-use exonum_proto::ProtobufConvert;
 
 /// Public keys of a validator. Each validator has two public keys: the
 /// `consensus_key` is used for internal operations in the consensus process,

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use exonum_derive::{BinaryValue, ObjectHash};
 use exonum_merkledb::{
     access::{Access, AccessExt, RawAccessMut},
     impl_binary_key_for_binary_value, Entry, KeySetIndex, ListIndex, MapIndex, ObjectHash,

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use exonum_crypto::{PublicKey, SecretKey};
+use exonum_derive::FromAccess;
 use exonum_merkledb::{
     access::Access, BinaryValue, Error as MerkledbError, ObjectHash, ProofListIndex, Snapshot,
     SystemSchema,

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -42,8 +42,6 @@
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
-#[macro_use]
-extern crate exonum_derive;
 pub use exonum_merkledb;
 #[cfg(feature = "sodiumoxide-crypto")]
 extern crate exonum_sodiumoxide as sodiumoxide;

--- a/exonum/src/messages/types.rs
+++ b/exonum/src/messages/types.rs
@@ -16,7 +16,9 @@ pub use crate::runtime::AnyTx;
 
 use bit_vec::BitVec;
 use chrono::{DateTime, Utc};
+use exonum_derive::{BinaryValue, ObjectHash};
 use exonum_merkledb::{BinaryValue, HashTag};
+use exonum_proto::ProtobufConvert;
 
 use std::convert::TryFrom;
 
@@ -26,8 +28,6 @@ use crate::{
     helpers::{Height, Round, ValidatorId},
     proto::schema::consensus,
 };
-
-use exonum_proto::ProtobufConvert;
 
 /// Protobuf based container for any signed messages.
 ///

--- a/exonum/src/proto/tests.rs
+++ b/exonum/src/proto/tests.rs
@@ -14,6 +14,7 @@
 
 use bit_vec::BitVec;
 use chrono::{DateTime, TimeZone, Utc};
+use exonum_derive::{BinaryValue, ObjectHash};
 use exonum_merkledb::BinaryValue;
 
 use std::{borrow::Cow, collections::HashMap};

--- a/exonum/src/runtime/rust/tests.rs
+++ b/exonum/src/runtime/rust/tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use exonum_crypto::{Hash, PublicKey, PUBLIC_KEY_LENGTH};
-use exonum_derive::exonum_interface;
+use exonum_derive::{exonum_interface, BinaryValue, ServiceDispatcher, ServiceFactory};
 use exonum_merkledb::{access::AccessExt, BinaryValue, Fork, Snapshot, SystemSchema};
 use exonum_proto::ProtobufConvert;
 use futures::{sync::mpsc, Future};

--- a/exonum/src/runtime/types.rs
+++ b/exonum/src/runtime/types.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use exonum_crypto::{PublicKey, SecretKey};
+use exonum_derive::{BinaryValue, ObjectHash};
 use exonum_merkledb::{
     impl_binary_key_for_binary_value,
     validation::{is_valid_identifier, is_valid_index_name_component},


### PR DESCRIPTION
## Overview

Removed `extern crate exonum_derive` in exonum.
