### PR TITLE
Remove extern crate exonum_sodiumoxide in exonum [ECR-4004]

### DIFF
--- a/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
@@ -15,6 +15,9 @@
 // spell-checker:ignore chacha, privkey, authtext, ciphertext
 
 use byteorder::{ByteOrder, LittleEndian};
+use exonum_sodiumoxide::crypto::{
+    aead::chacha20poly1305_ietf as sodium_chacha20poly1305, hash::sha256 as sodium_sha256,
+};
 use rand::{thread_rng, CryptoRng, Error, RngCore};
 use snow::{
     params::{CipherChoice, DHChoice, HashChoice},
@@ -25,9 +28,6 @@ use snow::{
 use crate::crypto::{
     x25519, PUBLIC_KEY_LENGTH as SHA256_PUBLIC_KEY_LENGTH,
     SECRET_KEY_LENGTH as SHA256_SECRET_KEY_LENGTH,
-};
-use crate::sodiumoxide::crypto::{
-    aead::chacha20poly1305_ietf as sodium_chacha20poly1305, hash::sha256 as sodium_sha256,
 };
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -45,8 +45,6 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate exonum_derive;
 pub use exonum_merkledb;
-#[cfg(feature = "sodiumoxide-crypto")]
-extern crate exonum_sodiumoxide as sodiumoxide;
 #[macro_use]
 extern crate failure;
 #[macro_use]


### PR DESCRIPTION
## Overview

Removed `extern crate exonum_sodiumoxide` in exonum.
