### PR TITLE
Improve `access` docs in MerkleDB

### DIFF
--- a/components/merkledb/src/access/extensions.rs
+++ b/components/merkledb/src/access/extensions.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Extension traits to simplify index instantiation.
 
 use super::{Access, FromAccess};

--- a/components/merkledb/src/access/mod.rs
+++ b/components/merkledb/src/access/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! High-level access to database.
 
 use failure::{Error, Fail};

--- a/components/merkledb/src/access/mod.rs
+++ b/components/merkledb/src/access/mod.rs
@@ -19,12 +19,12 @@
 //! The core type in this module is the [`Access`] trait, which provides ability to access
 //! [indexes] from the database. The `Access` trait has several implementations:
 //!
-//! - `Access` is implemented for [`RawAccess`]es, that is, types that provides access to the
+//! - `Access` is implemented for [`RawAccess`]es, that is, types that provide access to the
 //!   entire database. [`Snapshot`], [`Fork`] and [`ReadonlyFork`] fall into this category.
 //! - [`Prefixed`] restricts an access to a single *namespace*.
 //! - [`Migration`]s are used for data created during [migrations]. Similar to `Prefixed`, migrations
 //!   are separated by namespaces.
-//! - [`Scratchpad`]s can be used for temporary data. They too are distinguished by a namespace.
+//! - [`Scratchpad`]s can be used for temporary data. They are distinguished by namespaces as well.
 //!
 //! [`AccessExt`] extends [`Access`] and provides helper methods to instantiate indexes. This
 //! is useful in quick-and-dirty testing. For more complex applications, consider deriving

--- a/components/merkledb/src/access/mod.rs
+++ b/components/merkledb/src/access/mod.rs
@@ -117,7 +117,7 @@ pub struct Prefixed<'a, T> {
     prefix: Cow<'a, str>,
 }
 
-impl<'a, T: Access> Prefixed<'a, T> {
+impl<'a, T: RawAccess> Prefixed<'a, T> {
     /// Creates a new prefixed access.
     ///
     /// # Panics


### PR DESCRIPTION
## Overview

This PR improves documentation of the `access` module in MerkleDB crate and restricts the constructor of the `Prefixed` type.