### PR TITLE
Remove extern crate log in exonum [ECR-4004]

### DIFF
--- a/exonum/src/api/backends/actix.rs
+++ b/exonum/src/api/backends/actix.rs
@@ -26,6 +26,7 @@ use actix_web::{
 };
 use failure::{bail, ensure, format_err, Error};
 use futures::{future::Either, sync::mpsc, Future, IntoFuture, Stream};
+use log::trace;
 use serde::{
     de::{self, DeserializeOwned},
     ser, Serialize,

--- a/exonum/src/api/manager.rs
+++ b/exonum/src/api/manager.rs
@@ -18,6 +18,7 @@ use actix::prelude::*;
 use actix_net::server::Server;
 use actix_web::server::{HttpServer, StopServer};
 use futures::{sync::mpsc, Future};
+use log::{error, info, warn};
 
 use std::{collections::HashMap, fmt, io, time::Duration};
 

--- a/exonum/src/api/websocket.rs
+++ b/exonum/src/api/websocket.rs
@@ -22,7 +22,7 @@ use chrono::{DateTime, Utc};
 use exonum_merkledb::{access::Access, ListProof, ObjectHash};
 use futures::Future;
 use hex::FromHex;
-use log::error;
+use log::{error, warn};
 use rand::{rngs::ThreadRng, Rng};
 
 use std::{

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -24,6 +24,7 @@
 use exonum_derive::{BinaryValue, ObjectHash};
 use exonum_proto::ProtobufConvert;
 use failure::{bail, ensure};
+use log::warn;
 
 use std::collections::{HashMap, HashSet};
 

--- a/exonum/src/events/error.rs
+++ b/exonum/src/events/error.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
 
 use failure::Error;
+use log::error;
 
 use std::{error::Error as StdError, fmt::Display};
 

--- a/exonum/src/events/network.rs
+++ b/exonum/src/events/network.rs
@@ -19,6 +19,7 @@ use futures::{
     sync::mpsc,
     unsync, Future, IntoFuture, Sink, Stream,
 };
+use log::{error, trace, warn};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_codec::Framed;
 use tokio_core::reactor::Handle;

--- a/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
+++ b/exonum/src/events/noise/wrappers/sodium_wrapper/resolver.rs
@@ -18,6 +18,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use exonum_sodiumoxide::crypto::{
     aead::chacha20poly1305_ietf as sodium_chacha20poly1305, hash::sha256 as sodium_sha256,
 };
+use log::error;
 use rand::{thread_rng, CryptoRng, Error, RngCore};
 use snow::{
     params::{CipherChoice, DHChoice, HashChoice},

--- a/exonum/src/lib.rs
+++ b/exonum/src/lib.rs
@@ -44,8 +44,6 @@
 extern crate pretty_assertions;
 pub use exonum_merkledb;
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;

--- a/exonum/src/node/basic.rs
+++ b/exonum/src/node/basic.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::{error, info, trace};
 use rand::Rng;
 
 use super::{NodeHandler, NodeRole, RequestData};

--- a/exonum/src/node/consensus.rs
+++ b/exonum/src/node/consensus.rs
@@ -14,6 +14,7 @@
 
 use exonum_merkledb::{BinaryValue, ObjectHash, Patch};
 use failure::{bail, format_err};
+use log::{error, info, trace, warn};
 
 use std::{collections::HashSet, convert::TryFrom};
 

--- a/exonum/src/node/events.rs
+++ b/exonum/src/node/events.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::{info, trace, warn};
+
 use super::{ConnectListConfig, ExternalMessage, NodeHandler, NodeTimeout};
 
 use crate::{

--- a/exonum/src/node/mod.rs
+++ b/exonum/src/node/mod.rs
@@ -37,6 +37,7 @@ use exonum_keys::Keys;
 use exonum_merkledb::{Database, DbOptions, ObjectHash};
 use failure::{ensure, format_err, Error};
 use futures::{sync::mpsc, Future, Sink};
+use log::{info, trace};
 use tokio_core::reactor::Core;
 use tokio_threadpool::Builder as ThreadPoolBuilder;
 use toml::Value;

--- a/exonum/src/node/requests.rs
+++ b/exonum/src/node/requests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::{error, trace};
+
 use std::mem;
 
 use crate::{

--- a/exonum/src/node/state.rs
+++ b/exonum/src/node/state.rs
@@ -17,6 +17,7 @@
 use bit_vec::BitVec;
 use exonum_merkledb::{access::RawAccess, KeySetIndex, MapIndex, ObjectHash, Patch};
 use failure::bail;
+use log::{error, trace};
 
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -19,6 +19,7 @@ use futures::{
     future::{self, Either},
     Future,
 };
+use log::{error, info};
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/exonum/src/runtime/rust/mod.rs
+++ b/exonum/src/runtime/rust/mod.rs
@@ -264,6 +264,7 @@ pub mod error;
 
 use exonum_merkledb::Snapshot;
 use futures::{future, sync::mpsc, Future, IntoFuture, Sink};
+use log::trace;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 


### PR DESCRIPTION
Removed `extern crate log` in exonum.