### PR TITLE
Improve migration functionality [ECR-4078] [ECR-4079]

### DIFF
--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -41,6 +41,7 @@ assert_matches = "1.3.0"
 criterion = "0.3"
 exonum-derive = { version = "0.13.0-rc.2", path = "../derive" }
 rand = "0.7"
+rand_xorshift = "0.2.0"
 proptest = "0.9"
 modifier = "0.1"
 pretty_assertions = "0.6"

--- a/components/merkledb/examples/migration.rs
+++ b/components/merkledb/examples/migration.rs
@@ -35,7 +35,7 @@ use exonum_derive::FromAccess;
 use exonum_merkledb::{
     access::{Access, AccessExt, FromAccess, Prefixed},
     impl_object_hash_for_binary_value,
-    migration::Migration,
+    migration::{Migration, MigrationHelper},
     BinaryValue, Database, Entry, Fork, Group, ListIndex, MapIndex, ObjectHash, ProofEntry,
     ProofListIndex, ProofMapIndex, ReadonlyFork, SystemSchema, TemporaryDB,
 };
@@ -260,7 +260,7 @@ fn main() {
     assert_eq!(new_state_hash, migration_view.state_hash());
 
     let mut fork = db.fork();
-    fork.flush_migration("test");
+    MigrationHelper::flush_migration(&mut fork, "test");
     let patch = fork.into_patch();
 
     // Now, the new indexes have replaced the old ones.

--- a/components/merkledb/examples/migration.rs
+++ b/components/merkledb/examples/migration.rs
@@ -35,7 +35,7 @@ use exonum_derive::FromAccess;
 use exonum_merkledb::{
     access::{Access, AccessExt, FromAccess, Prefixed},
     impl_object_hash_for_binary_value,
-    migration::{Migration, MigrationHelper},
+    migration::{flush_migration, Migration},
     BinaryValue, Database, Entry, Fork, Group, ListIndex, MapIndex, ObjectHash, ProofEntry,
     ProofListIndex, ProofMapIndex, ReadonlyFork, SystemSchema, TemporaryDB,
 };
@@ -260,7 +260,7 @@ fn main() {
     assert_eq!(new_state_hash, migration_view.state_hash());
 
     let mut fork = db.fork();
-    MigrationHelper::flush_migration(&mut fork, "test");
+    flush_migration(&mut fork, "test");
     let patch = fork.into_patch();
 
     // Now, the new indexes have replaced the old ones.

--- a/components/merkledb/src/db.rs
+++ b/components/merkledb/src/db.rs
@@ -718,7 +718,7 @@ impl Fork {
     }
 
     /// Finishes a migration of indexes with the specified prefix.
-    pub fn flush_migration(&mut self, prefix: &str) {
+    pub(crate) fn flush_migration(&mut self, prefix: &str) {
         assert_valid_name_component(prefix);
 
         // Mutable `self` reference ensures that no indexes are instantiated in the client code.
@@ -753,7 +753,7 @@ impl Fork {
 
     /// Rolls back the migration with the specified name. This will remove all indexes
     /// within the migration.
-    pub fn rollback_migration(&mut self, prefix: &str) {
+    pub(crate) fn rollback_migration(&mut self, prefix: &str) {
         assert_valid_name_component(prefix);
         self.flush();
         SystemSchema::new(&*self).remove_namespace(prefix);

--- a/components/merkledb/src/indexes/group.rs
+++ b/components/merkledb/src/indexes/group.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::*;
     use crate::{
         access::{AccessExt, Prefixed, RawAccessMut},
-        migration::Migration,
+        migration::{Migration, Scratchpad},
         Database, ProofListIndex, TemporaryDB,
     };
 
@@ -260,5 +260,17 @@ mod tests {
         test_key_iter(Migration::new("namespace", &patch));
         db.merge(patch).unwrap();
         test_key_iter(Migration::new("namespace", &db.snapshot()));
+    }
+
+    #[test]
+    fn iterating_over_keys_in_scratchpad() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        prepare_key_iter(Scratchpad::new("namespace", &fork));
+        test_key_iter(Scratchpad::new("namespace", fork.readonly()));
+        let patch = fork.into_patch();
+        test_key_iter(Scratchpad::new("namespace", &patch));
+        db.merge(patch).unwrap();
+        test_key_iter(Scratchpad::new("namespace", &db.snapshot()));
     }
 }

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -266,6 +266,11 @@ impl<'a, T: RawAccess> Scratchpad<'a, T> {
         let prefixed_addr = addr.prepend_name(self.namespace);
         IndexAddress::from_root(SCRATCHPAD_NAME).append_key(&prefixed_addr.fully_qualified_name())
     }
+
+    fn get_scratchpad_prefix(&self, addr: IndexAddress) -> IndexAddress {
+        let prefixed_addr = addr.prepend_name(self.namespace);
+        IndexAddress::from_root(SCRATCHPAD_NAME).append_key(&prefixed_addr.qualified_prefix())
+    }
 }
 
 impl<T: RawAccessMut> Scratchpad<'_, T> {
@@ -311,7 +316,7 @@ impl<T: RawAccess> Access for Scratchpad<'_, T> {
         K: BinaryKey + ?Sized,
         Self::Base: AsReadonly<Readonly = Self::Base>,
     {
-        let base_addr = self.get_scratchpad_addr(base_addr);
+        let base_addr = self.get_scratchpad_prefix(base_addr);
         self.access.group_keys(base_addr)
     }
 }

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -57,7 +57,7 @@
 //!
 //! ```
 //! # use exonum_merkledb::{access::AccessExt, Database, SystemSchema, TemporaryDB};
-//! # use exonum_merkledb::migration::{Migration, MigrationHelper};
+//! # use exonum_merkledb::migration::{flush_migration, Migration, MigrationHelper};
 //! # use std::sync::Arc;
 //! # fn main() -> exonum_merkledb::Result<()> {
 //! let db = Arc::new(TemporaryDB::new());
@@ -107,7 +107,7 @@
 //!
 //! // The migration can be committed as follows.
 //! let mut fork = db.fork();
-//! MigrationHelper::flush_migration(&mut fork, "test");
+//! flush_migration(&mut fork, "test");
 //! db.merge(fork.into_patch())?;
 //! let snapshot = db.snapshot();
 //! assert_eq!(snapshot.get_proof_list::<_, u32>("test.list").len(), 3);

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -391,26 +391,26 @@ where
     type Item = <I::Iter as Iterator>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.inner {
-            Inner::Ended => None,
-            Inner::Active {
-                ref mut iter,
-                ref mut position_entry,
-            } => {
-                let next = iter.next();
-                if next.is_some() {
-                    position_entry.set(if let Some(ref item) = iter.peek() {
-                        let key = I::extract_key(item);
-                        IteratorPosition::NextKey(key)
-                    } else {
-                        IteratorPosition::Ended
-                    });
+        if let Inner::Active {
+            ref mut iter,
+            ref mut position_entry,
+        } = self.inner
+        {
+            let next = iter.next();
+            if next.is_some() {
+                position_entry.set(if let Some(ref item) = iter.peek() {
+                    let key = I::extract_key(item);
+                    IteratorPosition::NextKey(key)
                 } else {
-                    position_entry.set(IteratorPosition::Ended);
-                    self.inner = Inner::Ended;
-                }
-                next
+                    IteratorPosition::Ended
+                });
+            } else {
+                position_entry.set(IteratorPosition::Ended);
+                self.inner = Inner::Ended;
             }
+            next
+        } else {
+            None
         }
     }
 }

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -354,6 +354,7 @@ where
                         IteratorPosition::Ended
                     });
                 } else {
+                    position_entry.set(IteratorPosition::Ended);
                     self.inner = Inner::Ended;
                 }
                 next
