### PR TITLE
Clarify commit / flush split for migrations [ECR-4148]

### DIFF
--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -624,7 +624,7 @@ impl AbortHandle {
 /// # Safety
 ///
 /// Flushing a migration needs to be performed on a `fork` which contains the final migration
-/// changes. Not doing so **may break the hash aggregation in the database.** A scenario when
+/// changes. Not doing so **may break the state aggregation in the database.** A scenario when
 /// this requirement would be violated is as follows:
 ///
 /// 1. Start a database migration in a separate thread, constructing a `MigrationHelper` around

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -620,6 +620,22 @@ impl AbortHandle {
 /// - Migrated indexes will be aggregated in the default namespace
 /// - Indexes marked with tombstones will be removed
 /// - Scratchpad associated with the migration will be cleared
+///
+/// # Safety
+///
+/// Flushing a migration needs to be performed on a `fork` which contains the final migration
+/// changes. Not doing so **may break the hash aggregation in the database.** A scenario when
+/// this requirement would be violated is as follows:
+///
+/// 1. Start a database migration in a separate thread, constructing a `MigrationHelper` around
+///   `Arc<dyn Database>`.
+/// 2. Create a fork.
+/// 3. Ensure that the migration is complete via some synchronization primitive.
+/// 4. Call `flush_migration` on the fork from step 2.
+///
+/// In this scenario, a fork may not have the latest migration data because it was created before
+/// the migration is complete. The correct workflow would be to swap steps 2 and 3, i.e.,
+/// first ensure that the migration is complete and *then* create a fork in which it will be flushed.
 pub fn flush_migration(fork: &mut Fork, namespace: &str) {
     fork.flush_migration(namespace);
     Scratchpad::new(namespace, &*fork).clear();

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -623,7 +623,7 @@ impl AbortHandle {
 ///
 /// # Safety
 ///
-/// Flushing a migration needs to be performed on a `fork` which contains the final migration
+/// Flushing a migration must be performed on a `fork` which contains the final migration
 /// changes. Not doing so **may break the state aggregation in the database.** A scenario when
 /// this requirement would be violated is as follows:
 ///

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -83,7 +83,7 @@
 //!
 //! Note that commitment and flushing are separate operations and must be performed in
 //! different blocks. When a migration is flushed, the migrated data needs to have a definite
-//! state, which is ensured by an earlier commitment acting as a [Great Filter]. The requirement
+//! state, which is ensured by an earlier commitment acting as a filter. The requirement
 //! for different blocks is more nuanced and is related to implementation details of the database
 //! backend. Namely, the flushing operation needs to be performed on a fork which contains the final
 //! migration state; not doing this may break state aggregation.
@@ -103,7 +103,6 @@
 //! [`local_migration_result()`]: ../struct.DispatcherSchema.html#method.local_migration_result
 //! [artifact commitment]: ../index.html#artifact-lifecycle
 //! [`Stopped`]: ../enum.InstanceStatus.html#variant.Stopped
-//! [Great Filter]: https://en.wikipedia.org/wiki/Great_Filter
 
 pub use super::types::{InstanceMigration, MigrationStatus};
 

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -86,7 +86,7 @@
 //! state, which is ensured by an earlier commitment acting as a [Great Filter]. The requirement
 //! for different blocks is more nuanced and is related to implementation details of the database
 //! backend. Namely, the flushing operation needs to be performed on a fork which contains the final
-//! migration state; not doing this may break hash aggregation.
+//! migration state; not doing this may break state aggregation.
 //!
 //! Deciding when it is appropriate to commit or roll back a migration is the responsibility
 //! of the supervisor service. For example, it may commit the migration once all validators have

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -81,7 +81,7 @@
 //! returns to the [`Stopped`] status. The local migration result is ignored; if the migration
 //! script has not completed locally, it is aborted.
 //!
-//! Note that commitment and flushing are separate operations and need to be performed in
+//! Note that commitment and flushing are separate operations and must be performed in
 //! different blocks. When a migration is flushed, the migrated data needs to have a definite
 //! state, which is ensured by an earlier commitment acting as a [Great Filter]. The requirement
 //! for different blocks is more nuanced and is related to implementation details of the database

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -76,6 +76,13 @@
 //! returns to the [`Stopped`] status. The local migration result is ignored; if the migration
 //! script has not completed locally, it is aborted.
 //!
+//! Note that commitment and flushing are separate operations and need to be performed in
+//! different blocks. When a migration is flushed, the migrated data needs to have a definite
+//! state, which is ensured by an earlier commitment acting as a [Great Filter]. The requirement
+//! for different blocks is more nuanced and is related to implementation details of the database
+//! backend. Namely, the flushing operation needs to be performed on a fork which contains the final
+//! migration state; not doing this may break hash aggregation.
+//!
 //! Deciding when it is appropriate to commit or roll back a migration is the responsibility
 //! of the supervisor service. For example, it may commit the migration once all validators have
 //! submitted identical migration results, and roll back a migration if at least one validator
@@ -90,6 +97,7 @@
 //! [`local_migration_result()`]: ../struct.DispatcherSchema.html#method.local_migration_result
 //! [artifact commitment]: ../index.html#artifact-lifecycle
 //! [`Stopped`]: ../enum.InstanceStatus.html#variant.Stopped
+//! [Great Filter]: https://en.wikipedia.org/wiki/Great_Filter
 
 pub use super::types::{InstanceMigration, MigrationStatus};
 

--- a/exonum/src/runtime/migrations.rs
+++ b/exonum/src/runtime/migrations.rs
@@ -14,6 +14,11 @@
 
 //! Data migration tools.
 //!
+//! # Stability
+//!
+//! Since migrations are tightly related to unstable [`Runtime`] trait, the entirety of this
+//! module is considered unstable.
+//!
 //! # Migrations Overview
 //!
 //! The goal of a data migration is to prepare data of an Exonum service for use with an updated
@@ -88,6 +93,7 @@
 //! submitted identical migration results, and roll back a migration if at least one validator
 //! has reported an error during migration or there is divergence among reported migration results.
 //!
+//! [`Runtime`]: ../trait.Runtime.html
 //! [dispatcher]: ../index.html
 //! [supervisor service]: ../index.html#supervisor-service
 //! [`MigrationScript`]: struct.MigrationScript.html


### PR DESCRIPTION
## Overview

This PR clarifies split between `commit_migration` and `flush_migration` operations in the core.

---

See: https://jira.bf.local/browse/ECR-4148