### PR TITLE
Clarify why not 'entry':

### DIFF
--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -199,7 +199,8 @@ impl<T: RawAccess + AsReadonly> Migration<'_, T> {
     /// let patch = fork.into_patch();
     /// let migration_view = Migration::new("migration", &patch);
     /// let aggregator = migration_view.state_aggregator();
-    /// assert!(aggregator.contains("migration.entry")); // Not `entry`!
+    /// assert!(aggregator.contains("migration.entry")); // Not "entry": `state_aggregator` uses
+    ///                                                  // full index names as keys.
     /// ```
     pub fn state_aggregator(&self) -> ProofMapIndex<T::Readonly, str, Hash> {
         get_state_aggregator(self.access.as_readonly(), self.namespace)


### PR DESCRIPTION
## Overview

"Not `entry`!" alone might leave the reader
bewildered (as the index is an Entry).


<!-- Please describe your changes here 
  and list any open questions you might have. -->


### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