@@ -522,6 +523,19 @@ mod tests {
 
         let iter = PersistentIter::new(scratchpad, "list", &list);
         assert_eq!(iter.count(), 2);
+    }
+
+    #[test]
+    fn empty_persistent_iter() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let list = fork.get_list::<_, String>("list");
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        assert_eq!(iter.count(), 0);
+        let position_entry = scratchpad.get_entry::<_, IteratorPosition<u64>>("list");
+        assert_eq!(position_entry.get(), Some(IteratorPosition::Ended));
     }
 
     #[test]

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -284,7 +284,7 @@ where
 /// // the scratchpad data access.
 /// let iter = PersistentIter::new(helper.scratchpad(), "list_iter", &list);
 /// // Now, we can use `iter` as any other iterator. Persistence is most useful
-/// // together with the `take` combinator; it allows to break migrated data
+/// // together with the `take` adapter; it allows to break migrated data
 /// // into manageable chunks.
 /// for (_, item) in iter.take(100) {
 ///     // Migrate `item`. The first component of a tuple is the index of the item
@@ -554,7 +554,7 @@ mod tests {
 
         let scratchpad = Scratchpad::new("iter", &fork);
         let iter = PersistentIter::new(scratchpad, "list", &list);
-        // Test that iterators work with combinators as expected.
+        // Test that iterators work with adapters as expected.
         let items: Vec<_> = iter.take(5).filter(|(i, _)| i % 2 == 1).collect();
         assert_eq!(items, vec![(1, "1".to_owned()), (3, "3".to_owned())]);
 

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -1,0 +1,603 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Persistent iterators.
+
+use exonum_crypto::Hash;
+use failure::{bail, ensure};
+
+use std::{
+    borrow::{Borrow, Cow},
+    collections::HashSet,
+    fmt,
+    iter::{Peekable, Zip},
+    ops::RangeFrom,
+};
+
+use crate::{
+    access::{Access, AccessExt, RawAccess, RawAccessMut},
+    indexes::{self, proof_map::ToProofPath},
+    BinaryKey, BinaryValue, Entry, KeySetIndex, ListIndex, MapIndex, ObjectHash, ProofListIndex,
+    ProofMapIndex, SparseListIndex, ValueSetIndex,
+};
+
+/// Database object that supports iteration and continuing iteration from an intermediate position.
+pub trait ContinueIterator {
+    /// Type encompassing iteration position.
+    type Key: BinaryKey + ?Sized;
+    /// Iterator returned by the object.
+    type Iter: Iterator;
+
+    /// Continues iteration from the specified position. If `from` is `None`, starts the iteration
+    /// from scratch.
+    fn continue_iter(self, from: Option<&Self::Key>) -> Self::Iter;
+
+    /// Extracts the iteration position from the item returned by the iterator.
+    fn extract_key(item: &<Self::Iter as Iterator>::Item) -> <Self::Key as ToOwned>::Owned;
+}
+
+impl<'a, T, V> ContinueIterator for &'a ListIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue,
+{
+    type Key = u64;
+    type Iter = Zip<RangeFrom<u64>, indexes::list::Iter<'a, V>>;
+
+    fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
+        if let Some(&from) = from {
+            (from..).zip(self.iter_from(from))
+        } else {
+            (0..).zip(self.iter())
+        }
+    }
+
+    fn extract_key(item: &(u64, V)) -> u64 {
+        item.0
+    }
+}
+
+impl<'a, T, V> ContinueIterator for &'a ProofListIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue,
+{
+    type Key = u64;
+    type Iter = Zip<RangeFrom<u64>, indexes::proof_list::Iter<'a, V>>;
+
+    fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
+        if let Some(&from) = from {
+            (from..).zip(self.iter_from(from))
+        } else {
+            (0..).zip(self.iter())
+        }
+    }
+
+    fn extract_key(item: &(u64, V)) -> u64 {
+        item.0
+    }
+}
+
+impl<'a, T, V> ContinueIterator for &'a SparseListIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue,
+{
+    type Key = u64;
+    type Iter = indexes::sparse_list::Iter<'a, V>;
+
+    fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
+        if let Some(&from) = from {
+            self.iter_from(from)
+        } else {
+            self.iter()
+        }
+    }
+
+    fn extract_key(item: &(u64, V)) -> u64 {
+        item.0
+    }
+}
+
+impl<'a, T, K, V> ContinueIterator for &'a MapIndex<T, K, V>
+where
+    T: RawAccess,
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+{
+    type Key = K;
+    type Iter = indexes::map::Iter<'a, K, V>;
+
+    fn continue_iter(self, from: Option<&K>) -> Self::Iter {
+        if let Some(from) = from {
+            self.iter_from(from)
+        } else {
+            self.iter()
+        }
+    }
+
+    fn extract_key(item: &(K::Owned, V)) -> K::Owned {
+        item.0.borrow().to_owned()
+    }
+}
+
+impl<'a, T, K, V, KeyMode> ContinueIterator for &'a ProofMapIndex<T, K, V, KeyMode>
+where
+    T: RawAccess,
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+    KeyMode: ToProofPath<K>,
+{
+    type Key = K;
+    type Iter = indexes::proof_map::Iter<'a, K, V>;
+
+    fn continue_iter(self, from: Option<&K>) -> Self::Iter {
+        if let Some(from) = from {
+            self.iter_from(from)
+        } else {
+            self.iter()
+        }
+    }
+
+    fn extract_key(item: &(K::Owned, V)) -> K::Owned {
+        item.0.borrow().to_owned()
+    }
+}
+
+impl<'a, T, K> ContinueIterator for &'a KeySetIndex<T, K>
+where
+    T: RawAccess,
+    K: BinaryKey,
+{
+    type Key = K;
+    type Iter = indexes::key_set::Iter<'a, K>;
+
+    fn continue_iter(self, from: Option<&K>) -> Self::Iter {
+        if let Some(from) = from {
+            self.iter_from(from)
+        } else {
+            self.iter()
+        }
+    }
+
+    fn extract_key(item: &K::Owned) -> K::Owned {
+        item.borrow().to_owned()
+    }
+}
+
+impl<'a, T, V> ContinueIterator for &'a ValueSetIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue + ObjectHash,
+{
+    type Key = Hash;
+    type Iter = indexes::value_set::Iter<'a, V>;
+
+    fn continue_iter(self, from: Option<&Hash>) -> Self::Iter {
+        if let Some(from) = from {
+            self.iter_from(from)
+        } else {
+            self.iter()
+        }
+    }
+
+    fn extract_key(item: &(Hash, V)) -> Hash {
+        item.0
+    }
+}
+
+/// Persistent iterator position.
+#[derive(PartialEq)]
+enum IteratorPosition<K: BinaryKey + ?Sized> {
+    /// There is a next key to start iteration from.
+    NextKey(K::Owned),
+    /// The iterator has ended.
+    Ended,
+}
+
+impl<K> fmt::Debug for IteratorPosition<K>
+where
+    K: BinaryKey + fmt::Debug + ?Sized,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IteratorPosition::NextKey(key) => {
+                let key_ref: &K = key.borrow();
+                formatter.debug_tuple("NextKey").field(&key_ref).finish()
+            }
+            IteratorPosition::Ended => formatter.debug_tuple("Ended").finish(),
+        }
+    }
+}
+
+impl<K> BinaryValue for IteratorPosition<K>
+where
+    K: BinaryKey + ?Sized,
+{
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            IteratorPosition::NextKey(key) => {
+                let key: &K = key.borrow();
+                let mut buffer = vec![0; 1 + key.size()];
+                key.write(&mut buffer[1..]);
+                buffer
+            }
+            IteratorPosition::Ended => vec![1],
+        }
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Result<Self, failure::Error> {
+        ensure!(
+            !bytes.is_empty(),
+            "`IteratorPosition` serialization cannot be empty"
+        );
+        Ok(match bytes[0] {
+            0 => IteratorPosition::NextKey(K::read(&bytes[1..])),
+            1 => IteratorPosition::Ended,
+            _ => bail!("Invalid `IteratorPosition` discriminant"),
+        })
+    }
+}
+
+/// Persistent iterator that stores its position in the database.
+pub struct PersistentIter<T: RawAccess, I: ContinueIterator> {
+    inner: Inner<T, I>,
+}
+
+impl<T, I> fmt::Debug for PersistentIter<T, I>
+where
+    T: RawAccess,
+    I: ContinueIterator,
+    I::Key: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PersistentIter")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+/// Internal details of a persistent iterator.
+enum Inner<T: RawAccess, I: ContinueIterator> {
+    /// The iterator is active: it has an underlying iterator over a database object,
+    /// and an entry storing the iterator position.
+    Active {
+        iter: Peekable<I::Iter>,
+        position_entry: Entry<T, IteratorPosition<I::Key>>,
+    },
+    /// The iterator has ended.
+    Ended,
+}
+
+impl<T, I> fmt::Debug for Inner<T, I>
+where
+    T: RawAccess,
+    I: ContinueIterator,
+    I::Key: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Inner::Active { position_entry, .. } => formatter
+                .debug_struct("Active")
+                .field("position", &position_entry.get())
+                .finish(),
+            Inner::Ended => formatter.debug_tuple("Ended").finish(),
+        }
+    }
+}
+
+impl<T, I> PersistentIter<T, I>
+where
+    T: RawAccessMut,
+    I: ContinueIterator,
+{
+    fn new<A>(access: A, name: &str, index: I) -> Self
+    where
+        A: Access<Base = T>,
+    {
+        let position_entry: Entry<_, IteratorPosition<I::Key>> = access.get_entry(name);
+        let position = position_entry.get();
+
+        let start_key = match position {
+            None => None,
+            Some(IteratorPosition::NextKey(key)) => Some(key),
+            Some(IteratorPosition::Ended) => {
+                return Self {
+                    inner: Inner::Ended,
+                };
+            }
+        };
+
+        Self {
+            inner: Inner::Active {
+                iter: index
+                    .continue_iter(start_key.as_ref().map(Borrow::borrow))
+                    .peekable(),
+                position_entry,
+            },
+        }
+    }
+}
+
+impl<T, I> Iterator for PersistentIter<T, I>
+where
+    T: RawAccessMut,
+    I: ContinueIterator,
+{
+    type Item = <I::Iter as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner {
+            Inner::Ended => None,
+            Inner::Active {
+                ref mut iter,
+                ref mut position_entry,
+            } => {
+                let next = iter.next();
+                if next.is_some() {
+                    position_entry.set(if let Some(ref item) = iter.peek() {
+                        let key = I::extract_key(item);
+                        IteratorPosition::NextKey(key)
+                    } else {
+                        IteratorPosition::Ended
+                    });
+                } else {
+                    self.inner = Inner::Ended;
+                }
+                next
+            }
+        }
+    }
+}
+
+/// Factory for persistent iterators.
+#[derive(Debug)]
+pub struct PersistentIters<T> {
+    access: T,
+    names: HashSet<String>,
+}
+
+impl<T> PersistentIters<T>
+where
+    T: Access,
+    T::Base: RawAccessMut,
+{
+    /// Creates a new factory.
+    pub fn new(access: T) -> Self {
+        Self {
+            access,
+            names: HashSet::new(),
+        }
+    }
+
+    /// Creates a persistent iterator identified by the `name`.
+    pub fn create<I: ContinueIterator>(
+        &mut self,
+        name: &str,
+        index: I,
+    ) -> PersistentIter<T::Base, I> {
+        self.names.insert(name.to_owned());
+        PersistentIter::new(self.access.clone(), name, index)
+    }
+
+    /// Checks if all iterators instantiated via this instance have ended.
+    ///
+    /// This method will panic if any of iterators are borrowed and thus should only be called
+    /// when this is a priori not the case.
+    pub(super) fn all_ended(&self) -> bool {
+        for name in &self.names {
+            let pos = self
+                .access
+                .clone()
+                .get_entry::<_, IteratorPosition<()>>(name.as_str())
+                .get();
+            if pos != Some(IteratorPosition::Ended) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{migration::Scratchpad, Database, TemporaryDB};
+
+    use std::{collections::HashSet, iter::FromIterator};
+
+    #[test]
+    fn persistent_iter_for_map() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut map = fork.get_map("map");
+        for i in 0_u32..10 {
+            map.put(&i, i.to_string());
+        }
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "map", &map);
+        let mut count = 0;
+        for (i, (key, value)) in iter.take(5).enumerate() {
+            assert_eq!(key, i as u32);
+            assert_eq!(value, i.to_string());
+            count += 1;
+        }
+        assert_eq!(count, 5);
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u32>>("map");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::NextKey(5)));
+        }
+
+        // Resume the iterator.
+        let iter = PersistentIter::new(scratchpad, "map", &map);
+        count = 0;
+        for (i, (key, value)) in (5..).zip(iter) {
+            assert_eq!(key, i as u32);
+            assert_eq!(value, i.to_string());
+            count += 1;
+        }
+        assert_eq!(count, 5);
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u32>>("map");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::Ended));
+        }
+
+        // The iterator is ended now.
+        let iter = PersistentIter::new(scratchpad, "map", &map);
+        assert_eq!(iter.count(), 0);
+    }
+
+    #[test]
+    fn persistent_iter_with_unsized_keys() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut map: ProofMapIndex<_, str, u64> = fork.get_proof_map("map");
+        let words = ["How", "many", "letters", "are", "in", "this", "word", "?"];
+        for &word in &words {
+            map.put(word, word.len() as u64);
+        }
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "map", &map);
+        for (word, size) in iter.take_while(|(word, _)| word.as_str() < "many") {
+            assert!(words.contains(&word.as_str()));
+            assert_eq!(word.len() as u64, size);
+        }
+
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<str>>("map");
+            // Note that `many` is not included into the values yielded by the iterator,
+            // but the iterator is advanced past it.
+            let expected_pos = IteratorPosition::NextKey("this".to_owned());
+            assert_eq!(position_entry.get(), Some(expected_pos));
+        }
+
+        let iter = PersistentIter::new(scratchpad, "map", &map);
+        assert_eq!(
+            iter.collect::<Vec<_>>(),
+            vec![("this".to_owned(), 4), ("word".to_owned(), 4)]
+        );
+    }
+
+    #[test]
+    fn persistent_iter_for_list() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut list = fork.get_list("list");
+        list.extend((0_u32..10).map(|i| i.to_string()));
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        // Test that iterators work with combinators as expected.
+        let items: Vec<_> = iter.take(5).filter(|(i, _)| i % 2 == 1).collect();
+        assert_eq!(items, vec![(1, "1".to_owned()), (3, "3".to_owned())]);
+
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u64>>("list");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::NextKey(5)));
+        }
+
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        for (i, value) in iter.take(3) {
+            assert_eq!(i.to_string(), value);
+        }
+
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u64>>("list");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::NextKey(8)));
+        }
+
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        assert_eq!(iter.count(), 2);
+    }
+
+    #[test]
+    fn persistent_iter_for_sparse_list() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut list = fork.get_sparse_list("list");
+        for &i in &[0, 1, 2, 3, 5, 8, 13, 21] {
+            list.set(i, i.to_string());
+        }
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        let mut count = 0;
+        for (i, value) in iter.take(5) {
+            assert_eq!(value, i.to_string());
+            count += 1;
+        }
+        assert_eq!(count, 5);
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u64>>("list");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::NextKey(8)));
+        }
+
+        let iter = PersistentIter::new(scratchpad, "list", &list);
+        let indexes: Vec<_> = iter.map(|(i, _)| i).collect();
+        assert_eq!(indexes, vec![8, 13, 21]);
+    }
+
+    #[test]
+    fn persistent_iter_for_key_set() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut set = fork.get_key_set("set");
+        for &i in &[0_u16, 1, 2, 3, 5, 8, 13, 21] {
+            set.insert(i);
+        }
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "set", &set);
+        let head: Vec<_> = iter.take(3).collect();
+        assert_eq!(head, vec![0, 1, 2]);
+
+        {
+            let mut iter = PersistentIter::new(scratchpad, "set", &set);
+            assert_eq!(iter.nth(2), Some(8));
+        }
+        {
+            let position_entry = scratchpad.get_entry::<_, IteratorPosition<u16>>("set");
+            assert_eq!(position_entry.get(), Some(IteratorPosition::NextKey(13)));
+        }
+
+        let iter = PersistentIter::new(scratchpad, "set", &set);
+        let tail: Vec<_> = iter.collect();
+        assert_eq!(tail, vec![13, 21]);
+    }
+
+    #[test]
+    fn persistent_iter_for_value_set() {
+        let db = TemporaryDB::new();
+        let fork = db.fork();
+        let mut set = fork.get_value_set("set");
+        let items = [0_u16, 1, 2, 3, 5, 8, 13, 21];
+        for &i in &items {
+            set.insert(i);
+        }
+
+        let scratchpad = Scratchpad::new("iter", &fork);
+        let iter = PersistentIter::new(scratchpad, "set", &set);
+        let head: Vec<_> = iter.take(3).map(|(_, val)| val).collect();
+        let iter = PersistentIter::new(scratchpad, "set", &set);
+        let middle: Vec<_> = iter.take(2).map(|(_, val)| val).collect();
+        let iter = PersistentIter::new(scratchpad, "set", &set);
+        let tail: Vec<_> = iter.map(|(_, val)| val).collect();
+
+        let actual_set: HashSet<_> = HashSet::from_iter(head.into_iter().chain(middle).chain(tail));
+        assert_eq!(actual_set, HashSet::from_iter(items.iter().copied()));
+    }
+}

