### PR TITLE
Specify that ids are non-zero:

### DIFF
--- a/components/merkledb/src/views/metadata.rs
+++ b/components/merkledb/src/views/metadata.rs
@@ -164,7 +164,7 @@ impl Default for IndexType {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndexMetadata<V = Vec<u8>> {
     // A globally unique numeric index identifier. MerkleDB assigns a unique numeric ID for each
-    // fully-qualified index name.
+    // fully-qualified index name. Valid identifiers are non-zero.
     //
     // MerkleDB never re-uses the identifiers.
     identifier: u64,


### PR DESCRIPTION
According to `create_index_metadata`,
ids are non-zero:

> Identifier should be non-zero to translate to
a correct id in `ResolvedAddress`

## Overview

<!-- Please describe your changes here 
  and list any open questions you might have. -->

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
