### PR TITLE
Make DefaultConfigManager public

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -104,7 +104,7 @@ use exonum_supervisor::{Supervisor, SupervisorConfig};
 use std::sync::Arc;
 
 use crate::command::{run::NodeRunConfig, Command, ExonumCommand, StandardResult};
-use crate::config_manager::DefaultConfigManager;
+pub use crate::config_manager::DefaultConfigManager;
 
 pub mod command;
 pub mod config;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -87,6 +87,7 @@
 //! [serde]: https://crates.io/crates/serde
 //! [structopt]: https://crates.io/crates/structopt
 
+pub use crate::config_manager::DefaultConfigManager;
 pub use structopt;
 
 use exonum::{
@@ -104,7 +105,6 @@ use exonum_supervisor::{Supervisor, SupervisorConfig};
 use std::sync::Arc;
 
 use crate::command::{run::NodeRunConfig, Command, ExonumCommand, StandardResult};
-pub use crate::config_manager::DefaultConfigManager;
 
 pub mod command;
 pub mod config;


### PR DESCRIPTION
## Overview

DefaultConfigManager is needed for node instantiation with custom cli implementation.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
