### PR TITLE
Breaking changes regarding Merkelized maps [ECR-3485]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,16 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 
 - Public structures and enums were made non-exhaustive. (#1710)
 
+- `ProofPath` serialization during map hash computations was unified.
+  It now uses `LEB128(bit_length) || bytes` format, which was previously used
+  for branches, but not for a single-entry maps. (#1743)
+
+- Serialization of `ProofPath`s within `MapProof` Protobuf messages
+  was changed to a more compact and implementation-independent format. (#1743)
+
+- `MapProof` Protobuf messages now serialize keys according to their
+  `BinaryValue` implementation, rather than `BinaryKey`. (#1743)
+
 #### exonum-rust-runtime
 
 - Service interfaces now have to specify method IDs with either `interface_method`

--- a/components/merkledb/src/hash.rs
+++ b/components/merkledb/src/hash.rs
@@ -39,7 +39,7 @@ const EMPTY_MAP_HASH: [u8; HASH_SIZE] = [
 /// collection contents. This hash can then be used that a collection contains (or does not contain)
 /// certain elements.
 ///
-/// Different hashes for leaf and branch nodes of the list are used to secure merkle tree
+/// Different hashes for leaf and branch nodes of the list are used to secure Merkle tree
 /// from the pre-image attack. See more information [here][rfc6962].
 ///
 /// This type is not intended to be exhaustively matched. It can be extended in the future
@@ -142,8 +142,8 @@ impl HashTag {
             .hash()
     }
 
-    /// Hash of a branch node in a Merkle Patricia tree. `branch_node` is the binary serialization
-    /// of the node.
+    /// Obtains hash of a branch node in a Merkle Patricia tree.
+    /// `branch_node` is the binary serialization of the node.
     ///
     /// ```text
     /// h = sha256( HashTag::MapBranchNode || branch_node )
@@ -159,11 +159,15 @@ impl HashTag {
             .hash()
     }
 
-    /// Hash of a Merkelized map with a single entry.
+    /// Obtains hash of a Merkelized map with a single entry.
     ///
     /// ``` text
     /// h = sha256( HashTag::MapBranchNode || path || child_hash )
     /// ```
+    ///
+    /// See [`ProofMapIndex`] for details how `path` is serialized.
+    ///
+    /// [`ProofMapIndex`]: indexes/proof_map/struct.ProofMapIndex.html#impl-ObjectHash
     pub fn hash_single_entry_map(path: &ProofPath, child_hash: &Hash) -> Hash {
         // `HASH_SIZE` bytes are necessary for `path` bytes, and 2 additional bytes
         // for the `LEB128` encoding of bit length (`HASH_SIZE * 8`).
@@ -177,11 +181,12 @@ impl HashTag {
             .hash()
     }
 
-    /// Hash of an empty Merkelized map.
+    /// Obtains hash of an empty Merkelized map.
     ///
-    /// Empty map hash:
+    /// The hash is computed as
+    ///
     /// ```text
-    /// sha256( HashTag::MapNode || Hash::default() )
+    /// sha256( HashTag::MapNode || Hash::zero() )
     /// ```
     pub fn empty_map_hash() -> Hash {
         Hash::new(EMPTY_MAP_HASH)

--- a/components/merkledb/src/indexes/proof_map/mod.rs
+++ b/components/merkledb/src/indexes/proof_map/mod.rs
@@ -806,12 +806,22 @@ where
 /// ## Map with a single entry
 ///
 /// ```text
-/// root_hash = sha256( HashTag::MapBranchNode || 0x01 || path || 0x00 || child_hash ).
+/// root_hash = sha256( HashTag::MapBranchNode || path || child_hash ).
 /// ```
 ///
 /// Here, the map contains a single `path`, and `child_hash` is the hash
-/// of the object under this key. `path` is always serialized as 32 bytes. `0x01` and `0x00`
-/// are single bytes present for historic reasons.
+/// of the object under this key. `path` is serialized as
+///
+/// ```text
+/// LEB128(bit_length) || bytes,
+/// ```
+///
+/// where
+///
+/// - [LEB128] is a compact serialization format for unsigned integers
+/// - `bit_length` is the number of bits in the path
+/// - `bytes` is the path serialized as the minimum necessary number of bytes,
+///   with zero padding at the end if necessary.
 ///
 /// ## Map with multiple entries
 ///
@@ -831,16 +841,7 @@ where
 /// leaf_hash = sha256( HashTag::Blob || serialized_value ).
 /// ```
 ///
-/// `ProofPath`s are serialized in this case as
-///
-/// ```text
-/// LEB128(bit_length) || bytes.
-/// ```
-///
-/// - [LEB128] is a compact serialization format for unsigned integers
-/// - `bit_length` is the number of bits in the path
-/// - `bytes` is the path serialized as the minimum necessary number of bytes,
-///   with zero padding at the end if necessary.
+/// `ProofPath`s are serialized in the same way as in the previous case.
 ///
 /// [LEB128]: https://en.wikipedia.org/wiki/LEB128
 ///

--- a/components/merkledb/src/indexes/proof_map/mod.rs
+++ b/components/merkledb/src/indexes/proof_map/mod.rs
@@ -14,7 +14,7 @@
 
 //! An implementation of a Merkelized version of a map (Merkle Patricia tree).
 
-pub(crate) use self::key::ProofPath;
+pub(crate) use self::key::{BitsRange, ProofPath};
 pub use self::{
     key::{Hashed, Raw, RawKey, ToProofPath, KEY_SIZE as PROOF_MAP_KEY_SIZE, PROOF_PATH_SIZE},
     proof::{CheckedMapProof, MapProof, MapProofError, ValidationError},
@@ -25,7 +25,7 @@ use std::{fmt, io, marker::PhantomData};
 use exonum_crypto::Hash;
 
 use self::{
-    key::{BitsRange, ChildKind, VALUE_KEY_PREFIX},
+    key::{ChildKind, VALUE_KEY_PREFIX},
     node::{BranchNode, Node},
     proof_builder::{BuildProof, MerklePatriciaTree},
 };

--- a/components/merkledb/src/indexes/proof_map/tests.rs
+++ b/components/merkledb/src/indexes/proof_map/tests.rs
@@ -27,7 +27,7 @@ use serde_json::{self, json};
 use std::{cmp, collections::HashSet, fmt::Debug, hash::Hash as StdHash, marker::PhantomData};
 
 use super::{
-    key::{BitsRange, ChildKind, KEY_SIZE, LEAF_KEY_PREFIX},
+    key::{BitsRange, ChildKind, KEY_SIZE},
     node::BranchNode,
     MapProof, MapProofError, ProofPath,
 };
@@ -161,10 +161,11 @@ where
         let fork = db.fork();
         let mut table = fork.get_generic_proof_map::<_, _, _, S>(IDX_NAME);
         assert_eq!(table.object_hash(), HashTag::empty_map_hash());
-        let root_prefix = &[&[LEAF_KEY_PREFIX], vec![255; 32].as_slice(), &[0_u8]].concat();
+
         let hash = HashStream::new()
             .update(&[HashTag::MapBranchNode as u8])
-            .update(root_prefix)
+            .update(&[128, 2])
+            .update(&[255; HASH_SIZE])
             .update(HashTag::hash_leaf(&[2]).as_ref())
             .hash();
 
@@ -1222,25 +1223,6 @@ fn test_build_proof_in_single_node_tree_hashed() {
 }
 
 #[test]
-fn test_insert_same_key() {
-    let db = TemporaryDB::default();
-    let fork = db.fork();
-    let mut table = fork.get_raw_proof_map(IDX_NAME);
-    assert_eq!(table.object_hash(), HashTag::empty_map_hash());
-    let root_prefix = &[&[LEAF_KEY_PREFIX], vec![255; 32].as_slice(), &[0_u8]].concat();
-    let hash = HashStream::new()
-        .update(&[HashTag::MapBranchNode as u8])
-        .update(root_prefix)
-        .update(HashTag::hash_leaf(&[2]).as_ref())
-        .hash();
-
-    table.put(&[255; 32], vec![1]);
-    table.put(&[255; 32], vec![2]);
-    assert_eq!(table.get(&[255; 32]), Some(vec![2]));
-    assert_eq!(table.object_hash(), HashTag::hash_map_node(hash));
-}
-
-#[test]
 fn test_merkle_root_leaf() {
     let db = TemporaryDB::default();
     let fork = db.fork();
@@ -1250,9 +1232,13 @@ fn test_merkle_root_leaf() {
     let value = vec![4, 5, 6];
     index.put(&key, value.clone());
 
+    let path = Hashed::transform_key(&key);
+    let mut path_buffer = [0; HASH_SIZE + 2];
+    path.write_compressed(&mut path_buffer);
+
     let merkle_root = HashStream::new()
         .update(&[HashTag::MapBranchNode as u8])
-        .update(Hashed::transform_key(&key).as_bytes())
+        .update(&path_buffer[..])
         .update(HashTag::hash_leaf(&value).as_ref())
         .hash();
     assert_eq!(HashTag::hash_map_node(merkle_root), index.object_hash());

--- a/components/merkledb/src/proto/list_proof.proto
+++ b/components/merkledb/src/proto/list_proof.proto
@@ -42,7 +42,7 @@ message ListProofEntry {
     bytes value = 2;
 }
 
-// Represents list node position in the merkle tree.
+// Represents list node position in the Merkle tree.
 message ProofListKey {
     uint64 index = 1;
     uint32 height = 2;

--- a/components/merkledb/src/proto/map_proof.proto
+++ b/components/merkledb/src/proto/map_proof.proto
@@ -23,25 +23,40 @@ option java_package = "com.exonum.core.messages";
 // Subset of map elements coupled with a proof. MapProof can assert existence/absence of certain keys
 // from the underlying map.
 message MapProof {
-    // Array with 2 kinds of objects: `{ key, no_value }` for keys missing from
-    // the underlying index, and `{ key, value }` for key-value pairs, existence of
-    // which is asserted by the proof.
-    repeated OptionalEntry entries = 1;
-    // Array of { path: ProofPath, hash: Hash } objects.
-    repeated MapProofEntry proof = 2;
+  // Array with 2 kinds of objects: `{ key, no_value }` for keys missing from
+  // the underlying index, and `{ key, value }` for key-value pairs, existence of
+  // which is asserted by the proof.
+  repeated OptionalEntry entries = 1;
+  // Array of { path: ProofPath, hash: Hash } objects.
+  repeated MapProofEntry proof = 2;
 }
 
-// Key with corresponding value and empty value if key is missing.
+// Key with corresponding value or an empty value if the key is missing
+// from the underlying map.
 message OptionalEntry {
-    bytes key = 1;
-    oneof maybe_value {
-        bytes value = 2;
-        google.protobuf.Empty no_value = 3;
-    }
+  // Key serialized as per `BinaryKey` implementation (usually as
+  // a Protobuf message, except for primitive types).
+  bytes key = 1;
+  oneof maybe_value {
+    // Value serialized per `BinaryValue` implementation (usually as
+    // a Protobuf message, except for primitive types).
+    bytes value = 2;
+    // Indicator that `key` is missing from the underlying map.
+    google.protobuf.Empty no_value = 3;
+  }
 }
 
-// Proof path and corresponding hash value.
+// Path to an intermediate Merkle Patricia tree node and a corresponding
+// hash value.
 message MapProofEntry {
-    bytes proof_path = 1;
-    exonum.crypto.Hash hash = 2;
+  // Path to the node, expressed with the minimum necessary number of bytes.
+  // Bits within each byte are indexed from the least significant to
+  // the most significant.
+  // The last byte may be padded with zeros if necessary.
+  bytes path = 1;
+  // Hash associated with the node.
+  exonum.crypto.Hash hash = 2;
+  // Number of zero bit padding at the end of the path. Must be in the `0..8`
+  // interval.
+  uint32 path_padding = 3;
 }

--- a/components/merkledb/src/proto/map_proof.proto
+++ b/components/merkledb/src/proto/map_proof.proto
@@ -34,7 +34,7 @@ message MapProof {
 // Key with corresponding value or an empty value if the key is missing
 // from the underlying map.
 message OptionalEntry {
-  // Key serialized as per `BinaryKey` implementation (usually as
+  // Key serialized as per `BinaryValue` implementation (usually as
   // a Protobuf message, except for primitive types).
   bytes key = 1;
   oneof maybe_value {

--- a/components/merkledb/src/proto/mod.rs
+++ b/components/merkledb/src/proto/mod.rs
@@ -19,16 +19,40 @@
 
 pub use self::{list_proof::*, map_proof::*};
 
-use exonum_crypto::proto::*;
+use exonum_crypto::{proto::*, HASH_SIZE};
 use exonum_proto::ProtobufConvert;
 use failure::{ensure, Error};
 use protobuf::{well_known_types::Empty, RepeatedField};
 
 use std::borrow::Cow;
 
-use crate::{proof_map::ProofPath, BinaryKey, BinaryValue};
+use crate::{
+    proof_map::{BitsRange, ProofPath},
+    BinaryKey, BinaryValue,
+};
 
 include!(concat!(env!("OUT_DIR"), "/protobuf_mod.rs"));
+
+fn parse_map_proof_entry(
+    mut entry: MapProofEntry,
+) -> Result<(ProofPath, exonum_crypto::Hash), Error> {
+    let padding = entry.get_path_padding();
+    ensure!(padding < 8, "`padding` is not in 0..8 interval");
+    let mut path_buffer = entry.take_path();
+    ensure!(!path_buffer.is_empty(), "Empty `path`");
+    ensure!(path_buffer.len() <= HASH_SIZE, "`path` is too long");
+
+    // Since we've checked both `path_buffer.len()` and `padding` sanity, the coercions
+    // and the subtraction below will not lead to unexpected results.
+    let path_bit_length = path_buffer.len() as u16 * 8 - padding as u16;
+    path_buffer.resize(HASH_SIZE, 0);
+    let mut path = ProofPath::from_bytes(path_buffer);
+    if path_bit_length < HASH_SIZE as u16 * 8 {
+        path = path.prefix(path_bit_length);
+    }
+    let hash = exonum_crypto::Hash::from_pb(entry.take_hash())?;
+    Ok((path, hash))
+}
 
 impl<K, V, S> ProtobufConvert for crate::MapProof<K, V, S>
 where
@@ -43,10 +67,17 @@ where
         let proof: Vec<MapProofEntry> = self
             .proof_unchecked()
             .iter()
-            .map(|(p, h)| {
+            .map(|(path, hash)| {
                 let mut entry = MapProofEntry::new();
-                entry.set_hash(h.to_pb());
-                entry.set_proof_path(p.as_bytes().to_vec());
+                let padding = match u32::from(path.len()) % 8 {
+                    0 => 0,
+                    value => 8 - value,
+                };
+                debug_assert!(padding < 8);
+
+                entry.set_hash(hash.to_pb());
+                entry.set_path_padding(padding);
+                entry.set_path(path.path_bits());
                 entry
             })
             .collect();
@@ -74,16 +105,11 @@ where
         map_proof
     }
 
-    fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
+    fn from_pb(mut pb: Self::ProtoStruct) -> Result<Self, Error> {
         let proof = pb
-            .get_proof()
-            .iter()
-            .map(|entry| {
-                Ok((
-                    ProofPath::read(entry.get_proof_path()),
-                    exonum_crypto::Hash::from_pb(entry.get_hash().clone())?,
-                ))
-            })
+            .take_proof()
+            .into_iter()
+            .map(parse_map_proof_entry)
             .collect::<Result<Vec<_>, Error>>()?;
 
         let entries = pb
@@ -121,7 +147,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use exonum_crypto::{proto::types, PublicKey};
+    use exonum_crypto::{hash, proto::types, PublicKey};
     use exonum_proto::ProtobufConvert;
     use protobuf::RepeatedField;
 
@@ -179,7 +205,7 @@ mod tests {
 
         hash.set_data(vec![0_u8; 31]);
         proof_entry.set_hash(hash);
-        proof_entry.set_proof_path(vec![0_u8; 34]);
+        proof_entry.set_path(vec![0_u8; 32]);
         proof.set_proof(RepeatedField::from_vec(vec![proof_entry]));
 
         let res = MapProof::<u8, u8>::from_pb(proof.clone());
@@ -195,15 +221,45 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn map_proof_malformed_key_serialize() {
+    fn map_proof_malformed_proof_entry() {
         let mut proof = proto::MapProof::new();
         let mut proof_entry = proto::MapProofEntry::new();
-        proof_entry.set_proof_path(vec![0_u8; 33]);
+        proof_entry.set_hash(hash(b"foo").to_pb());
         proof.set_proof(RepeatedField::from_vec(vec![proof_entry]));
+        let err = MapProof::<u16, u8>::from_pb(proof).unwrap_err();
+        assert!(err.to_string().contains("Empty `path`"));
+
+        let mut proof = proto::MapProof::new();
+        let mut proof_entry = proto::MapProofEntry::new();
+        proof_entry.set_hash(hash(b"foo").to_pb());
+        proof_entry.set_path(vec![1; 33]);
+        proof.set_proof(RepeatedField::from_vec(vec![proof_entry]));
+        let err = MapProof::<u16, u8>::from_pb(proof).unwrap_err();
+        assert!(err.to_string().contains("`path` is too long"));
+
+        let mut proof = proto::MapProof::new();
+        let mut proof_entry = proto::MapProofEntry::new();
+        proof_entry.set_hash(hash(b"foo").to_pb());
+        proof_entry.set_path(vec![11; 32]);
+        proof_entry.set_path_padding(8);
+        proof.set_proof(RepeatedField::from_vec(vec![proof_entry]));
+        let err = MapProof::<u16, u8>::from_pb(proof).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("`padding` is not in 0..8 interval"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn map_proof_malformed_key_deserialize() {
+        let mut proof = proto::MapProof::new();
+        let mut entry = proto::OptionalEntry::new();
+        entry.set_key(vec![1]); // invalid `u16` serialization.
+        entry.set_value(vec![2]);
+        proof.set_entries(RepeatedField::from_vec(vec![entry]));
 
         // TODO: will panic at runtime, should change BinaryKey::read signature (ECR-174)
-        let _res = MapProof::<u8, u8>::from_pb(proof);
+        let _res = MapProof::<u16, u8>::from_pb(proof);
     }
 
     #[test]


### PR DESCRIPTION
## Overview

This PR:

- unifies `ProofPath` serialization for hashing
- changes serialization of `MapProofEntry`
- replaces `BinaryKey` to `BinaryValue` as a constraint on `MapProof` keys for which Protobuf serialization is defined

---

See: https://jira.bf.local/browse/ECR-3485