### PR TITLE
Fix Rust compatibility

### DIFF
--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -13,30 +13,22 @@ description = "Cryptography related types, constants, traits and functions."
 links = "exonum_protobuf_crypto"
 
 [dependencies]
-byteorder = { version = "1.2.7", features = [ "i128" ] }
-chrono = "0.4.6"
 hex = "0.4"
-hex-buffer-serde = "0.2.0"
-rand = "0.7"
-rust_decimal = "1.0"
 serde = "1.0.101"
 serde_derive = "1.0.101"
-serde_json = "1.0.19"
 failure = "0.1.5"
-toml = "0.5.0"
-uuid = "0.8"
-exonum_sodiumoxide = { version = "0.0.23", optional = true}
-exonum-proto = { path = "../proto", version = "0.13.0-rc.2", optional = true}
-protobuf = { version = "2.8.1", features = ["with-serde"] }
-bit-vec = "0.6.1"
+exonum_sodiumoxide = { version = "0.0.23", optional = true }
+exonum-proto = { path = "../proto", version = "0.13.0-rc.2", optional = true }
+protobuf = { version = "2.8.1", features = ["with-serde"], optional = true }
 
 [dev-dependencies]
+serde_json = "1.0.44"
 tempdir = "0.3.7"
 
 [features]
 default = ["sodiumoxide-crypto", "with-protobuf", "with-serde"]
 sodiumoxide-crypto = ["exonum_sodiumoxide"]
-with-protobuf = ["exonum-proto"]
+with-protobuf = ["exonum-proto", "protobuf"]
 with-serde = []
 
 [build-dependencies]

--- a/components/crypto/src/lib.rs
+++ b/components/crypto/src/lib.rs
@@ -29,6 +29,7 @@ pub use self::crypto_impl::{
 };
 #[cfg(feature = "sodiumoxide-crypto")]
 pub use self::crypto_lib::sodiumoxide::x25519;
+#[cfg(feature = "with-protobuf")]
 pub use self::proto::*;
 
 #[cfg(feature = "with-protobuf")]

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4"
 leb128 = "0.2"
 num-traits = "0.2"
 rocksdb = { version = "0.12.3", default-features = false }
-rust_decimal = "1.0"
+rust_decimal = "1.0, <1.1.0" # The 1.1.0 version requires Rust 1.39+
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
## Overview

We target Rust 1.36, so newer crate versions may have to wait.