### PR TITLE
Document supervisor api [ECR-4149]

### DIFF
--- a/services/supervisor/README.md
+++ b/services/supervisor/README.md
@@ -73,6 +73,10 @@ configuration change and follows the same rules.
 Consult [the crate docs](https://docs.rs/exonum-supervisor) for more details
 about the service API.
 
+## HTTP API
+
+REST API of the service is documented in the crate docs.
+
 ## Usage
 
 Include `exonum-supervisor` as a dependency in your `Cargo.toml`:

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -78,12 +78,12 @@
 //! | Path        | `/api/supervisor/v1/config-proposal` |
 //! | Method      | GET   |
 //! | Query type  | - |
-//! | Return type | Option<[`ConfigProposalWithHash`]> |
+//! | Return type | `Option<[ConfigProposalWithHash]>` |
 //!
 //! Returns the configuration proposal which is currently pending. Returns `None` if there is no
 //! pending configuration at the moment.
 //!
-//! [`ConfigProposalWithHash`]: ../struct.ConfigProposalWithHash.html
+//! [ConfigProposalWithHash]: ../struct.ConfigProposalWithHash.html
 //!
 //! ```
 //! # use exonum_rust_runtime::ServiceFactory;

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -153,7 +153,7 @@
 //! # impl Service for SomeService {}
 //! #
 //! # fn config_for_service() -> Vec<u8> {
-//! #     Vec::new()   
+//! #     Vec::new()
 //! # }
 //! #
 //! # fn main() -> Result<(), failure::Error> {
@@ -446,7 +446,7 @@
 //!
 //! Returns the current supervisor configuration, which includes the supervisor operating mode.
 //!
-//! [`SupervisorConfig`]: ../SupervisorConfig.html
+//! [`SupervisorConfig`]: ../struct.SupervisorConfig.html
 //!
 //! ```
 //! use exonum_rust_runtime::ServiceFactory;
@@ -482,7 +482,7 @@
 //! Returns the state of the deployment for a certain `ArtifactId`.
 //!
 //! [`DeployInfoQuery`]: struct.DeployInfoQuery.html
-//! [`AsyncEventState`]: ../struct.AsyncEventState.html
+//! [`AsyncEventState`]: ../enum.AsyncEventState.html
 //!
 //! ```
 //! # use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -34,7 +34,6 @@
 //!     - [Check the deployment status](#check-deployment-status)
 //!     - [Check the migration status](#check-migration-status)
 //!
-//!
 //! # Public API
 //!
 //! ## Obtaining Consensus Configuration
@@ -44,7 +43,7 @@
 //! | Path        | `/api/supervisor/v1/consensus-config` |
 //! | Method      | GET   |
 //! | Query type  | - |
-//! | Return type | [`BlockInfo`] |
+//! | Return type | [`ConsensusConfig`] |
 //!
 //! Returns the current consensus configuration.
 //!
@@ -79,24 +78,25 @@
 //! | Path        | `/api/supervisor/v1/config-proposal` |
 //! | Method      | GET   |
 //! | Query type  | - |
-//! | Return type | `Option<[ConfigProposalWithHash]>` |
+//! | Return type | Option<[`ConfigProposalWithHash`]> |
 //!
 //! Returns the configuration proposal which is currently pending. Returns `None` if there is no
 //! pending configuration at the moment.
 //!
-//! [ConfigProposalWithHash]: ../struct.ConfigProposalWithHash.html
+//! [`ConfigProposalWithHash`]: ../struct.ConfigProposalWithHash.html
 //!
 //! ```
-//! use exonum_rust_runtime::ServiceFactory;
+//! # use exonum_rust_runtime::ServiceFactory;
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //! use exonum_supervisor::{ConfigProposalWithHash, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let pending_proposal: Option<ConfigProposalWithHash> = testkit
 //!     .api()
@@ -117,7 +117,7 @@
 //! |-------------|-------|
 //! | Path        | `/api/supervisor/v1/deploy-artifact` |
 //! | Method      | POST   |
-//! | Query type  | [`DeployRequest`] |
+//! | Body type   | [`DeployRequest`] |
 //! | Return type | [`Hash`] |
 //!
 //! Requests the deployment of a certain artifact.
@@ -139,9 +139,9 @@
 //!
 //! ```
 //! use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
-//! use exonum_rust_runtime::ServiceFactory;
 //! use exonum_supervisor::{DeployRequest, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum_rust_runtime::ServiceFactory;
 //!
 //! # use exonum_derive::*;
 //! # use exonum_rust_runtime::Service;
@@ -157,20 +157,21 @@
 //! # }
 //! #
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .with_rust_service(SomeService)
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
-//! // In this example, we will try to deploy supervisor service.
+//! // In this example, we will try to deploy `SomeService` artifact.
 //! let deploy_request = DeployRequest {
 //!     artifact: SomeService.artifact_id(),
 //!     spec: config_for_service(),
 //!     deadline_height: Height(10),
 //! };
 //!
+//! // `deploy_request` will be automatically serialized to hexadecimal string.
 //! let tx_hash: Hash = testkit
 //!     .api()
 //!     .private(ApiKind::Service("supervisor"))
@@ -192,7 +193,7 @@
 //! |-------------|-------|
 //! | Path        | `/api/supervisor/v1/migrate` |
 //! | Method      | POST   |
-//! | Query type  | [`MigrationRequest`] |
+//! | Body type   | [`MigrationRequest`] |
 //! | Return type | [`Hash`] |
 //!
 //! Requests the migration of certain service to a newer artifact version.
@@ -213,10 +214,11 @@
 //! [`Hash`]: https://docs.rs/exonum-crypto/latest/exonum_crypto/struct.Hash.html
 //!
 //! ```
-//! use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
-//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum::crypto::Hash;
 //! use exonum_supervisor::{MigrationRequest, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum::helpers::Height;
+//! # use exonum_rust_runtime::ServiceFactory;
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
 //! let mut testkit = TestKitBuilder::validator()
@@ -235,6 +237,7 @@
 //! #         deadline_height: Height(10),
 //! #     };
 //!
+//! // `migration_request` will be automatically serialized to hexadecimal string.
 //! let tx_hash: Hash = testkit
 //!     .api()
 //!     .private(ApiKind::Service("supervisor"))
@@ -254,7 +257,7 @@
 //! |-------------|-------|
 //! | Path        | `/api/supervisor/v1/propose-config` |
 //! | Method      | POST   |
-//! | Query type  | [`ConfigPropose`] |
+//! | Body type   | [`ConfigPropose`] |
 //! | Return type | [`Hash`] |
 //!
 //! Proposes the new configuration for the Exonum blockchain.
@@ -285,22 +288,23 @@
 //!
 //! ```
 //! use exonum::crypto::Hash;
-//! # use exonum::helpers::Height;
-//! use exonum_rust_runtime::ServiceFactory;
 //! use exonum_supervisor::{ConfigPropose, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum::helpers::Height;
+//! # use exonum_rust_runtime::ServiceFactory;
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let proposal: ConfigPropose = // Proposal creation skipped...
 //! # ConfigPropose::new(0, Height(0));
 //!
-//! // In this example, query is serialized to hexadecimal string automatically.
+//! // `proposal` will be automatically serialized to hexadecimal string.
 //! let tx_hash: Hash = testkit
 //!     .api()
 //!     .private(ApiKind::Service("supervisor"))
@@ -330,7 +334,7 @@
 //! Depending on the supervisor operating mode, it may be required to vote by majority of
 //! nodes (in "decentralized" mode), or one vote will be enough (in "simple" mode).
 //!
-//! The first vote is sent automatically by the node which broadcast the proposal, there is
+//! The node that broadcast the proposal is considered to have voted for it, there is
 //! no need to send vote request for this node manually.
 //!
 //! After receiving a vote, supervisor creates a corresponding transaction, signs it
@@ -347,18 +351,19 @@
 //!
 //! ```
 //! use exonum::crypto::Hash;
-//! # use exonum::helpers::{Height, ValidatorId};
-//! use exonum_rust_runtime::ServiceFactory;
 //! use exonum_supervisor::{ConfigPropose, ConfigVote, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum::helpers::{Height, ValidatorId};
+//! # use exonum_rust_runtime::ServiceFactory;
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_validators(2)
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example (but with several validators)...
+//! #     TestKitBuilder::validator()
+//! #         .with_validators(2) // 2 validators to create a config to vote for.
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let proposal: ConfigPropose = // Proposal creation skipped...
 //! # ConfigPropose::new(0, Height(10));
@@ -415,14 +420,15 @@
 //! ```
 //! use exonum_rust_runtime::ServiceFactory;
 //! use exonum_supervisor::Supervisor;
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let configuration_number: u64 = testkit
 //!     .api()
@@ -454,11 +460,12 @@
 //! use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let config: SupervisorConfig = testkit
 //!     .api()
@@ -486,9 +493,9 @@
 //!
 //! ```
 //! # use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
-//! use exonum_rust_runtime::ServiceFactory;
-//! use exonum_supervisor::{DeployInfoQuery, DeployRequest, AsyncEventState, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{api::DeployInfoQuery, DeployRequest, AsyncEventState, Supervisor};
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # use exonum_derive::*;
 //! # use exonum_rust_runtime::Service;
@@ -500,12 +507,13 @@
 //! # impl Service for SomeService {}
 //! #
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//! #    .with_rust_service(SomeService)
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .with_rust_service(SomeService)
+//! #         .create();
 //!
 //! let deploy_request: DeployRequest = // Some previously performed deploy request.
 //! #     DeployRequest {
@@ -548,16 +556,17 @@
 //!
 //! ```
 //! # use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
-//! use exonum_rust_runtime::ServiceFactory;
-//! use exonum_supervisor::{MigrationInfoQuery, MigrationRequest, MigrationState, Supervisor};
-//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//! # use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{api::MigrationInfoQuery, MigrationRequest, MigrationState, Supervisor};
+//! # use exonum_testkit::{ApiKind, TestKitBuilder};
 //!
 //! # fn main() -> Result<(), failure::Error> {
-//! let mut testkit = TestKitBuilder::validator()
-//!     .with_rust_service(Supervisor)
-//!     .with_artifact(Supervisor.artifact_id())
-//!     .with_instance(Supervisor::simple())
-//!     .create();
+//! let mut testkit = // Same as in previous example...
+//! #     TestKitBuilder::validator()
+//! #         .with_rust_service(Supervisor)
+//! #         .with_artifact(Supervisor.artifact_id())
+//! #         .with_instance(Supervisor::simple())
+//! #         .create();
 //!
 //! let migration_request: MigrationRequest = // Some previously performed migration request.
 //! #     MigrationRequest {
@@ -831,7 +840,7 @@ impl PublicApi for ApiImpl<'_> {
 }
 
 /// Wires Supervisor API endpoints.