--- a/components/merkledb/src/views/address.rs
+++ b/components/merkledb/src/views/address.rs
@@ -165,8 +165,8 @@ impl IndexAddress {
         }
     }
 
-    /// Returns common prefix of fully qualified names for the child indexes.
-    pub(super) fn qualified_prefix(&self) -> Vec<u8> {
+    /// Returns the common prefix of fully qualified names for the child indexes.
+    pub(crate) fn qualified_prefix(&self) -> Vec<u8> {
         let mut prefix = self.fully_qualified_name();
         if self.id_in_group.is_none() {
             prefix.push(SEPARATOR_CHAR);

--- a/components/merkledb/src/views/address.rs
+++ b/components/merkledb/src/views/address.rs
@@ -150,7 +150,7 @@ impl IndexAddress {
     }
 
     /// Full address with a separator between `name` and `bytes` represented as byte array.
-    pub(super) fn fully_qualified_name(&self) -> Vec<u8> {
+    pub(crate) fn fully_qualified_name(&self) -> Vec<u8> {
         /// Separator between the name and the additional bytes in family indexes.
         const INDEX_NAME_SEPARATOR: &[u8] = &[SEPARATOR_CHAR];
         const MIGRATION_PREFIX: &[u8] = &[MIGRATION_CHAR];

--- a/components/merkledb/tests/migration.rs
+++ b/components/merkledb/tests/migration.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 
 use exonum_merkledb::{
     access::{Access, AccessExt},
-    migration::{Migration, MigrationHelper},
+    migration::{flush_migration, rollback_migration, Migration},
     Database, HashTag, IndexAddress, IndexType, ObjectHash, Snapshot, SystemSchema, TemporaryDB,
 };
 
@@ -319,7 +319,7 @@ fn apply_actions(
             }
 
             MigrationAction::Rollback(namespace) => {
-                MigrationHelper::rollback_migration(&mut fork, namespace);
+                rollback_migration(&mut fork, namespace);
                 new_indexes.retain(|(ns, _), _| *ns != namespace);
             }
 
@@ -341,7 +341,7 @@ fn apply_actions(
     }
 
     for &namespace in namespaces {
-        MigrationHelper::flush_migration(&mut fork, namespace);
+        flush_migration(&mut fork, namespace);
     }
 
     // Compute the final list of indexes. Note that indexes removed in the migration

--- a/components/merkledb/tests/migration.rs
+++ b/components/merkledb/tests/migration.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 
 use exonum_merkledb::{
     access::{Access, AccessExt},
-    migration::Migration,
+    migration::{Migration, MigrationHelper},
     Database, HashTag, IndexAddress, IndexType, ObjectHash, Snapshot, SystemSchema, TemporaryDB,
 };
 
@@ -319,7 +319,7 @@ fn apply_actions(
             }
 
             MigrationAction::Rollback(namespace) => {
-                fork.rollback_migration(namespace);
+                MigrationHelper::rollback_migration(&mut fork, namespace);
                 new_indexes.retain(|(ns, _), _| *ns != namespace);
             }
 
@@ -341,7 +341,7 @@ fn apply_actions(
     }
 
     for &namespace in namespaces {
-        fork.flush_migration(namespace);
+        MigrationHelper::flush_migration(&mut fork, namespace);
     }
 
     // Compute the final list of indexes. Note that indexes removed in the migration

--- a/components/merkledb/tests/persistent_iter.rs
+++ b/components/merkledb/tests/persistent_iter.rs
@@ -1,0 +1,327 @@
+// Copyright 2019 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Property testing for persistent iterators. The test checks that persistent iterators do not
+//! skip or duplicate items, and that multiple iterators over the same collection are independent.
+
+use proptest::{
+    collection::vec, num, prop_assert_eq, prop_oneof, proptest, sample, strategy,
+    strategy::Strategy, test_runner::TestCaseResult,
+};
+use rand::{Rng, SeedableRng};
+use rand_xorshift::XorShiftRng;
+
+use exonum_merkledb::migration::{rollback_migration, Scratchpad};
+use exonum_merkledb::{
+    access::AccessExt, migration::PersistentIter, Database, Fork, IndexAddress, IndexType,
+    TemporaryDB,
+};
+
+const ACTIONS_MAX_LEN: usize = 50;
+
+#[derive(Debug, Clone, Copy)]
+struct Collection {
+    name: &'static str,
+    prefix: Option<u32>,
+    ty: IndexType,
+}
+
+impl Collection {
+    const fn new(name: &'static str, prefix: Option<u32>, ty: IndexType) -> Self {
+        Self { name, prefix, ty }
+    }
+
+    fn get_address(self) -> IndexAddress {
+        let mut addr = IndexAddress::from_root(self.name);
+        if let Some(prefix) = self.prefix {
+            addr = addr.append_key(&prefix);
+        }
+        addr
+    }
+
+    fn fill(self, fork: &Fork, rng: &mut impl Rng) {
+        let addr = self.get_address();
+        let item_count = rng.gen_range(25, 100);
+        match self.ty {
+            IndexType::List => {
+                let mut list = fork.get_list(addr);
+                list.extend((0..item_count).map(|_| rng.gen::<u64>()));
+            }
+            IndexType::ProofList => {
+                let mut list = fork.get_proof_list(addr);
+                list.extend((0..item_count).map(|_| rng.gen::<u64>()));
+            }
+            IndexType::SparseList => {
+                let mut list = fork.get_sparse_list(addr);
+                for _ in 0..item_count {
+                    let index = rng.gen::<u64>() % 256;
+                    let value = rng.gen::<u64>();
+                    list.set(index, value);
+                }
+            }
+
+            IndexType::Map => {
+                let mut map = fork.get_map(addr);
+                for _ in 0..item_count {
+                    let key = rng.gen::<u64>() & 0xffff;
+                    let value = rng.gen::<u64>();
+                    map.put(&key, value);
+                }
+            }
+            IndexType::ProofMap => {
+                let mut map = fork.get_proof_map(addr);
+                for _ in 0..item_count {
+                    let key = rng.gen::<u64>() & 0xffff;
+                    let value = rng.gen::<u64>();
+                    map.put(&key, value);
+                }
+            }
+
+            IndexType::KeySet => {
+                let mut set = fork.get_key_set(addr);
+                for _ in 0..item_count {
+                    set.insert(rng.gen::<u64>());
+                }
+            }
+            IndexType::ValueSet => {
+                let mut set = fork.get_value_set(addr);
+                for _ in 0..item_count {
+                    set.insert(rng.gen::<u64>());
+                }
+            }
+
+            _ => unreachable!(),
+        }
+    }
+}
+
+const COLLECTIONS: &[Collection] = &[
+    Collection::new("list", None, IndexType::List),
+    Collection::new("list", Some(1), IndexType::List),
+    Collection::new("proof_list", None, IndexType::ProofList),
+    Collection::new("list", Some(2), IndexType::ProofList),
+    Collection::new("sparse_list", None, IndexType::SparseList),
+    Collection::new("list", Some(3), IndexType::SparseList),
+    Collection::new("map", None, IndexType::Map),
+    Collection::new("map", Some(1), IndexType::Map),
+    Collection::new("proof_map", None, IndexType::ProofMap),
+    Collection::new("map", Some(2), IndexType::ProofMap),
+    Collection::new("key_set", None, IndexType::KeySet),
+    Collection::new("set", Some(1), IndexType::KeySet),
+    Collection::new("value_set", None, IndexType::ValueSet),
+    Collection::new("set", Some(2), IndexType::ValueSet),
+];
+
+#[derive(Debug, Clone)]
+enum Action {
+    CreateIter(Collection),
+    AdvanceIter {
+        index: usize, // the real index will be taken modulo the number of iterators.
+        amount: usize,
+    },
+    FlushFork,
+    MergeFork,
+}
+
+fn generate_action(collections: &'static [Collection]) -> impl Strategy<Value = Action> {
+    prop_oneof![
+        4 => sample::select(collections).prop_map(Action::CreateIter),
+        4 => (num::usize::ANY, 1_usize..10).prop_map(|(index, amount)| Action::AdvanceIter {
+            index,
+            amount,
+        }),
+        1 => strategy::Just(Action::FlushFork),
+        1 => strategy::Just(Action::MergeFork),
+    ]
+}
+
+// Since collection contents is not the subject of the test, we do not include into `Action`s.
+// Instead, we use an RNG to fill each of predefined collections with 25-100 pseudo-random elements.
+fn fill_collections(db: &TemporaryDB) {
+    const RNG_SEED: [u8; 16] = *b"seedseedseedseed";
+
+    let fork = db.fork();
+    let mut rng = XorShiftRng::from_seed(RNG_SEED);
+    for &collection in COLLECTIONS {
+        collection.fill(&fork, &mut rng);
+    }
+    db.merge(fork.into_patch()).unwrap();
+}
+
+fn clear_scratchpad(db: &TemporaryDB) {
+    let mut fork = db.fork();
+    rollback_migration(&mut fork, "iters");
+    db.merge(fork.into_patch()).unwrap();
+}
+
+#[derive(Debug)]
+struct IterState {
+    name: String,
+    collection: Collection,
+    items: Vec<u64>,
+    position: usize,
+}
+
+impl IterState {
+    fn advance(&mut self, fork: &Fork, amount: usize) {
+        self.position += amount;
+        let addr = self.collection.get_address();
+        let scratchpad = Scratchpad::new("iters", fork);
+
+        match self.collection.ty {
+            IndexType::List => {
+                let list = fork.get_list::<_, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &list);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+            IndexType::ProofList => {
+                let list = fork.get_proof_list::<_, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &list);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+            IndexType::SparseList => {
+                let list = fork.get_sparse_list::<_, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &list);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+
+            IndexType::Map => {
+                let map = fork.get_map::<_, u64, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &map);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+            IndexType::ProofMap => {
+                let map = fork.get_proof_map::<_, u64, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &map);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+
+            IndexType::KeySet => {
+                let set = fork.get_key_set::<_, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &set);
+                self.items.extend(iter.take(amount));
+            }
+            IndexType::ValueSet => {
+                let set = fork.get_value_set::<_, u64>(addr);
+                let iter = PersistentIter::new(scratchpad, &self.name, &set);
+                self.items.extend(iter.map(|(_, value)| value).take(amount));
+            }
+
+            _ => unreachable!(),
+        }
+    }
+
+    fn check(&self, fork: &Fork) -> TestCaseResult {
+        let addr = self.collection.get_address();
+        let expected_items: Vec<_> = match self.collection.ty {
+            IndexType::List => {
+                let list = fork.get_list::<_, u64>(addr);
+                list.iter().take(self.position).collect()
+            }
+            IndexType::ProofList => {
+                let list = fork.get_proof_list::<_, u64>(addr);
+                list.iter().take(self.position).collect()
+            }
+            IndexType::SparseList => {
+                let list = fork.get_sparse_list::<_, u64>(addr);
+                list.values().take(self.position).collect()
+            }
+
+            IndexType::Map => {
+                let map = fork.get_map::<_, u64, u64>(addr);
+                map.values().take(self.position).collect()
+            }
+            IndexType::ProofMap => {
+                let map = fork.get_proof_map::<_, u64, u64>(addr);
+                map.values().take(self.position).collect()
+            }
+
+            IndexType::KeySet => {
+                let set = fork.get_key_set::<_, u64>(addr);
+                set.iter().take(self.position).collect()
+            }
+            IndexType::ValueSet => {
+                let set = fork.get_value_set::<_, u64>(addr);
+                set.iter()
+                    .map(|(_, value)| value)
+                    .take(self.position)
+                    .collect()
+            }
+
+            _ => unreachable!(),
+        };
+        prop_assert_eq!(&expected_items, &self.items);
+
+        Ok(())
+    }
+}
+
+fn apply_actions(db: &TemporaryDB, actions: Vec<Action>) -> TestCaseResult {
+    let mut fork = db.fork();
+    let mut iters = vec![];
+
+    for action in actions {
+        match action {
+            Action::CreateIter(collection) => {
+                iters.push(IterState {
+                    name: format!("iter{}", iters.len()),
+                    collection,
+                    items: vec![],
+                    position: 0,
+                });
+            }
+            Action::AdvanceIter { index, amount } => {
+                if iters.is_empty() {
+                    continue;
+                }
+                let len = iters.len();
+                let iter = iters.get_mut(index % len).unwrap();
+                iter.advance(&fork, amount);
+                iter.check(&fork)?;
+            }
+            Action::FlushFork => fork.flush(),
+            Action::MergeFork => {
+                db.merge(fork.into_patch()).unwrap();
+                fork = db.fork();
+            }
+        }
+    }
+
+    for iter in &iters {
+        iter.check(&fork)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn persistent_iters() {
+    let db = TemporaryDB::new();
+    fill_collections(&db);
+
+    proptest!(|(actions in vec(generate_action(COLLECTIONS), 1..ACTIONS_MAX_LEN))| {
+        apply_actions(&db, actions)?;
+        clear_scratchpad(&db);
+    });
+}
+
+#[test]
+fn persistent_iters_over_single_collection() {
+    let db = TemporaryDB::new();
+    fill_collections(&db);
+
+    proptest!(|(actions in vec(generate_action(&COLLECTIONS[0..1]), 1..ACTIONS_MAX_LEN))| {
+        apply_actions(&db, actions)?;
+        clear_scratchpad(&db);
+    });
+}

--- a/components/merkledb/tests/persistent_iter.rs
+++ b/components/merkledb/tests/persistent_iter.rs
@@ -149,7 +149,7 @@ fn generate_action(collections: &'static [Collection]) -> impl Strategy<Value = 
 // Since collection contents is not the subject of the test, we do not include into `Action`s.
 // Instead, we use an RNG to fill each of predefined collections with 25-100 pseudo-random elements.
 fn fill_collections(db: &TemporaryDB) {
-    const RNG_SEED: [u8; 16] = *b"seedseedseedseed";
+    const RNG_SEED: [u8; 16] = *b"_seed_seed_seed_";
 
     let fork = db.fork();
     let mut rng = XorShiftRng::from_seed(RNG_SEED);

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -17,6 +17,7 @@
 //! FIXME: more details (ECR-4081)
 
 use exonum_merkledb::migration::MigrationHelper;
+use failure::Fail;
 
 use std::{collections::BTreeMap, fmt};
 
@@ -298,7 +299,9 @@ mod tests {
 
     use assert_matches::assert_matches;
     use exonum_crypto::Hash;
-    use exonum_merkledb::{access::AccessExt, Database, Snapshot, TemporaryDB};
+    use exonum_merkledb::{
+        access::AccessExt, migration::flush_migration, Database, Snapshot, TemporaryDB,
+    };
 
     use std::{collections::HashSet, sync::Arc};
 
@@ -387,7 +390,7 @@ mod tests {
             assert!(migration_hashes.insert(migration_hash));
 
             let mut fork = db.fork();
-            fork.flush_migration("test");
+            flush_migration(&mut fork, "test");
             db.merge(fork.into_patch()).unwrap();
         }
         db.snapshot()

--- a/test-suite/testkit/src/migrations.rs
+++ b/test-suite/testkit/src/migrations.rs
@@ -18,7 +18,9 @@
 
 use exonum::{
     merkledb::{
-        access::Prefixed, migration::MigrationHelper, Database, Fork, Snapshot, TemporaryDB,
+        access::Prefixed,
+        migration::{flush_migration, MigrationHelper},
+        Database, Fork, Snapshot, TemporaryDB,
     },
     runtime::{
         migrations::{MigrateData, MigrationContext, MigrationScript},
@@ -113,7 +115,7 @@ where
         context.helper.finish().unwrap();
 
         let mut fork = self.db.fork();
-        fork.flush_migration(Self::SERVICE_NAME);
+        flush_migration(&mut fork, Self::SERVICE_NAME);
         self.db.merge(fork.into_patch()).unwrap();
         self.data_version = end_version;
     }


### PR DESCRIPTION
## Overview

This PR introduces scratchpads (the access to temporary data during migration that is removed at the end of migration, regardless of whether the migration is successful) and persistent iterators.

---

See: https://jira.bf.local/browse/ECR-4078 https://jira.bf.local/browse/ECR-4079