### PR TITLE
Use uint32 for tx position in block: [ECR-4083]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `BlockchainBuilder::build` now returns `BlockchainMut` instead of `Result`. (#1659)
 - A type for transaction position in block has been changed for `u32`. (#1668)
+- A type for a position of transaction in the block has been changed for `u32`. (#1668)
 
 #### exonum-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `update_service_status` now does not return a value. (#1659)
 
 - `BlockchainBuilder::build` now returns `BlockchainMut` instead of `Result`. (#1659)
+- A type for transaction position in block has been changed for `u32`. (#1668)
 
 #### exonum-cli
 

--- a/components/explorer/src/api.rs
+++ b/components/explorer/src/api.rs
@@ -218,7 +218,7 @@ impl CommittedTransactionSummary {
         let tx_result = schema.transaction_result(location)?;
         let location_proof = schema
             .block_transactions(location.block_height())
-            .get_proof(location.position_in_block());
+            .get_proof(location.position_in_block().into());
         let time = median_precommits_time(
             &schema
                 .block_and_precommits(location.block_height())

--- a/components/explorer/src/lib.rs
+++ b/components/explorer/src/lib.rs
@@ -656,7 +656,7 @@ impl<'a> BlockchainExplorer<'a> {
         let location_proof = self
             .schema
             .block_transactions(location.block_height())
-            .get_proof(location.position_in_block() as u64);
+            .get_proof(u64::from(location.position_in_block()));
 
         let block_precommits = self
             .schema

--- a/components/explorer/src/lib.rs
+++ b/components/explorer/src/lib.rs
@@ -656,7 +656,7 @@ impl<'a> BlockchainExplorer<'a> {
         let location_proof = self
             .schema
             .block_transactions(location.block_height())
-            .get_proof(location.position_in_block());
+            .get_proof(location.position_in_block() as u64);
 
         let block_precommits = self
             .schema

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -801,7 +801,7 @@ mod tests {
         scratchpad.get_list("list").extend(vec![2_u32, 3]);
 
         // Check that info persists to `Patch`es and `Snapshot`s.
-        let patch = fork.into_patch();;
+        let patch = fork.into_patch();
         let scratchpad = Scratchpad::new("test", &patch);
         let list = scratchpad.get_list::<_, u32>("list");
         assert_eq!(list.len(), 2);

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -307,7 +307,7 @@ impl BlockchainMut {
         }
 
         // Save & execute transactions.
-        for (index, hash) in (0..).zip(tx_hashes.iter()) {
+        for (index, hash) in (0..).zip(tx_hashes) {
             self.execute_transaction(*hash, height, index, &mut fork, tx_cache);
         }
 

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -35,6 +35,7 @@ use futures::Future;
 
 use std::{
     collections::{BTreeMap, HashMap},
+    convert::TryInto,
     iter,
     sync::Arc,
 };
@@ -308,7 +309,13 @@ impl BlockchainMut {
 
         // Save & execute transactions.
         for (index, hash) in tx_hashes.iter().enumerate() {
-            self.execute_transaction(*hash, height, index, &mut fork, tx_cache);
+            self.execute_transaction(
+                *hash,
+                height,
+                index.try_into().unwrap(),
+                &mut fork,
+                tx_cache,
+            );
         }
 
         // During processing of the genesis block, this hook is already called in another method.
@@ -368,7 +375,7 @@ impl BlockchainMut {
         &self,
         tx_hash: Hash,
         height: Height,
-        index: usize,
+        index: u32,
         fork: &mut Fork,
         tx_cache: &mut BTreeMap<Hash, Verified<AnyTx>>,
     ) {
@@ -377,19 +384,17 @@ impl BlockchainMut {
             .unwrap_or_else(|| panic!("BUG: Cannot find transaction {:?} in database", tx_hash));
         fork.flush();
 
-        let tx_result = self
-            .dispatcher
-            .execute(fork, tx_hash, index as u64, &transaction);
+        let tx_result = self.dispatcher.execute(fork, tx_hash, index, &transaction);
         let mut schema = Schema::new(&*fork);
 
         if let Err(e) = tx_result {
             schema
                 .call_errors(height)
-                .put(&CallInBlock::transaction(index as u64), e);
+                .put(&CallInBlock::transaction(index), e);
         }
         schema.commit_transaction(&tx_hash, height, transaction);
         tx_cache.remove(&tx_hash);
-        let location = TxLocation::new(height, index as u64);
+        let location = TxLocation::new(height, index);
         schema.transactions_locations().put(&tx_hash, location);
         fork.flush();
     }

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -35,7 +35,6 @@ use futures::Future;
 
 use std::{
     collections::{BTreeMap, HashMap},
-    convert::TryInto,
     iter,
     sync::Arc,
 };
@@ -308,14 +307,8 @@ impl BlockchainMut {
         }
 
         // Save & execute transactions.
-        for (index, hash) in tx_hashes.iter().enumerate() {
-            self.execute_transaction(
-                *hash,
-                height,
-                index.try_into().unwrap(),
-                &mut fork,
-                tx_cache,
-            );
+        for (index, hash) in (0..).zip(tx_hashes.iter()) {
+            self.execute_transaction(*hash, height, index, &mut fork, tx_cache);
         }
 
         // During processing of the genesis block, this hook is already called in another method.

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -71,12 +71,12 @@ pub struct TxLocation {
     /// Height of the block where the transaction was included.
     block_height: Height,
     /// Zero-based position of this transaction in the block.
-    position_in_block: u64,
+    position_in_block: u32,
 }
 
 impl TxLocation {
     /// Creates a new transaction location.
-    pub fn new(block_height: Height, position_in_block: u64) -> Self {
+    pub fn new(block_height: Height, position_in_block: u32) -> Self {
         Self {
             block_height,
             position_in_block,
@@ -89,7 +89,7 @@ impl TxLocation {
     }
 
     /// Zero-based position of this transaction in the block.
-    pub fn position_in_block(&self) -> u64 {
+    pub fn position_in_block(&self) -> u32 {
         self.position_in_block
     }
 }
@@ -143,7 +143,8 @@ impl<T: Access> Schema<T> {
     /// Returns the result of the execution for a transaction with the specified location.
     /// If the location does not correspond to a transaction, returns `None`.
     pub fn transaction_result(&self, location: TxLocation) -> Option<Result<(), ExecutionError>> {
-        if self.block_transactions(location.block_height).len() <= location.position_in_block {
+        if self.block_transactions(location.block_height).len() <= location.position_in_block as u64
+        {
             return None;
         }
 
@@ -389,7 +390,7 @@ pub enum CallInBlock {
     /// Call of a transaction within the block.
     Transaction {
         /// Zero-based transaction index.
-        index: u64,
+        index: u32,
     },
     /// Call of `after_transactions` hook in a service.
     AfterTransactions {
@@ -437,7 +438,7 @@ impl CallInBlock {
     }
 
     /// Creates a location corresponding to a transaction.
-    pub fn transaction(index: u64) -> Self {
+    pub fn transaction(index: u32) -> Self {
         CallInBlock::Transaction { index }
     }
 

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -143,7 +143,8 @@ impl<T: Access> Schema<T> {
     /// Returns the result of the execution for a transaction with the specified location.
     /// If the location does not correspond to a transaction, returns `None`.
     pub fn transaction_result(&self, location: TxLocation) -> Option<Result<(), ExecutionError>> {
-        if self.block_transactions(location.block_height).len() <= location.position_in_block as u64
+        if self.block_transactions(location.block_height).len()
+            <= u64::from(location.position_in_block)
         {
             return None;
         }

--- a/exonum/src/proto/schema/exonum/blockchain.proto
+++ b/exonum/src/proto/schema/exonum/blockchain.proto
@@ -34,7 +34,7 @@ message Block {
 
 message TxLocation {
   uint64 block_height = 1;
-  uint64 position_in_block = 2;
+  uint32 position_in_block = 2;
 }
 
 // Location of an isolated call within a block.
@@ -42,7 +42,7 @@ message CallInBlock {
   oneof call {
     // Call of a transaction within the block. The value is the zero-based
     // transaction index.
-    uint64 transaction = 1;
+    uint32 transaction = 1;
     // Call of `before_transactions` hook in a service. The value is
     // the service identifier.
     uint32 before_transactions = 2;

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -317,7 +317,7 @@ impl Dispatcher {
         &self,
         fork: &mut Fork,
         tx_id: Hash,
-        tx_index: u64,
+        tx_index: u32,
         tx: &Verified<AnyTx>,
     ) -> Result<(), ExecutionError> {
         let caller = Caller::Transaction {

--- a/test-suite/consensus-tests/tests/basic.rs
+++ b/test-suite/consensus-tests/tests/basic.rs
@@ -30,7 +30,7 @@ use exonum_consensus_tests::{
 use exonum_merkledb::ObjectHash;
 use rand::{thread_rng, Rng};
 
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::collections::BTreeMap;
 
 /// idea of the test is to verify that at certain periodic rounds we (`validator_0`) become a leader
 /// assumption: in some loops current node becomes a leader
@@ -276,12 +276,9 @@ fn test_store_txs_positions() {
     let snapshot = sandbox.blockchain().snapshot();
     let schema = snapshot.for_core();
     let locations = schema.transactions_locations();
-    for (expected_idx, hash) in hashes.iter().enumerate() {
+    for (expected_idx, hash) in (0u32..).zip(hashes.iter()) {
         let location = locations.get(hash).unwrap();
-        assert_eq!(
-            u32::try_from(expected_idx).unwrap(),
-            location.position_in_block()
-        );
+        assert_eq!(expected_idx, location.position_in_block());
         assert_eq!(committed_height, location.block_height());
     }
 }

--- a/test-suite/consensus-tests/tests/basic.rs
+++ b/test-suite/consensus-tests/tests/basic.rs
@@ -30,7 +30,7 @@ use exonum_consensus_tests::{
 use exonum_merkledb::ObjectHash;
 use rand::{thread_rng, Rng};
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 /// idea of the test is to verify that at certain periodic rounds we (`validator_0`) become a leader
 /// assumption: in some loops current node becomes a leader
@@ -278,7 +278,10 @@ fn test_store_txs_positions() {
     let locations = schema.transactions_locations();
     for (expected_idx, hash) in hashes.iter().enumerate() {
         let location = locations.get(hash).unwrap();
-        assert_eq!(expected_idx as u64, location.position_in_block());
+        assert_eq!(
+            u32::try_from(expected_idx).unwrap(),
+            location.position_in_block()
+        );
         assert_eq!(committed_height, location.block_height());
     }
 }

--- a/test-suite/consensus-tests/tests/basic.rs
+++ b/test-suite/consensus-tests/tests/basic.rs
@@ -276,7 +276,7 @@ fn test_store_txs_positions() {
     let snapshot = sandbox.blockchain().snapshot();
     let schema = snapshot.for_core();
     let locations = schema.transactions_locations();
-    for (expected_idx, hash) in (0u32..).zip(hashes.iter()) {
+    for (expected_idx, hash) in (0u32..).zip(&hashes) {
         let location = locations.get(hash).unwrap();
         assert_eq!(expected_idx, location.position_in_block());
         assert_eq!(committed_height, location.block_height());


### PR DESCRIPTION

## Overview

2^32 - 1 is plenty to index tx position in block.

The number of tx is already limited to a way smaller number.

See ECR-4083

[skip ci]


<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
