### PR TITLE
Change type for precommits in BlockProof [ECR-4108]

### DIFF
--- a/exonum/src/messages/signed.rs
+++ b/exonum/src/messages/signed.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use crate::{
-    crypto::{self, Hash, PublicKey, SecretKey, Signature},
+    crypto::{self, Hash, PublicKey, SecretKey},
     messages::types::SignedMessage,
     proto,
 };
@@ -231,22 +231,12 @@ where
     type ProtoStruct = proto::SignedMessage;
 
     fn to_pb(&self) -> Self::ProtoStruct {
-        let mut message = Self::ProtoStruct::new();
         let signed_message = self.as_raw();
-
-        message.set_payload(signed_message.payload.to_pb());
-        message.set_author(signed_message.author.to_pb());
-        message.set_signature(signed_message.signature.to_pb());
-        message
+        signed_message.to_pb()
     }
 
-    fn from_pb(mut pb: Self::ProtoStruct) -> Result<Self, Error> {
-        let signed_message = SignedMessage {
-            payload: pb.take_payload(),
-            author: PublicKey::from_pb(pb.take_author())?,
-            signature: Signature::from_pb(pb.take_signature())?,
-        };
-
+    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
+        let signed_message = SignedMessage::from_pb(pb)?;
         signed_message.into_verified()
     }
 }

--- a/exonum/src/messages/signed.rs
+++ b/exonum/src/messages/signed.rs
@@ -243,9 +243,8 @@ where
     fn from_pb(mut pb: Self::ProtoStruct) -> Result<Self, Error> {
         let signed_message = SignedMessage {
             payload: pb.take_payload(),
-            author: PublicKey::from_pb(pb.take_author()).expect("Failed to convert from protobuf."),
-            signature: Signature::from_pb(pb.take_signature())
-                .expect("Failed to convert from protobuf."),
+            author: PublicKey::from_pb(pb.take_author())?,
+            signature: Signature::from_pb(pb.take_signature())?,
         };
 
         signed_message.into_verified()

--- a/exonum/src/proto/mod.rs
+++ b/exonum/src/proto/mod.rs
@@ -16,7 +16,7 @@
 
 pub use self::schema::{
     blockchain::{AdditionalHeaders, Block, CallInBlock, TxLocation},
-    messages::{CoreMessage, Precommit, SignedMessage, Verified},
+    messages::{CoreMessage, Precommit, SignedMessage},
     proofs::{BlockProof, IndexProof},
     runtime::{AnyTx, CallInfo, GenesisConfig, InstanceInitParams},
 };

--- a/exonum/src/proto/schema/exonum/messages.proto
+++ b/exonum/src/proto/schema/exonum/messages.proto
@@ -34,11 +34,6 @@ message SignedMessage {
   exonum.crypto.Signature signature = 3;
 }
 
-// Container for a verified message.
-message Verified {
-  SignedMessage raw = 1;
-}
-
 // Subset of Exonum messages defined in the Exonum core.
 message CoreMessage {
   oneof kind {

--- a/exonum/src/proto/schema/exonum/proofs.proto
+++ b/exonum/src/proto/schema/exonum/proofs.proto
@@ -33,7 +33,7 @@ message BlockProof {
   // in the block, etc.
   Block block = 1;
   // List of `Precommit` messages for the block.
-  repeated messages.Verified precommits = 2;
+  repeated messages.SignedMessage precommits = 2;
 }
 
 // Proof of authenticity for a single index within the database.


### PR DESCRIPTION
## Overview

Use `repeated SignedMessage` instead of  `repeated Verified` in `BlockProof` in the proto description.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-4108
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