-pub fn wire(builder: &mut ServiceApiBuilder) {
+pub(crate) fn wire(builder: &mut ServiceApiBuilder) {
     builder
         .private_scope()
         .endpoint_mut("deploy-artifact", |state, query| {

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -12,6 +12,578 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! HTTP API for the supervisor service. Supervisor API is divided into public and private
+//! parts, with public part intended for unauthorized use, and private parts intended to be
+//! used by network administrator for the Exonum blockchain configuration.
+//!
+//! # Table of Contents
+//!
+//! - Public API:
+//!
+//!     - [Obtaining consensus configuration](#obtaining-consensus-configuration)
+//!     - [Obtaining pending configuration proposal](#obtaining-pending-configuration-proposal)
+//!
+//! - Private API:
+//!
+//!     - [Request to deploy an artifact](#request-to-deploy-an-artifact)
+//!     - [Request service migration](#request-service-migration)
+//!     - [Request to accept new configuration](#request-to-accept-new-configuration)
+//!     - [Vote for configuration proposal](#vote-for-configuration-proposal)
+//!     - [Obtain current configuration number](#obtain-current-configuration-number)
+//!     - [Obtain current supervisor operating mode](#obtain-current-supervisor-operating-mode)
+//!     - [Check the deployment status](#check-deployment-status)
+//!     - [Check the migration status](#check-migration-status)
+//!
+//!
+//! # Public API
+//!
+//! ## Obtaining Consensus Configuration
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/consensus-config` |
+//! | Method      | GET   |
+//! | Query type  | - |
+//! | Return type | [`BlockInfo`] |
+//!
+//! Returns the current consensus configuration.
+//!
+//! [`ConsensusConfig`]: https://docs.rs/exonum/latest/exonum/blockchain/config/struct.ConsensusConfig.html
+//!
+//! ```
+//! use exonum::blockchain::ConsensusConfig;
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::Supervisor;
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let consensus_config: ConsensusConfig = testkit
+//!     .api()
+//!     .public(ApiKind::Service("supervisor"))
+//!     .get("consensus-config")?;
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Obtaining Pending Configuration Proposal
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/config-proposal` |
+//! | Method      | GET   |
+//! | Query type  | - |
+//! | Return type | `Option<[ConfigProposalWithHash]>` |
+//!
+//! Returns the configuration proposal which is currently pending. Returns `None` if there is no
+//! pending configuration at the moment.
+//!
+//! [ConfigProposalWithHash]: ../struct.ConfigProposalWithHash.html
+//!
+//! ```
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{ConfigProposalWithHash, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let pending_proposal: Option<ConfigProposalWithHash> = testkit
+//!     .api()
+//!     .public(ApiKind::Service("supervisor"))
+//!     .get("config-proposal")?;
+//!
+//! // Will be none, since we did not send a proposal.
+//! assert!(pending_proposal.is_none());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Private API
+//!
+//! ## Request to Deploy an Artifact
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/deploy-artifact` |
+//! | Method      | POST   |
+//! | Query type  | [`DeployRequest`] |
+//! | Return type | [`Hash`] |
+//!
+//! Requests the deployment of a certain artifact.
+//!
+//! Depending on the supervisor operating mode, it may be required to send such a request to
+//! majority of nodes (in "decentralized" mode), or one request will be enough (in "simple" mode).
+//!
+//! After receiving a deployment request, supervisor creates a corresponding transaction, signs it
+//! with node's keys and broadcasts the transaction within the network. The hash of broadcast
+//! transaction is returned from the endpoint.
+//!
+//! For more details on deploy requests, see [crate documentation](../index.html).
+//!
+//! **Warning:** `DeployRequest` structure should be serialized using corresponding protobuf message,
+//! and represented as a hexadecimal string.
+//!
+//! [`DeployRequest`]: ../struct.DeployRequest.html
+//! [`Hash`]: https://docs.rs/exonum-crypto/latest/exonum_crypto/struct.Hash.html
+//!
+//! ```
+//! use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{DeployRequest, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # use exonum_derive::*;
+//! # use exonum_rust_runtime::Service;
+//! #
+//! # #[derive(Debug, ServiceFactory, ServiceDispatcher)]
+//! # #[service_factory(artifact_name = "exonum.doc.SomeService", artifact_version = "0.1.0")]
+//! # pub struct SomeService;
+//! #
+//! # impl Service for SomeService {}
+//! #
+//! # fn config_for_service() -> Vec<u8> {
+//! #     Vec::new()   
+//! # }
+//! #
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .with_rust_service(SomeService)
+//!     .create();
+//!
+//! // In this example, we will try to deploy supervisor service.
+//! let deploy_request = DeployRequest {
+//!     artifact: SomeService.artifact_id(),
+//!     spec: config_for_service(),
+//!     deadline_height: Height(10),
+//! };
+//!
+//! let tx_hash: Hash = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&deploy_request)
+//!     .post("deploy-artifact")?;
+//!
+//! let block = testkit.create_block();
+//! let result = block[tx_hash].status();
+//! # // Call `expect` for a better error reporting if test will fail.
+//! # result.expect("Deploy request failed");
+//! assert!(result.is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Request Service Migration
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/migrate` |
+//! | Method      | POST   |
+//! | Query type  | [`MigrationRequest`] |
+//! | Return type | [`Hash`] |
+//!
+//! Requests the migration of certain service to a newer artifact version.
+//!
+//! Depending on the supervisor operating mode, it may be required to send such a request to
+//! majority of nodes (in "decentralized" mode), or one request will be enough (in "simple" mode).
+//!
+//! After receiving a migration request, supervisor creates a corresponding transaction, signs it
+//! with node's keys and broadcasts the transaction within the network. The hash of broadcast
+//! transaction is returned from the endpoint.
+//!
+//! For more details on migration requests, see [crate documentation](../index.html).
+//!
+//! **Warning:** `MigrationRequest` structure should be serialized using corresponding protobuf message,
+//! and represented as a hexadecimal string.
+//!
+//! [`MigrationRequest`]: ../struct.MigrationRequest.html
+//! [`Hash`]: https://docs.rs/exonum-crypto/latest/exonum_crypto/struct.Hash.html
+//!
+//! ```
+//! use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{MigrationRequest, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     // Add some service that supports migrations...
+//!     .create();
+//!
+//! // Migration request creation skipped...
+//! let migration_request = // Migration of some service.
+//! #     // Request migration of supervisor for simplicity.
+//! #     MigrationRequest {
+//! #         new_artifact: Supervisor.artifact_id(),
+//! #         service: Supervisor::NAME.to_owned(),
+//! #         deadline_height: Height(10),
+//! #     };
+//!
+//! let tx_hash: Hash = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&migration_request)
+//!     .post("migrate")?;
+//!
+//! let block = testkit.create_block();
+//! let result = block[tx_hash].status();
+//! assert!(result.is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Request to Accept New Configuration
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/propose-config` |
+//! | Method      | POST   |
+//! | Query type  | [`ConfigPropose`] |
+//! | Return type | [`Hash`] |
+//!
+//! Proposes the new configuration for the Exonum blockchain.
+//!
+//! Configuration changes may include the following items:
+//!
+//! - Request to change the consensus configuration.
+//! - Request to start a new service instance.
+//! - Request to stop an existing service instance.
+//! - Request to resume a previously stopped service.
+//! - Request to change the configuration of an existing service instance.
+//!
+//! Configuration proposal does not cause the configuration change itself, instead it
+//! initializes a voting process: if node administrators of the network agree on the
+//! suggested proposal, the configuration is applies. Otherwise, no changes in the
+//! network configuration are performed.
+//!
+//! Voting for a configuration is performed via [`confirm-config`](#vote-for-configuration-proposal)
+//! endpoint.
+//!
+//! For more details on configuration proposals, see [crate documentation](../index.html).
+//!
+//! **Warning:** `ConfigPropose` structure should be serialized using corresponding protobuf message,
+//! and represented as a hexadecimal string.
+//!
+//! [`ConfigPropose`]: ../struct.ConfigPropose.html
+//! [`Hash`]: https://docs.rs/exonum-crypto/latest/exonum_crypto/struct.Hash.html
+//!
+//! ```
+//! use exonum::crypto::Hash;
+//! # use exonum::helpers::Height;
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{ConfigPropose, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let proposal: ConfigPropose = // Proposal creation skipped...
+//! # ConfigPropose::new(0, Height(0));
+//!
+//! // In this example, query is serialized to hexadecimal string automatically.
+//! let tx_hash: Hash = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&proposal)
+//!     .post("propose-config")?;
+//!
+//! // Create a block, so the proposal transaction will appear in the blockchain.
+//! let block = testkit.create_block();
+//!
+//! // Verify that transaction was executed successfully.
+//! assert!(block[tx_hash].status().is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Vote for Configuration Proposal
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/confirm-config` |
+//! | Method      | POST   |
+//! | Query type  | [`DeployRequest`] |
+//! | Return type | [`Hash`] |
+//!
+//! Votes for a pending configuration with a certain hash.
+//!
+//! Depending on the supervisor operating mode, it may be required to vote by majority of
+//! nodes (in "decentralized" mode), or one vote will be enough (in "simple" mode).
+//!
+//! The first vote is sent automatically by the node which broadcast the proposal, there is
+//! no need to send vote request for this node manually.
+//!
+//! After receiving a vote, supervisor creates a corresponding transaction, signs it
+//! with node's keys and broadcasts the transaction within the network. The hash of broadcast
+//! transaction is returned from the endpoint.
+//!
+//! For more details on voting, see [crate documentation](../index.html).
+//!
+//! **Warning:** `ConfigVote` structure should be serialized using corresponding protobuf message,
+//! and represented as a hexadecimal string.
+//!
+//! [`ConfigVote`]: ../struct.ConfigVote.html
+//! [`Hash`]: https://docs.rs/exonum-crypto/latest/exonum_crypto/struct.Hash.html
+//!
+//! ```
+//! use exonum::crypto::Hash;
+//! # use exonum::helpers::{Height, ValidatorId};
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{ConfigPropose, ConfigVote, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_validators(2)
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let proposal: ConfigPropose = // Proposal creation skipped...
+//! # ConfigPropose::new(0, Height(10));
+//!
+//! // Assuming that config proposal was broadcast by other validator...
+//! # let keys = &testkit.validator(ValidatorId(1)).service_keypair();
+//! # let tx = proposal.clone().sign_for_supervisor(keys.0, &keys.1);
+//! # testkit.create_block_with_transaction(tx).transactions[0]
+//! #     .status()
+//! #     .expect("Transaction with change propose discarded.");
+//!
+//! // Create a vote.
+//! let config_vote = ConfigVote::from(proposal);
+//!
+//! // Send it.
+//! // In this example, query is serialized to hexadecimal string automatically.
+//! let tx_hash: Hash = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&config_vote)
+//!     .post("confirm-config")?;
+//!
+//! // Create a block, so the proposal transaction will appear in the blockchain.
+//! let block = testkit.create_block();
+//!
+//! // Verify that transaction was executed successfully.
+//! assert!(block[tx_hash].status().is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Obtain Current Configuration Number
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/configuration-number` |
+//! | Method      | GET   |
+//! | Query type  | - |
+//! | Return type | `u64` |
+//!
+//! To avoid the situation when several conflicting configuration proposals are broadcast
+//! within the network, `ConfigPropose` contains a `configuration_number` field, which
+//! should be equal to the amount of configurations, processed by supervisor (only configurations
+//! that did participate in voting are counted, incorrect configurations are not).
+//!
+//! This field acts like a [nonce], approving the fact that node broadcasting proposal is
+//! aware of the last accepted configuration.
+//!
+//! `configuration-number` endpoint allows requester to obtain the current number of processed
+//! configurations.
+//!
+//! [nonce]: https://en.wikipedia.org/wiki/Cryptographic_nonce
+//!
+//! ```
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::Supervisor;
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let configuration_number: u64 = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .get("configuration-number")?;
+//!
+//! // There was no configuration proposals, so configuration number is 0.
+//! assert_eq!(configuration_number, 0);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Obtaining Supervisor Configuration
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/supervisor-config` |
+//! | Method      | GET   |
+//! | Query type  | - |
+//! | Return type | [`SupervisorConfig`] |
+//!
+//! Returns the current supervisor configuration, which includes the supervisor operating mode.
+//!
+//! [`SupervisorConfig`]: ../SupervisorConfig.html
+//!
+//! ```
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{mode::Mode, Supervisor, SupervisorConfig};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let config: SupervisorConfig = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .get("supervisor-config")?;
+//!
+//! assert_eq!(config.mode, Mode::Simple);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Check the Deployment Status
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/deploy-status` |
+//! | Method      | GET   |
+//! | Query type  | [`DeployInfoQuery`] |
+//! | Return type | [`AsyncEventState`] |
+//!
+//! Returns the state of the deployment for a certain `ArtifactId`.
+//!
+//! [`DeployInfoQuery`]: struct.DeployInfoQuery.html
+//! [`AsyncEventState`]: ../struct.AsyncEventState.html
+//!
+//! ```
+//! # use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{DeployInfoQuery, DeployRequest, AsyncEventState, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # use exonum_derive::*;
+//! # use exonum_rust_runtime::Service;
+//! #
+//! # #[derive(Debug, ServiceFactory, ServiceDispatcher)]
+//! # #[service_factory(artifact_name = "exonum.doc.SomeService", artifact_version = "0.1.0")]
+//! # pub struct SomeService;
+//! #
+//! # impl Service for SomeService {}
+//! #
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//! #    .with_rust_service(SomeService)
+//!     .create();
+//!
+//! let deploy_request: DeployRequest = // Some previously performed deploy request.
+//! #     DeployRequest {
+//! #         artifact: SomeService.artifact_id(),
+//! #         spec: Vec::new(),
+//! #         deadline_height: Height(10),
+//! #     };
+//! # // Request deploy, so we will be able to request its state.
+//! # let _hash: Hash = testkit
+//! #     .api()
+//! #     .private(ApiKind::Service("supervisor"))
+//! #     .query(&deploy_request)
+//! #     .post("deploy-artifact")?;
+//! # testkit.create_block();
+//!
+//! let query = DeployInfoQuery::from(deploy_request);
+//!
+//! let deploy_state: AsyncEventState = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&query)
+//!     .get("deploy-status")?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Check the Migration Status
+//!
+//! | Property    | Value |
+//! |-------------|-------|
+//! | Path        | `/api/supervisor/v1/migration-status` |
+//! | Method      | GET   |
+//! | Query type  | [`MigrationInfoQuery`] |
+//! | Return type | [`MigrationState`] |
+//!
+//! Returns the state of the migration for a certain service instance.
+//!
+//! [`MigrationInfoQuery`]: struct.MigrationInfoQuery.html
+//! [`MigrationState`]: ../struct.MigrationState.html
+//!
+//! ```
+//! # use exonum::{crypto::Hash, helpers::Height, merkledb::BinaryValue};
+//! use exonum_rust_runtime::ServiceFactory;
+//! use exonum_supervisor::{MigrationInfoQuery, MigrationRequest, MigrationState, Supervisor};
+//! use exonum_testkit::{ApiKind, TestKitBuilder};
+//!
+//! # fn main() -> Result<(), failure::Error> {
+//! let mut testkit = TestKitBuilder::validator()
+//!     .with_rust_service(Supervisor)
+//!     .with_artifact(Supervisor.artifact_id())
+//!     .with_instance(Supervisor::simple())
+//!     .create();
+//!
+//! let migration_request: MigrationRequest = // Some previously performed migration request.
+//! #     MigrationRequest {
+//! #         new_artifact: Supervisor.artifact_id(),
+//! #         service: Supervisor::NAME.to_owned(),
+//! #         deadline_height: Height(10),
+//! #     };
+//! # // Request migration. It will fail, but we'll be able to request its state.
+//! # let _hash: Hash = testkit
+//! #     .api()
+//! #     .private(ApiKind::Service("supervisor"))
+//! #     .query(&migration_request)
+//! #     .post("migrate")?;
+//! # testkit.create_block();
+//!
+//! let query = MigrationInfoQuery::from(migration_request);
+//!
+//! let migration_state: MigrationState = testkit
+//!     .api()
+//!     .private(ApiKind::Service("supervisor"))
+//!     .query(&query)
+//!     .get("migration-status")?;
+//! # Ok(())
+//! # }
+//! ```
+
 use exonum::{blockchain::ConsensusConfig, crypto::Hash, helpers::Height, runtime::ArtifactId};
 use exonum_rust_runtime::{
     api::{self, ServiceApiBuilder, ServiceApiState},
@@ -130,7 +702,7 @@ impl From<MigrationRequest> for MigrationInfoQuery {
 }
 
 /// Private API specification of the supervisor service.
-pub trait PrivateApi {
+trait PrivateApi {
     /// Error type for the current API implementation.
     type Error: Fail;
 
@@ -163,7 +735,7 @@ pub trait PrivateApi {
     fn migration_status(&self, request: MigrationInfoQuery) -> Result<MigrationState, Self::Error>;
 }
 
-pub trait PublicApi {
+trait PublicApi {
     /// Error type for the current API implementation.
     type Error: Fail;
     /// Returns an actual consensus configuration of the blockchain.
@@ -258,6 +830,7 @@ impl PublicApi for ApiImpl<'_> {
     }
 }
 
+/// Wires Supervisor API endpoints.
 pub fn wire(builder: &mut ServiceApiBuilder) {
     builder
         .private_scope()

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -56,7 +56,6 @@
 //! The operation of starting or resuming a service is treated similarly to a configuration change
 //! and follows the same rules.
 //!
-//!
 //! ## Migrations Management
 //!
 //! Supervisor service provides a functionality to perform data migrations for services.

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -56,6 +56,7 @@
 //! The operation of starting or resuming a service is treated similarly to a configuration change
 //! and follows the same rules.
 //!
+//!
 //! ## Migrations Management
 //!
 //! Supervisor service provides a functionality to perform data migrations for services.
@@ -114,6 +115,10 @@
 //! 0.3, but decided to go with version 0.2), you will have to deploy a corresponding artifact after
 //! you migrate to version 0.2, before you'll be able to start your service.
 //!
+//! # HTTP API
+//!
+//! REST API of the service is documented in the [`api` module](api/index.html).
+//!
 //! [exonum]: https://github.com/exonum/exonum
 //! [runtime-docs]: https://docs.rs/exonum/latest/exonum/runtime/index.html
 //! [`DeployRequest`]: struct.DeployRequest.html
@@ -157,9 +162,9 @@ use exonum_rust_runtime::{
 
 use crate::{configure::ConfigureMut, mode::Mode};
 
+pub mod api;
 pub mod mode;
 
-mod api;
 mod configure;
 mod errors;
 mod event_state;

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -132,7 +132,6 @@
 )]
 
 pub use self::{
-    api::{DeployInfoQuery, MigrationInfoQuery},
     configure::{Configure, CONFIGURE_INTERFACE_NAME},
     errors::{ArtifactError, CommonError, ConfigurationError, MigrationError, ServiceError},
     event_state::AsyncEventState,

--- a/services/supervisor/tests/supervisor/deploy_failures.rs
+++ b/services/supervisor/tests/supervisor/deploy_failures.rs
@@ -31,7 +31,8 @@ use exonum_rust_runtime::ServiceFactory;
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 use exonum_supervisor::{
-    AsyncEventState, DeployInfoQuery, DeployRequest, DeployResult, Supervisor, SupervisorInterface,
+    api::DeployInfoQuery, AsyncEventState, DeployRequest, DeployResult, Supervisor,
+    SupervisorInterface,
 };
 
 use self::failing_runtime::{FailingRuntime, FailingRuntimeError};

--- a/services/supervisor/tests/supervisor/migrations/mod.rs
+++ b/services/supervisor/tests/supervisor/migrations/mod.rs
@@ -25,7 +25,7 @@ use exonum_rust_runtime::{DefaultInstance, ServiceFactory};
 use exonum_testkit::{ApiKind, TestKit, TestKitApi, TestKitBuilder};
 
 use exonum_supervisor::{
-    AsyncEventState, ConfigPropose, MigrationError, MigrationInfoQuery, MigrationRequest,
+    api::MigrationInfoQuery, AsyncEventState, ConfigPropose, MigrationError, MigrationRequest,
     MigrationResult, MigrationState, SchemaImpl, Supervisor, SupervisorInterface,
 };
 

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -192,7 +192,10 @@ where
         }
     }
 
-    /// Sets a query data of the current request.
+    /// Sets a request data of the current request.
+    ///
+    /// For `GET` requests, it will be serialized as a query string parameters,
+    /// and for `POST` requests, it will be serialized as a JSON in the request body.
     pub fn query<T>(self, query: &'b T) -> RequestBuilder<'a, 'b, T> {
         RequestBuilder {
             test_server_url: self.test_server_url,
@@ -228,6 +231,8 @@ where
 
     /// Sends a get request to the testing API endpoint and decodes response as
     /// the corresponding type.
+    ///
+    /// If query was specified, it is serialized as a query string parameters.
     pub fn get<R>(self, endpoint: &str) -> api::Result<R>
     where
         R: DeserializeOwned + 'static,
@@ -264,6 +269,8 @@ where
 
     /// Sends a post request to the testing API endpoint and decodes response as
     /// the corresponding type.
+    ///
+    /// If query was specified, it is serialized as a JSON in the request body.
     pub fn post<R>(self, endpoint: &str) -> api::Result<R>
     where
         R: DeserializeOwned + 'static,


### PR DESCRIPTION
This PR adds a documentation for public and private REST API for supervisor.

Note that doctests are still sometimes failing due to some bug (which, as occurs, was not really fixed by the recent PR).