### PR TITLE
Unified iterator types [ECR-4192]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,14 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 - `MapProof` Protobuf messages now serialize keys according to their
   `BinaryValue` implementation, rather than `BinaryKey`. (#1743)
 
+- All index types now share a common set of iterators: `Entries`, `Keys`
+  and `Values`. (#1762)
+
+- `KeySetIndex::insert` now takes the element by reference. (#1762)
+
+- `KeySetIndex` now supports unsized keys. Its getter methods are no longer
+  parameterized by the key type, similar to `MapIndex` / `ProofMapIndex`. (#1762)
+
 #### exonum-rust-runtime
 
 - Service interfaces now have to specify method IDs with either `interface_method`
@@ -308,6 +316,10 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 
 - `Snapshot` implementation for `Patch` has been fixed. The previous implementation
   could lead to stale reads from a `Patch` or a `Fork`. (#1611)
+
+- Maximum height in `ProofListIndex` was fixed from the bogus value 58 to 56. (#1762)
+
+- Bogus setting of the empty key was removed for `ListIndex`. (#1762)
 
 ## 0.13.0-rc.2 - 2019-12-04
 

--- a/components/merkledb/benches/schema_patterns.rs
+++ b/components/merkledb/benches/schema_patterns.rs
@@ -96,7 +96,7 @@ where
         }
 
         if transaction.value % COLD_CHANCE == 0 {
-            self.other_cold_index.insert(transaction.value);
+            self.other_cold_index.insert(&transaction.value);
         }
     }
 }
@@ -157,7 +157,7 @@ where
         }
 
         if transaction.value % COLD_CHANCE == 0 {
-            self.other_cold_index.get().insert(transaction.value);
+            self.other_cold_index.get().insert(&transaction.value);
         }
     }
 }
@@ -234,7 +234,7 @@ where
         }
 
         if transaction.value % COLD_CHANCE == 0 {
-            self.other_cold_index().insert(transaction.value);
+            self.other_cold_index().insert(&transaction.value);
         }
     }
 }

--- a/components/merkledb/src/access/extensions.rs
+++ b/components/merkledb/src/access/extensions.rs
@@ -238,10 +238,10 @@ pub trait CopyAccessExt: Access + Copy {
     /// # Panics
     ///
     /// If the index exists, but is not a key set.
-    fn get_key_set<I, V>(self, addr: I) -> KeySetIndex<Self::Base, V>
+    fn get_key_set<I, K>(self, addr: I) -> KeySetIndex<Self::Base, K>
     where
         I: Into<IndexAddress>,
-        V: BinaryKey,
+        K: BinaryKey + ?Sized,
     {
         KeySetIndex::from_access(self, addr.into())
             .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))
@@ -461,10 +461,10 @@ pub trait AccessExt: Access {
     /// # Panics
     ///
     /// If the index exists, but is not a key set.
-    fn get_key_set<I, V>(&self, addr: I) -> KeySetIndex<Self::Base, V>
+    fn get_key_set<I, K>(&self, addr: I) -> KeySetIndex<Self::Base, K>
     where
         I: Into<IndexAddress>,
-        V: BinaryKey,
+        K: BinaryKey + ?Sized,
     {
         KeySetIndex::from_access(self.clone(), addr.into())
             .unwrap_or_else(|e| panic!("MerkleDB error: {}", e))

--- a/components/merkledb/src/generic.rs
+++ b/components/merkledb/src/generic.rs
@@ -540,7 +540,7 @@ mod tests {
         let access = Migration::new("foo", &fork).into_erased();
         assert!(access.is_mutable());
         access.get_proof_list("list").extend(vec![4_i32, 5, 6, 7]);
-        access.get_key_set("set").insert(99_u8);
+        access.get_key_set("set").insert(&99_u8);
         let access = Scratchpad::new("foo", &fork).into_erased();
         access.get_entry("iter_position").set(123_u32);
         drop(access);

--- a/components/merkledb/src/indexes/iter.rs
+++ b/components/merkledb/src/indexes/iter.rs
@@ -1,0 +1,109 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic iterator types used by all indexes.
+
+use crate::{
+    views::{Iter, RawAccess, View},
+    BinaryKey, BinaryValue,
+};
+
+/// FIXME
+#[derive(Debug)]
+pub struct Entries<'a, K: ?Sized, V> {
+    base_iter: Iter<'a, K, V>,
+}
+
+impl<'a, K, V> Entries<'a, K, V>
+where
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+{
+    pub(crate) fn new<T: RawAccess>(view: &'a View<T>, from: Option<&K>) -> Self {
+        Self::with_prefix(view, &(), from)
+    }
+
+    pub(crate) fn with_prefix<T, P>(view: &'a View<T>, prefix: &P, from: Option<&K>) -> Self
+    where
+        T: RawAccess,
+        P: BinaryKey,
+    {
+        let base_iter = if let Some(from) = from {
+            view.iter_from(prefix, from)
+        } else {
+            view.iter(prefix)
+        };
+        Self { base_iter }
+    }
+
+    /// FIXME
+    pub fn skip_values(self) -> Keys<'a, K> {
+        Keys {
+            base_iter: self.base_iter.drop_value_type(),
+        }
+    }
+
+    /// FIXME
+    pub fn skip_keys(self) -> Values<'a, V> {
+        Values {
+            base_iter: self.base_iter.drop_key_type(),
+        }
+    }
+}
+
+impl<K, V> Iterator for Entries<'_, K, V>
+where
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+{
+    type Item = (K::Owned, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.base_iter.next()
+    }
+}
+
+/// FIXME
+#[derive(Debug)]
+pub struct Keys<'a, K: ?Sized> {
+    base_iter: Iter<'a, K, ()>,
+}
+
+impl<K> Iterator for Keys<'_, K>
+where
+    K: BinaryKey + ?Sized,
+{
+    type Item = K::Owned;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.base_iter.next().map(|(key, _)| key)
+    }
+}
+
+/// FIXME
+#[derive(Debug)]
+pub struct Values<'a, V> {
+    base_iter: Iter<'a, (), V>,
+}
+
+impl<V> Iterator for Values<'_, V>
+where
+    V: BinaryValue,
+{
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.base_iter.next().map(|(_, value)| value)
+    }
+}

--- a/components/merkledb/src/indexes/iter.rs
+++ b/components/merkledb/src/indexes/iter.rs
@@ -120,3 +120,15 @@ where
         self.base_iter.next().map(|(_, value)| value)
     }
 }
+
+/// Database object that supports iteration and continuing iteration from an intermediate position.
+pub trait IndexIterator {
+    /// Type encompassing iteration position.
+    type Key: BinaryKey + ?Sized;
+    /// Type encompassing returned value.
+    type Value: BinaryValue;
+
+    /// Continues iteration from the specified position. If `from` is `None`, starts the iteration
+    /// from scratch.
+    fn index_iter(&self, from: Option<&Self::Key>) -> Entries<'_, Self::Key, Self::Value>;
+}

--- a/components/merkledb/src/indexes/iter.rs
+++ b/components/merkledb/src/indexes/iter.rs
@@ -19,7 +19,12 @@ use crate::{
     BinaryKey, BinaryValue,
 };
 
-/// FIXME
+/// Iterator over key-value pairs of an index.
+///
+/// This structure is returned by the [`IndexIterator`] trait and by inherent methods
+/// of some indexes.
+///
+/// [`IndexIterator`]: trait.IndexIterator.html
 #[derive(Debug)]
 pub struct Entries<'a, K: ?Sized, V> {
     base_iter: Iter<'a, K, V>,
@@ -30,10 +35,13 @@ where
     K: BinaryKey + ?Sized,
     V: BinaryValue,
 {
+    /// Creates a new iterator based on the provided view.
     pub(crate) fn new<T: RawAccess>(view: &'a View<T>, from: Option<&K>) -> Self {
         Self::with_prefix(view, &(), from)
     }
 
+    /// Creates a new iterator based on the provided view. The keys returned by the iterator
+    /// are additionally filtered by the `prefix`.
     pub(crate) fn with_prefix<T, P>(view: &'a View<T>, prefix: &P, from: Option<&K>) -> Self
     where
         T: RawAccess,
@@ -47,6 +55,9 @@ where
         Self { base_iter }
     }
 
+    /// Creates a new iterator based on the provided view. The keys returned by the iterator
+    /// are additionally filtered by the `prefix`, which is detached from the key before
+    /// deserialization.
     pub(crate) fn with_detached_prefix<T, P>(
         view: &'a View<T>,
         prefix: &P,
@@ -60,14 +71,14 @@ where
         Self { base_iter }
     }
 
-    /// FIXME
+    /// Skips values in the iterator output without parsing them.
     pub fn skip_values(self) -> Keys<'a, K> {
         Keys {
             base_iter: self.base_iter.drop_value_type(),
         }
     }
 
-    /// FIXME
+    /// Skips keys in the iterator output without parsing them.
     pub fn skip_keys(self) -> Values<'a, V> {
         Values {
             base_iter: self.base_iter.drop_key_type(),
@@ -87,7 +98,12 @@ where
     }
 }
 
-/// FIXME
+/// Iterator over keys of an index.
+///
+/// This structure is returned by [`Entries::skip_values`] , and by inherent methods
+/// of some indexes.
+///
+/// [`Entries::skip_values`]: struct.Entries.html#method.skip_values
 #[derive(Debug)]
 pub struct Keys<'a, K: ?Sized> {
     base_iter: Iter<'a, K, ()>,
@@ -104,7 +120,12 @@ where
     }
 }
 
-/// FIXME
+/// Iterator over values of an index.
+///
+/// This structure is returned by [`Entries::skip_keys`] , and by inherent methods
+/// of some indexes.
+///
+/// [`Entries::skip_keys`]: struct.Entries.html#method.skip_keys
 #[derive(Debug)]
 pub struct Values<'a, V> {
     base_iter: Iter<'a, (), V>,
@@ -122,10 +143,13 @@ where
 }
 
 /// Database object that supports iteration and continuing iteration from an intermediate position.
+///
+/// This trait is implemented for all index collections (i.e., all index types except for
+/// `Entry` and `ProofEntry`) and can thus be used by the generic iteration routines.
 pub trait IndexIterator {
-    /// Type encompassing iteration position.
+    /// Type encompassing index keys.
     type Key: BinaryKey + ?Sized;
-    /// Type encompassing returned value.
+    /// Type encompassing index values.
     type Value: BinaryValue;
 
     /// Continues iteration from the specified position. If `from` is `None`, starts the iteration

--- a/components/merkledb/src/indexes/iter.rs
+++ b/components/merkledb/src/indexes/iter.rs
@@ -47,6 +47,19 @@ where
         Self { base_iter }
     }
 
+    pub(crate) fn with_detached_prefix<T, P>(
+        view: &'a View<T>,
+        prefix: &P,
+        from: Option<&K>,
+    ) -> Self
+    where
+        T: RawAccess,
+        P: BinaryKey,
+    {
+        let base_iter = view.iter_detached(prefix, from);
+        Self { base_iter }
+    }
+
     /// FIXME
     pub fn skip_values(self) -> Keys<'a, K> {
         Keys {

--- a/components/merkledb/src/indexes/key_set.rs
+++ b/components/merkledb/src/indexes/key_set.rs
@@ -18,13 +18,12 @@
 //! The given section contains information on the methods related to `KeySetIndex`
 //! and the iterator over the items of this set.
 
-use std::{borrow::Borrow, marker::PhantomData};
+use std::marker::PhantomData;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    views::{
-        IndexAddress, IndexType, Iter as ViewIter, RawAccess, RawAccessMut, View, ViewWithMetadata,
-    },
+    indexes::iter::{Entries, Keys},
+    views::{IndexAddress, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryKey,
 };
 
@@ -35,28 +34,15 @@ use crate::{
 ///
 /// [`BinaryKey`]: ../../trait.BinaryKey.html
 #[derive(Debug)]
-pub struct KeySetIndex<T: RawAccess, K> {
+pub struct KeySetIndex<T: RawAccess, K: ?Sized> {
     base: View<T>,
     _k: PhantomData<K>,
-}
-
-/// Returns an iterator over the items of a `KeySetIndex`.
-///
-/// This struct is created by the [`iter`] or
-/// [`iter_from`] method on [`KeySetIndex`]. See its documentation for details.
-///
-/// [`iter`]: struct.KeySetIndex.html#method.iter
-/// [`iter_from`]: struct.KeySetIndex.html#method.iter_from
-/// [`KeySetIndex`]: struct.KeySetIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, K> {
-    base_iter: ViewIter<'a, K, ()>,
 }
 
 impl<T, K> FromAccess<T> for KeySetIndex<T::Base, K>
 where
     T: Access,
-    K: BinaryKey,
+    K: BinaryKey + ?Sized,
 {
     fn from_access(access: T, addr: IndexAddress) -> Result<Self, AccessError> {
         let view = access.get_or_create_view(addr, IndexType::KeySet)?;
@@ -67,7 +53,7 @@ where
 impl<T, K> KeySetIndex<T, K>
 where
     T: RawAccess,
-    K: BinaryKey,
+    K: BinaryKey + ?Sized,
 {
     fn new(view: ViewWithMetadata<T>) -> Self {
         let base = view.into();
@@ -89,14 +75,10 @@ where
     /// let mut index = fork.get_key_set("name");
     /// assert!(!index.contains(&1));
     ///
-    /// index.insert(1);
+    /// index.insert(&1);
     /// assert!(index.contains(&1));
     /// ```
-    pub fn contains<Q>(&self, item: &Q) -> bool
-    where
-        K: Borrow<Q>,
-        Q: BinaryKey + ?Sized,
-    {
+    pub fn contains(&self, item: &K) -> bool {
         self.base.contains(item)
     }
 
@@ -115,10 +97,8 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, K> {
-        Iter {
-            base_iter: self.base.iter(&()),
-        }
+    pub fn iter(&self) -> Keys<'_, K> {
+        Entries::<K, ()>::new(&self.base, None).skip_values()
     }
 
     /// Returns an iterator visiting all elements in arbitrary order starting from the specified value.
@@ -137,17 +117,15 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter_from(&self, from: &K) -> Iter<'_, K> {
-        Iter {
-            base_iter: self.base.iter_from(&(), from),
-        }
+    pub fn iter_from(&self, from: &K) -> Keys<'_, K> {
+        Entries::<K, ()>::new(&self.base, Some(from)).skip_values()
     }
 }
 
 impl<T, K> KeySetIndex<T, K>
 where
     T: RawAccessMut,
-    K: BinaryKey,
+    K: BinaryKey + ?Sized,
 {
     /// Adds a key to the set.
     ///
@@ -160,12 +138,11 @@ where
     /// let fork = db.fork();
     /// let mut index = fork.get_key_set("name");
     ///
-    /// index.insert(1);
+    /// index.insert(&1);
     /// assert!(index.contains(&1));
     /// ```
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
-    pub fn insert(&mut self, item: K) {
-        self.base.put(&item, ())
+    pub fn insert(&mut self, item: &K) {
+        self.base.put(item, ())
     }
 
     /// Removes a key from the set.
@@ -179,17 +156,13 @@ where
     /// let fork = db.fork();
     /// let mut index = fork.get_key_set("name");
     ///
-    /// index.insert(1);
+    /// index.insert(&1);
     /// assert!(index.contains(&1));
     ///
     /// index.remove(&1);
     /// assert!(!index.contains(&1));
     /// ```
-    pub fn remove<Q>(&mut self, item: &Q)
-    where
-        K: Borrow<Q>,
-        Q: BinaryKey + ?Sized,
-    {
+    pub fn remove(&mut self, item: &K) {
         self.base.remove(item)
     }
 
@@ -209,7 +182,7 @@ where
     /// let fork = db.fork();
     /// let mut index = fork.get_key_set("name");
     ///
-    /// index.insert(1);
+    /// index.insert(&1);
     /// assert!(index.contains(&1));
     ///
     /// index.clear();
@@ -220,27 +193,16 @@ where
     }
 }
 
-impl<'a, T, K> std::iter::IntoIterator for &'a KeySetIndex<T, K>
+impl<'a, T, K> IntoIterator for &'a KeySetIndex<T, K>
 where
     T: RawAccess,
-    K: BinaryKey,
+    K: BinaryKey + ?Sized,
 {
     type Item = K::Owned;
-    type IntoIter = Iter<'a, K>;
+    type IntoIter = Keys<'a, K>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, K> Iterator for Iter<'a, K>
-where
-    K: BinaryKey,
-{
-    type Item = K::Owned;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(k, ..)| k)
     }
 }
 
@@ -257,9 +219,9 @@ mod tests {
         let db = TemporaryDB::new();
         let fork = db.fork();
 
-        let mut index: KeySetIndex<_, String> = fork.get_key_set(INDEX_NAME);
+        let mut index: KeySetIndex<_, str> = fork.get_key_set(INDEX_NAME);
         assert_eq!(false, index.contains(KEY));
-        index.insert(KEY.to_owned());
+        index.insert(KEY);
         assert_eq!(true, index.contains(KEY));
         index.remove(KEY);
         assert_eq!(false, index.contains(KEY));
@@ -271,9 +233,9 @@ mod tests {
         let db = TemporaryDB::new();
         let fork = db.fork();
 
-        let mut index: KeySetIndex<_, Vec<u8>> = fork.get_key_set(INDEX_NAME);
+        let mut index = fork.get_key_set(INDEX_NAME);
         assert_eq!(false, index.contains(KEY));
-        index.insert(KEY.to_owned());
+        index.insert(KEY);
         assert_eq!(true, index.contains(KEY));
         index.remove(KEY);
         assert_eq!(false, index.contains(KEY));
@@ -286,9 +248,9 @@ mod tests {
 
         let mut index = fork.get_key_set(INDEX_NAME);
         assert!(!index.contains(&1_u8));
-        index.insert(1_u8);
+        index.insert(&1_u8);
         assert!(index.contains(&1_u8));
-        index.insert(2_u8);
+        index.insert(&2_u8);
         let key = index.iter().next().unwrap();
         index.remove(&key);
         assert!(!index.contains(&1_u8));
@@ -302,7 +264,7 @@ mod tests {
         let mut fork = db.fork();
         {
             let mut set = fork.get_key_set::<_, u8>(INDEX_NAME);
-            set.insert(4);
+            set.insert(&4);
             set.clear();
         }
         fork.flush();

--- a/components/merkledb/src/indexes/key_set.rs
+++ b/components/merkledb/src/indexes/key_set.rs
@@ -82,7 +82,7 @@ where
         self.base.contains(item)
     }
 
-    /// Returns an iterator visiting all elements in ascending order. The iterator element type is K.
+    /// Returns an iterator over set elements.
     ///
     /// # Examples
     ///
@@ -101,8 +101,7 @@ where
         self.index_iter(None).skip_values()
     }
 
-    /// Returns an iterator visiting all elements in arbitrary order starting from the specified value.
-    /// The iterator element type is K.
+    /// Returns an iterator over set elements starting from the specified value.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/key_set.rs
+++ b/components/merkledb/src/indexes/key_set.rs
@@ -22,7 +22,7 @@ use std::marker::PhantomData;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    indexes::iter::{Entries, Keys},
+    indexes::iter::{Entries, IndexIterator, Keys},
     views::{IndexAddress, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryKey,
 };
@@ -98,7 +98,7 @@ where
     /// }
     /// ```
     pub fn iter(&self) -> Keys<'_, K> {
-        Entries::<K, ()>::new(&self.base, None).skip_values()
+        self.index_iter(None).skip_values()
     }
 
     /// Returns an iterator visiting all elements in arbitrary order starting from the specified value.
@@ -118,7 +118,7 @@ where
     /// }
     /// ```
     pub fn iter_from(&self, from: &K) -> Keys<'_, K> {
-        Entries::<K, ()>::new(&self.base, Some(from)).skip_values()
+        self.index_iter(Some(from)).skip_values()
     }
 }
 
@@ -203,6 +203,19 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T, K> IndexIterator for KeySetIndex<T, K>
+where
+    T: RawAccess,
+    K: BinaryKey + ?Sized,
+{
+    type Key = K;
+    type Value = ();
+
+    fn index_iter(&self, from: Option<&K>) -> Entries<'_, K, ()> {
+        Entries::new(&self.base, from)
     }
 }
 

--- a/components/merkledb/src/indexes/key_set.rs
+++ b/components/merkledb/src/indexes/key_set.rs
@@ -32,7 +32,7 @@ use crate::{
 /// `KeySetIndex` implements a set that stores the elements as keys with empty values.
 /// `KeySetIndex` requires that elements should implement the [`BinaryKey`] trait.
 ///
-/// [`BinaryKey`]: ../../trait.BinaryKey.html
+/// [`BinaryKey`]: ../trait.BinaryKey.html
 #[derive(Debug)]
 pub struct KeySetIndex<T: RawAccess, K: ?Sized> {
     base: View<T>,

--- a/components/merkledb/src/indexes/list.rs
+++ b/components/merkledb/src/indexes/list.rs
@@ -34,7 +34,7 @@ use crate::{
 /// using `u64` as an index. `ListIndex` requires that elements implement the
 /// [`BinaryValue`] trait.
 ///
-/// [`BinaryValue`]: ../../trait.BinaryValue.html
+/// [`BinaryValue`]: ../trait.BinaryValue.html
 #[derive(Debug)]
 pub struct ListIndex<T: RawAccess, V> {
     base: View<T>,

--- a/components/merkledb/src/indexes/list.rs
+++ b/components/merkledb/src/indexes/list.rs
@@ -150,7 +150,7 @@ where
         self.state.get().unwrap_or_default()
     }
 
-    /// Returns an iterator over the list. The iterator element type is V.
+    /// Returns an iterator over the list values.
     ///
     /// # Examples
     ///
@@ -171,8 +171,7 @@ where
         self.index_iter(None).skip_keys()
     }
 
-    /// Returns an iterator over the list starting from the specified position. The iterator
-    /// element type is V.
+    /// Returns an iterator over the list values starting from the specified position.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/list.rs
+++ b/components/merkledb/src/indexes/list.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    indexes::iter::{Entries, Values},
+    indexes::iter::{Entries, IndexIterator, Values},
     views::{IndexAddress, IndexState, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryValue,
 };
@@ -168,7 +168,7 @@ where
     /// }
     /// ```
     pub fn iter(&self) -> Values<'_, V> {
-        Entries::<u64, V>::new(&self.base, None).skip_keys()
+        self.index_iter(None).skip_keys()
     }
 
     /// Returns an iterator over the list starting from the specified position. The iterator
@@ -190,7 +190,7 @@ where
     /// }
     /// ```
     pub fn iter_from(&self, from: u64) -> Values<'_, V> {
-        Entries::<_, V>::new(&self.base, Some(&from)).skip_keys()
+        self.index_iter(Some(&from)).skip_keys()
     }
 }
 
@@ -377,6 +377,19 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T, V> IndexIterator for ListIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue,
+{
+    type Key = u64;
+    type Value = V;
+
+    fn index_iter(&self, from: Option<&u64>) -> Entries<'_, u64, V> {
+        Entries::new(&self.base, from)
     }
 }
 

--- a/components/merkledb/src/indexes/list.rs
+++ b/components/merkledb/src/indexes/list.rs
@@ -21,10 +21,8 @@ use std::marker::PhantomData;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    views::{
-        IndexAddress, IndexState, IndexType, Iter as ViewIter, RawAccess, RawAccessMut, View,
-        ViewWithMetadata,
-    },
+    indexes::iter::{Entries, Values},
+    views::{IndexAddress, IndexState, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryValue,
 };
 
@@ -42,19 +40,6 @@ pub struct ListIndex<T: RawAccess, V> {
     base: View<T>,
     state: IndexState<T, u64>,
     _v: PhantomData<V>,
-}
-
-/// Returns an iterator over the items of a `ListIndex`.
-///
-/// This struct is created by the [`iter`] or
-/// [`iter_from`] method on [`ListIndex`]. See its documentation for details.
-///
-/// [`iter`]: struct.ListIndex.html#method.iter
-/// [`iter_from`]: struct.ListIndex.html#method.iter_from
-/// [`ListIndex`]: struct.ListIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, V> {
-    base_iter: ViewIter<'a, u64, V>,
 }
 
 impl<T, V> FromAccess<T> for ListIndex<T::Base, V>
@@ -182,10 +167,8 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&(), &0_u64),
-        }
+    pub fn iter(&self) -> Values<'_, V> {
+        Entries::<u64, V>::new(&self.base, None).skip_keys()
     }
 
     /// Returns an iterator over the list starting from the specified position. The iterator
@@ -206,10 +189,8 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter_from(&self, from: u64) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&(), &from),
-        }
+    pub fn iter_from(&self, from: u64) -> Values<'_, V> {
+        Entries::<_, V>::new(&self.base, Some(&from)).skip_keys()
     }
 }
 
@@ -290,7 +271,6 @@ where
             self.base.put(&len, value);
             len += 1;
         }
-        self.base.put(&(), len);
         self.set_len(len);
     }
 
@@ -387,27 +367,16 @@ where
     }
 }
 
-impl<'a, T, V> std::iter::IntoIterator for &'a ListIndex<T, V>
+impl<'a, T, V> IntoIterator for &'a ListIndex<T, V>
 where
     T: RawAccess,
     V: BinaryValue,
 {
     type Item = V;
-    type IntoIter = Iter<'a, V>;
+    type IntoIter = Values<'a, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, V> Iterator for Iter<'a, V>
-where
-    V: BinaryValue,
-{
-    type Item = V;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(.., v)| v)
     }
 }
 
@@ -465,13 +434,10 @@ mod tests {
     fn list_index_iter(list_index: &mut ListIndex<&Fork, u8>) {
         list_index.extend(vec![1_u8, 2, 3]);
 
-        assert_eq!(list_index.iter().collect::<Vec<u8>>(), vec![1, 2, 3]);
-        assert_eq!(list_index.iter_from(0).collect::<Vec<u8>>(), vec![1, 2, 3]);
-        assert_eq!(list_index.iter_from(1).collect::<Vec<u8>>(), vec![2, 3]);
-        assert_eq!(
-            list_index.iter_from(3).collect::<Vec<u8>>(),
-            Vec::<u8>::new()
-        );
+        assert_eq!(list_index.iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(list_index.iter_from(0).collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(list_index.iter_from(1).collect::<Vec<_>>(), vec![2, 3]);
+        assert_eq!(list_index.iter_from(3).count(), 0);
     }
 
     fn list_index_clear_in_family(db: &dyn Database, x: u32, y: u32, merge_before_clear: bool) {

--- a/components/merkledb/src/indexes/map.rs
+++ b/components/merkledb/src/indexes/map.rs
@@ -22,7 +22,7 @@ use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    indexes::iter::{Entries, Keys, Values},
+    indexes::iter::{Entries, IndexIterator, Keys, Values},
     views::{IndexAddress, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryKey, BinaryValue,
 };
@@ -123,7 +123,7 @@ where
     /// }
     /// ```
     pub fn iter(&self) -> Entries<'_, K, V> {
-        Entries::new(&self.base, None)
+        self.index_iter(None)
     }
 
     /// Returns an iterator over the keys of a map in ascending order. The iterator element
@@ -183,7 +183,7 @@ where
     /// }
     /// ```
     pub fn iter_from(&self, from: &K) -> Entries<'_, K, V> {
-        Entries::new(&self.base, Some(from))
+        self.index_iter(Some(from))
     }
 
     /// Returns an iterator over the keys of a map in ascending order starting from the
@@ -313,6 +313,20 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T, K, V> IndexIterator for MapIndex<T, K, V>
+where
+    T: RawAccess,
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+{
+    type Key = K;
+    type Value = V;
+
+    fn index_iter(&self, from: Option<&K>) -> Entries<'_, K, V> {
+        Entries::new(&self.base, from)
     }
 }
 

--- a/components/merkledb/src/indexes/map.rs
+++ b/components/merkledb/src/indexes/map.rs
@@ -106,8 +106,7 @@ where
         self.base.contains(key)
     }
 
-    /// Returns an iterator over the entries of the map in ascending order. The iterator element
-    /// type is (K, V).
+    /// Returns an iterator over the entries of the map in ascending order.
     ///
     /// # Examples
     ///
@@ -126,8 +125,7 @@ where
         self.index_iter(None)
     }
 
-    /// Returns an iterator over the keys of a map in ascending order. The iterator element
-    /// type is K.
+    /// Returns an iterator over the keys of a map in ascending order.
     ///
     /// # Examples
     ///
@@ -146,8 +144,7 @@ where
         self.iter().skip_values()
     }
 
-    /// Returns an iterator over the values of a map in ascending order of keys. The iterator
-    /// element type is V.
+    /// Returns an iterator over the values of a map in ascending order of keys.
     ///
     /// # Examples
     ///
@@ -167,7 +164,7 @@ where
     }
 
     /// Returns an iterator over the entries of a map in ascending order starting from the
-    /// specified key. The iterator element type is (K, V).
+    /// specified key.
     ///
     /// # Examples
     ///
@@ -187,7 +184,7 @@ where
     }
 
     /// Returns an iterator over the keys of a map in ascending order starting from the
-    /// specified key. The iterator element type is K.
+    /// specified key.
     ///
     /// # Examples
     ///
@@ -207,7 +204,7 @@ where
     }
 
     /// Returns an iterator over the values of a map in ascending order of keys starting from the
-    /// specified key. The iterator element type is V.
+    /// specified key.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/map.rs
+++ b/components/merkledb/src/indexes/map.rs
@@ -32,8 +32,8 @@ use crate::{
 /// `MapIndex` requires that keys implement the [`BinaryKey`] trait and values implement
 /// the [`BinaryValue`] trait.
 ///
-/// [`BinaryKey`]: ../../trait.BinaryKey.html
-/// [`BinaryValue`]: ../../trait.BinaryValue.html
+/// [`BinaryKey`]: ../trait.BinaryKey.html
+/// [`BinaryValue`]: ../trait.BinaryValue.html
 #[derive(Debug)]
 pub struct MapIndex<T: RawAccess, K: ?Sized, V> {
     base: View<T>,

--- a/components/merkledb/src/indexes/mod.rs
+++ b/components/merkledb/src/indexes/mod.rs
@@ -14,17 +14,26 @@
 
 //! All available `MerkleDB` indexes.
 
-pub use self::{entry::Entry, group::Group, proof_entry::ProofEntry};
+pub use self::{
+    entry::Entry,
+    group::Group,
+    iter::{Entries, IndexIterator, Keys, Values},
+    key_set::KeySetIndex,
+    list::ListIndex,
+    map::MapIndex,
+    proof_entry::ProofEntry,
+    sparse_list::SparseListIndex,
+    value_set::ValueSetIndex,
+};
 
 mod entry;
 mod group;
+mod iter;
+mod key_set;
+mod list;
+mod map;
 mod proof_entry;
-
-pub mod iter;
-pub mod key_set;
-pub mod list;
-pub mod map;
 pub mod proof_list;
 pub mod proof_map;
-pub mod sparse_list;
-pub mod value_set;
+mod sparse_list;
+mod value_set;

--- a/components/merkledb/src/indexes/mod.rs
+++ b/components/merkledb/src/indexes/mod.rs
@@ -20,6 +20,7 @@ mod entry;
 mod group;
 mod proof_entry;
 
+pub mod iter;
 pub mod key_set;
 pub mod list;
 pub mod map;

--- a/components/merkledb/src/indexes/proof_list/key.rs
+++ b/components/merkledb/src/indexes/proof_list/key.rs
@@ -18,7 +18,7 @@ use std::cmp::Ordering;
 
 use crate::BinaryKey;
 
-const HEIGHT_SHIFT: u64 = 56;
+pub(crate) const HEIGHT_SHIFT: u64 = 56;
 pub(crate) const MAX_INDEX: u64 = 0xFF_FFFF_FFFF_FFFF; // 2_u64.pow(56) - 1
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,7 +29,7 @@ pub struct ProofListKey {
 
 impl ProofListKey {
     pub fn new(height: u8, index: u64) -> Self {
-        debug_assert!(height <= 58 && index <= MAX_INDEX);
+        debug_assert!(u64::from(height) <= HEIGHT_SHIFT && index <= MAX_INDEX);
         Self { height, index }
     }
 

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -284,7 +284,7 @@ where
         self.create_range_proof(range)
     }
 
-    /// Returns an iterator over the list. The iterator element type is `V`.
+    /// Returns an iterator over the list values.
     ///
     /// # Examples
     ///
@@ -303,8 +303,7 @@ where
         self.index_iter(None).skip_keys()
     }
 
-    /// Returns an iterator over the list starting from the specified position. The iterator
-    /// element type is `V`.
+    /// Returns an iterator over the list values starting from the specified position.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -21,16 +21,15 @@ use exonum_crypto::Hash;
 use std::{cmp, iter, marker::PhantomData, ops::RangeBounds};
 
 use self::{
-    key::{ProofListKey, MAX_INDEX},
+    key::ProofListKey,
     proof::HashedEntry,
     proof_builder::{BuildProof, MerkleTree},
 };
 use crate::{
     access::{Access, AccessError, FromAccess},
     hash::HashTag,
-    views::{
-        IndexState, IndexType, Iter as ViewIter, RawAccess, RawAccessMut, View, ViewWithMetadata,
-    },
+    indexes::iter::{Entries, Values},
+    views::{IndexState, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryValue, IndexAddress, ObjectHash,
 };
 
@@ -59,19 +58,6 @@ pub struct ProofListIndex<T: RawAccess, V> {
     base: View<T>,
     state: IndexState<T, u64>,
     _v: PhantomData<V>,
-}
-
-/// An iterator over the items of a `ProofListIndex`.
-///
-/// This struct is created by the [`iter`] or
-/// [`iter_from`] method on [`ProofListIndex`]. See its documentation for details.
-///
-/// [`iter`]: struct.ProofListIndex.html#method.iter
-/// [`iter_from`]: struct.ProofListIndex.html#method.iter_from
-/// [`ProofListIndex`]: struct.ProofListIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, V> {
-    base_iter: ViewIter<'a, ProofListKey, V>,
 }
 
 impl<T, V> MerkleTree<V> for ProofListIndex<T, V>
@@ -298,7 +284,7 @@ where
         self.create_range_proof(range)
     }
 
-    /// Returns an iterator over the list. The iterator element type is V.
+    /// Returns an iterator over the list. The iterator element type is `V`.
     ///
     /// # Examples
     ///
@@ -313,14 +299,12 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter(&0_u8),
-        }
+    pub fn iter(&self) -> Values<'_, V> {
+        Entries::<u64, _>::with_prefix(&self.base, &0_u8, None).skip_keys()
     }
 
     /// Returns an iterator over the list starting from the specified position. The iterator
-    /// element type is V.
+    /// element type is `V`.
     ///
     /// # Examples
     ///
@@ -335,10 +319,11 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn iter_from(&self, from: u64) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&0_u8, &ProofListKey::leaf(from)),
-        }
+    pub fn iter_from(&self, from: u64) -> Values<'_, V> {
+        // Using `from` directly works because of `prefix`. If `from` is greater than
+        // the maximum index of a leaf element, the iterator should immediately end
+        // because the key does not start with the prefix.
+        Entries::with_prefix(&self.base, &0_u8, Some(&from)).skip_keys()
     }
 }
 
@@ -734,21 +719,10 @@ where
     V: BinaryValue,
 {
     type Item = V;
-    type IntoIter = Iter<'a, V>;
+    type IntoIter = Values<'a, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, V> Iterator for Iter<'a, V>
-where
-    V: BinaryValue,
-{
-    type Item = V;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(_, v)| v)
     }
 }
 
@@ -760,9 +734,14 @@ mod proto {
 
     use std::borrow::Cow;
 
-    use super::{HashedEntry, ListProof, ProofListKey};
-    pub use crate::proto::{self, *};
-    use crate::{indexes::proof_list::MAX_INDEX, BinaryValue};
+    use super::{
+        key::{HEIGHT_SHIFT, MAX_INDEX},
+        HashedEntry, ListProof, ProofListKey,
+    };
+    use crate::{
+        proto::{self, *},
+        BinaryValue,
+    };
 
     impl ProtobufConvert for ProofListKey {
         type ProtoStruct = proto::ProofListKey;
@@ -780,7 +759,7 @@ mod proto {
 
             // ProtobufConvert is implemented manually to add these checks.
             ensure!(index <= MAX_INDEX, "index is out of range");
-            ensure!(height <= 58, "height is out of range");
+            ensure!(u64::from(height) <= HEIGHT_SHIFT, "height is out of range");
 
             Ok(ProofListKey::new(height as u8, index))
         }

--- a/components/merkledb/src/indexes/proof_list/tests.rs
+++ b/components/merkledb/src/indexes/proof_list/tests.rs
@@ -162,6 +162,21 @@ fn iter() {
 }
 
 #[test]
+fn iter_from_with_large_index() {
+    let db = TemporaryDB::new();
+    let fork = db.fork();
+    let mut list_index = fork.get_proof_list(IDX_NAME);
+
+    list_index.extend(1_u8..10);
+    // This key should be present in the Merkle tree, but should not be returned
+    // from the iterator.
+    let key = ProofListKey::new(1, 0).as_db_key();
+    assert!(key >= 1 << 56);
+    let items = list_index.iter_from(key);
+    assert_eq!(items.count(), 0);
+}
+
+#[test]
 fn simple_proof() {
     let db = TemporaryDB::new();
     let fork = db.fork();

--- a/components/merkledb/src/indexes/proof_map/mod.rs
+++ b/components/merkledb/src/indexes/proof_map/mod.rs
@@ -31,9 +31,10 @@ use self::{
 };
 use crate::{
     access::{Access, AccessError, FromAccess},
+    indexes::iter::{Entries, Keys, Values},
     views::{
-        BinaryAttribute, IndexAddress, IndexState, IndexType, Iter as ViewIter, RawAccess,
-        RawAccessMut, View, ViewWithMetadata,
+        BinaryAttribute, IndexAddress, IndexState, IndexType, RawAccess, RawAccessMut, View,
+        ViewWithMetadata,
     },
     BinaryKey, BinaryValue, HashTag, ObjectHash,
 };
@@ -83,47 +84,6 @@ pub struct ProofMapIndex<T: RawAccess, K: ?Sized, V, KeyMode: ToProofPath<K> = H
     _key_mode: PhantomData<KeyMode>,
 }
 
-/// An iterator over the entries of a `ProofMapIndex`.
-///
-/// This struct is created by the [`iter`] or
-/// [`iter_from`] method on [`ProofMapIndex`]. See its documentation for details.
-///
-/// [`iter`]: struct.ProofMapIndex.html#method.iter
-/// [`iter_from`]: struct.ProofMapIndex.html#method.iter_from
-/// [`ProofMapIndex`]: struct.ProofMapIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, K: ?Sized, V> {
-    base_iter: ViewIter<'a, Vec<u8>, V>,
-    _k: PhantomData<K>,
-}
-
-/// An iterator over the keys of a `ProofMapIndex`.
-///
-/// This struct is created by the [`keys`] or
-/// [`keys_from`] method on [`ProofMapIndex`]. See its documentation for details.
-///
-/// [`keys`]: struct.ProofMapIndex.html#method.keys
-/// [`keys_from`]: struct.ProofMapIndex.html#method.keys_from
-/// [`ProofMapIndex`]: struct.ProofMapIndex.html
-#[derive(Debug)]
-pub struct Keys<'a, K: ?Sized> {
-    base_iter: ViewIter<'a, Vec<u8>, ()>,
-    _k: PhantomData<K>,
-}
-
-/// An iterator over the values of a `ProofMapIndex`.
-///
-/// This struct is created by the [`values`] or
-/// [`values_from`] method on [`ProofMapIndex`]. See its documentation for details.
-///
-/// [`values`]: struct.ProofMapIndex.html#method.values
-/// [`values_from`]: struct.ProofMapIndex.html#method.values_from
-/// [`ProofMapIndex`]: struct.ProofMapIndex.html
-#[derive(Debug)]
-pub struct Values<'a, V> {
-    base_iter: ViewIter<'a, Vec<u8>, V>,
-}
-
 /// TODO Clarify documentation. [ECR-2820]
 enum RemoveAction {
     KeyNotFound,
@@ -136,11 +96,9 @@ enum RemoveAction {
 ///
 /// Represents the original key bytes with the `VALUE_KEY_PREFIX` prefix.
 /// TODO Clarify documentation. [ECR-2820]
-trait ValuePath: ToOwned {
+trait ValuePath {
     /// Converts the given key to the value path bytes.
     fn to_value_path(&self) -> Vec<u8>;
-    /// Extracts the given key from the value path bytes.
-    fn from_value_path(bytes: &[u8]) -> Self::Owned;
 }
 
 impl<T: BinaryKey + ?Sized> ValuePath for T {
@@ -149,10 +107,6 @@ impl<T: BinaryKey + ?Sized> ValuePath for T {
         buf[0] = VALUE_KEY_PREFIX;
         self.write(&mut buf[1..]);
         buf
-    }
-
-    fn from_value_path(buffer: &[u8]) -> Self::Owned {
-        Self::read(&buffer[1..])
     }
 }
 
@@ -347,11 +301,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, K, V> {
-        Iter {
-            base_iter: self.base.iter(&VALUE_KEY_PREFIX),
-            _k: PhantomData,
-        }
+    pub fn iter(&self) -> Entries<'_, K, V> {
+        Entries::with_detached_prefix(&self.base, &VALUE_KEY_PREFIX, None)
     }
 
     /// Returns an iterator over the keys of the map in ascending order. The iterator element
@@ -372,10 +323,7 @@ where
     /// }
     /// ```
     pub fn keys(&self) -> Keys<'_, K> {
-        Keys {
-            base_iter: self.base.iter(&VALUE_KEY_PREFIX),
-            _k: PhantomData,
-        }
+        self.iter().skip_values()
     }
 
     /// Returns an iterator over the values of the map in ascending order of keys. The iterator
@@ -396,9 +344,7 @@ where
     /// }
     /// ```
     pub fn values(&self) -> Values<'_, V> {
-        Values {
-            base_iter: self.base.iter(&VALUE_KEY_PREFIX),
-        }
+        self.iter().skip_keys()
     }
 
     /// Returns an iterator over the entries of the map in ascending order starting from the
@@ -419,13 +365,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn iter_from(&self, from: &K) -> Iter<'_, K, V> {
-        Iter {
-            base_iter: self
-                .base
-                .iter_from(&VALUE_KEY_PREFIX, &from.to_value_path()),
-            _k: PhantomData,
-        }
+    pub fn iter_from(&self, from: &K) -> Entries<'_, K, V> {
+        Entries::with_detached_prefix(&self.base, &VALUE_KEY_PREFIX, Some(from))
     }
 
     /// Returns an iterator over the keys of the map in ascending order starting from the
@@ -447,12 +388,7 @@ where
     /// }
     /// ```
     pub fn keys_from(&self, from: &K) -> Keys<'_, K> {
-        Keys {
-            base_iter: self
-                .base
-                .iter_from(&VALUE_KEY_PREFIX, &from.to_value_path()),
-            _k: PhantomData,
-        }
+        self.iter_from(from).skip_values()
     }
 
     /// Returns an iterator over the values of the map in ascending order of keys starting from the
@@ -474,11 +410,7 @@ where
     /// }
     /// ```
     pub fn values_from(&self, from: &K) -> Values<'_, V> {
-        Values {
-            base_iter: self
-                .base
-                .iter_from(&VALUE_KEY_PREFIX, &from.to_value_path()),
-        }
+        self.iter_from(from).skip_keys()
     }
 }
 
@@ -883,46 +815,10 @@ where
     KeyMode: ToProofPath<K>,
 {
     type Item = (K::Owned, V);
-    type IntoIter = Iter<'a, K, V>;
+    type IntoIter = Entries<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, K, V> Iterator for Iter<'a, K, V>
-where
-    K: BinaryKey + ?Sized,
-    V: BinaryValue,
-{
-    type Item = (K::Owned, V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter
-            .next()
-            .map(|(k, v)| (K::from_value_path(&k), v))
-    }
-}
-
-impl<'a, K> Iterator for Keys<'a, K>
-where
-    K: BinaryKey + ?Sized,
-{
-    type Item = K::Owned;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(k, _)| K::from_value_path(&k))
-    }
-}
-
-impl<'a, V> Iterator for Values<'a, V>
-where
-    V: BinaryValue,
-{
-    type Item = V;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(_, v)| v)
     }
 }
 

--- a/components/merkledb/src/indexes/proof_map/mod.rs
+++ b/components/merkledb/src/indexes/proof_map/mod.rs
@@ -284,8 +284,7 @@ where
         self.create_multiproof(keys)
     }
 
-    /// Returns an iterator over the entries of the map in ascending order. The iterator element
-    /// type is `(K::Output, V)`.
+    /// Returns an iterator over the entries of the map in ascending order.
     ///
     /// # Examples
     ///
@@ -305,8 +304,7 @@ where
         self.index_iter(None)
     }
 
-    /// Returns an iterator over the keys of the map in ascending order. The iterator element
-    /// type is `K::Output`.
+    /// Returns an iterator over the keys of the map in ascending order.
     ///
     /// # Examples
     ///
@@ -326,8 +324,7 @@ where
         self.iter().skip_values()
     }
 
-    /// Returns an iterator over the values of the map in ascending order of keys. The iterator
-    /// element type is `V`.
+    /// Returns an iterator over the values of the map in ascending order of keys.
     ///
     /// # Examples
     ///
@@ -348,7 +345,7 @@ where
     }
 
     /// Returns an iterator over the entries of the map in ascending order starting from the
-    /// specified key. The iterator element type is `(K::Output, V)`.
+    /// specified key.
     ///
     /// # Examples
     ///
@@ -370,7 +367,7 @@ where
     }
 
     /// Returns an iterator over the keys of the map in ascending order starting from the
-    /// specified key. The iterator element type is `K::Output`.
+    /// specified key.
     ///
     /// # Examples
     ///
@@ -392,7 +389,7 @@ where
     }
 
     /// Returns an iterator over the values of the map in ascending order of keys starting from the
-    /// specified key. The iterator element type is `V`.
+    /// specified key.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/proof_map/tests.rs
+++ b/components/merkledb/src/indexes/proof_map/tests.rs
@@ -935,64 +935,52 @@ where
         map_index.put(&k3, 3_u8);
 
         assert_eq!(
-            map_index.iter().collect::<Vec<([u8; 32], u8)>>(),
+            map_index.iter().collect::<Vec<_>>(),
             vec![(k1, 1), (k2, 2), (k3, 3)]
         );
 
         assert_eq!(
-            map_index.iter_from(&k0).collect::<Vec<([u8; 32], u8)>>(),
+            map_index.iter_from(&k0).collect::<Vec<_>>(),
             vec![(k1, 1), (k2, 2), (k3, 3)]
         );
         assert_eq!(
-            map_index.iter_from(&k1).collect::<Vec<([u8; 32], u8)>>(),
+            map_index.iter_from(&k1).collect::<Vec<_>>(),
             vec![(k1, 1), (k2, 2), (k3, 3)]
         );
         assert_eq!(
-            map_index.iter_from(&k2).collect::<Vec<([u8; 32], u8)>>(),
+            map_index.iter_from(&k2).collect::<Vec<_>>(),
             vec![(k2, 2), (k3, 3)]
         );
-        assert_eq!(
-            map_index.iter_from(&k4).collect::<Vec<([u8; 32], u8)>>(),
-            Vec::<([u8; 32], u8)>::new()
-        );
+        assert_eq!(map_index.iter_from(&k4).count(), 0);
+
+        assert_eq!(map_index.keys().collect::<Vec<_>>(), vec![k1, k2, k3]);
 
         assert_eq!(
-            map_index.keys().collect::<Vec<[u8; 32]>>(),
-            vec![k1, k2, k3]
-        );
-
-        assert_eq!(
-            map_index.keys_from(&k0).collect::<Vec<[u8; 32]>>(),
+            map_index.keys_from(&k0).collect::<Vec<_>>(),
             vec![k1, k2, k3]
         );
         assert_eq!(
-            map_index.keys_from(&k1).collect::<Vec<[u8; 32]>>(),
+            map_index.keys_from(&k1).collect::<Vec<_>>(),
             vec![k1, k2, k3]
         );
+        assert_eq!(map_index.keys_from(&k2).collect::<Vec<_>>(), vec![k2, k3]);
         assert_eq!(
-            map_index.keys_from(&k2).collect::<Vec<[u8; 32]>>(),
-            vec![k2, k3]
-        );
-        assert_eq!(
-            map_index.keys_from(&k4).collect::<Vec<[u8; 32]>>(),
+            map_index.keys_from(&k4).collect::<Vec<_>>(),
             Vec::<[u8; 32]>::new()
         );
 
-        assert_eq!(map_index.values().collect::<Vec<u8>>(), vec![1, 2, 3]);
+        assert_eq!(map_index.values().collect::<Vec<_>>(), vec![1, 2, 3]);
 
         assert_eq!(
-            map_index.values_from(&k0).collect::<Vec<u8>>(),
+            map_index.values_from(&k0).collect::<Vec<_>>(),
             vec![1, 2, 3]
         );
         assert_eq!(
             map_index.values_from(&k1).collect::<Vec<u8>>(),
             vec![1, 2, 3]
         );
-        assert_eq!(map_index.values_from(&k2).collect::<Vec<u8>>(), vec![2, 3]);
-        assert_eq!(
-            map_index.values_from(&k4).collect::<Vec<u8>>(),
-            Vec::<u8>::new()
-        );
+        assert_eq!(map_index.values_from(&k2).collect::<Vec<_>>(), vec![2, 3]);
+        assert_eq!(map_index.values_from(&k4).count(), 0);
     }
 }
 

--- a/components/merkledb/src/indexes/sparse_list.rs
+++ b/components/merkledb/src/indexes/sparse_list.rs
@@ -204,7 +204,7 @@ where
         self.size().length
     }
 
-    /// Returns an iterator over the list. The iterator element type is (u64, V).
+    /// Returns an iterator over the list elements with corresponding indexes.
     ///
     /// # Examples
     ///
@@ -246,8 +246,7 @@ where
         self.iter().skip_values()
     }
 
-    /// Returns an iterator over the values of the `SparseListIndex`. The iterator element type is
-    /// `V`.
+    /// Returns an iterator over list elements.
     ///
     /// # Examples
     ///
@@ -268,8 +267,8 @@ where
         self.iter().skip_keys()
     }
 
-    /// Returns an iterator over the list starting from the specified position. The iterator
-    /// element type is `(u64, V)`.
+    /// Returns an iterator over the list elements starting from the specified position. Elements
+    /// are yielded with the corresponding index.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/sparse_list.rs
+++ b/components/merkledb/src/indexes/sparse_list.rs
@@ -23,7 +23,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    indexes::iter::{Entries, Keys, Values},
+    indexes::iter::{Entries, IndexIterator, Keys, Values},
     views::{
         BinaryAttribute, IndexAddress, IndexState, IndexType, RawAccess, RawAccessMut, View,
         ViewWithMetadata,
@@ -222,7 +222,7 @@ where
     /// }
     /// ```
     pub fn iter(&self) -> Entries<'_, u64, V> {
-        Entries::new(&self.base, None)
+        self.index_iter(None)
     }
 
     /// Returns an iterator over the indexes of the `SparseListIndex`.
@@ -288,7 +288,7 @@ where
     /// }
     /// ```
     pub fn iter_from(&self, from: u64) -> Entries<'_, u64, V> {
-        Entries::new(&self.base, Some(&from))
+        self.index_iter(Some(&from))
     }
 }
 
@@ -494,6 +494,19 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T, V> IndexIterator for SparseListIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue,
+{
+    type Key = u64;
+    type Value = V;
+
+    fn index_iter(&self, from: Option<&u64>) -> Entries<'_, u64, V> {
+        Entries::new(&self.base, from)
     }
 }
 

--- a/components/merkledb/src/indexes/sparse_list.rs
+++ b/components/merkledb/src/indexes/sparse_list.rs
@@ -57,9 +57,9 @@ impl BinaryAttribute for SparseListSize {
     }
 }
 
-/// A list of items similar to the [`ListIndex`], however, it may contain "spaces". For instance,
-/// a list might contain six elements with indexes: "1, 2, 3, 5, 7, 8" (missing 4 and 6). And if you
-/// try to get the element for index 4 or 6, you'll get `None`.
+/// A list of items similar to `ListIndex`; however, it may contain "spaces". For instance,
+/// a list might contain six elements with indexes: `1, 2, 3, 5, 7, 8` (missing 4 and 6). And if you
+/// try to get the element for index 4 or 6, you will get `None`.
 ///
 /// Later, elements can be added to the
 /// spaces, if required. Elements in this list are added to the end of the list and are
@@ -73,8 +73,7 @@ impl BinaryAttribute for SparseListSize {
 /// as an index.
 /// `SparseListIndex` requires that elements should implement the [`BinaryValue`] trait.
 ///
-/// [`BinaryValue`]: ../../trait.BinaryValue.html
-/// [`ListIndex`]: ../../indexes/list/struct.ListIndex.html
+/// [`BinaryValue`]: ../trait.BinaryValue.html
 #[derive(Debug)]
 pub struct SparseListIndex<T: RawAccess, V> {
     base: View<T>,

--- a/components/merkledb/src/indexes/sparse_list.rs
+++ b/components/merkledb/src/indexes/sparse_list.rs
@@ -23,9 +23,10 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
     access::{Access, AccessError, FromAccess},
+    indexes::iter::{Entries, Keys, Values},
     views::{
-        BinaryAttribute, IndexAddress, IndexState, IndexType, Iter as ViewIter, RawAccess,
-        RawAccessMut, View, ViewWithMetadata,
+        BinaryAttribute, IndexAddress, IndexState, IndexType, RawAccess, RawAccessMut, View,
+        ViewWithMetadata,
     },
     BinaryValue,
 };
@@ -79,42 +80,6 @@ pub struct SparseListIndex<T: RawAccess, V> {
     base: View<T>,
     state: IndexState<T, SparseListSize>,
     _v: PhantomData<V>,
-}
-
-/// Returns an iterator over the items of a `SparseListIndex`.
-///
-/// This struct is created by the [`iter`] method on [`SparseListIndex`].
-/// See its documentation for details.
-///
-/// [`iter`]: struct.SparseListIndex.html#method.iter
-/// [`SparseListIndex`]: struct.SparseListIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, V> {
-    base_iter: ViewIter<'a, u64, V>,
-}
-
-/// Returns an iterator over the indexes of a `SparseListIndex`.
-///
-/// This struct is created by the [`indexes`] method on [`SparseListIndex`].
-/// See its documentation for more.
-///
-/// [`indexes`]: struct.SparseListIndex.html#method.indexes
-/// [`SparseListIndex`]: struct.SparseListIndex.html
-#[derive(Debug)]
-pub struct Keys<'a> {
-    base_iter: ViewIter<'a, u64, ()>,
-}
-
-/// Returns an iterator over the values of a `SparseListIndex`.
-///
-/// This struct is created by the [`values`] method on [`SparseListIndex`].
-/// See its documentation for details.
-///
-/// [`values`]: struct.SparseListIndex.html#method.values
-/// [`SparseListIndex`]: struct.SparseListIndex.html
-#[derive(Debug)]
-pub struct Values<'a, V> {
-    base_iter: ViewIter<'a, (), V>,
 }
 
 impl<T, V> FromAccess<T> for SparseListIndex<T::Base, V>
@@ -256,10 +221,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&(), &0_u64),
-        }
+    pub fn iter(&self) -> Entries<'_, u64, V> {
+        Entries::new(&self.base, None)
     }
 
     /// Returns an iterator over the indexes of the `SparseListIndex`.
@@ -279,14 +242,12 @@ where
     ///     println!("{}", val);
     /// }
     /// ```
-    pub fn indexes(&self) -> Keys<'_> {
-        Keys {
-            base_iter: self.base.iter_from(&(), &0_u64),
-        }
+    pub fn indexes(&self) -> Keys<'_, u64> {
+        self.iter().skip_values()
     }
 
     /// Returns an iterator over the values of the `SparseListIndex`. The iterator element type is
-    /// V.
+    /// `V`.
     ///
     /// # Examples
     ///
@@ -304,13 +265,11 @@ where
     /// }
     /// ```
     pub fn values(&self) -> Values<'_, V> {
-        Values {
-            base_iter: self.base.iter_from(&(), &0_u64),
-        }
+        self.iter().skip_keys()
     }
 
     /// Returns an iterator over the list starting from the specified position. The iterator
-    /// element type is (u64, V).
+    /// element type is `(u64, V)`.
     ///
     /// # Examples
     ///
@@ -328,10 +287,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn iter_from(&self, from: u64) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&(), &from),
-        }
+    pub fn iter_from(&self, from: u64) -> Entries<'_, u64, V> {
+        Entries::new(&self.base, Some(&from))
     }
 }
 
@@ -527,46 +484,16 @@ where
     }
 }
 
-impl<'a, T, V> std::iter::IntoIterator for &'a SparseListIndex<T, V>
+impl<'a, T, V> IntoIterator for &'a SparseListIndex<T, V>
 where
     T: RawAccess,
     V: BinaryValue,
 {
     type Item = (u64, V);
-    type IntoIter = Iter<'a, V>;
+    type IntoIter = Entries<'a, u64, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, V> Iterator for Iter<'a, V>
-where
-    V: BinaryValue,
-{
-    type Item = (u64, V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next()
-    }
-}
-
-impl<'a> Iterator for Keys<'a> {
-    type Item = u64;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(k, ..)| k)
-    }
-}
-
-impl<'a, V> Iterator for Values<'a, V>
-where
-    V: BinaryValue,
-{
-    type Item = V;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(.., v)| v)
     }
 }
 
@@ -667,28 +594,22 @@ mod tests {
         list_index.remove(2);
 
         assert_eq!(
-            list_index.iter().collect::<Vec<(u64, u8)>>(),
+            list_index.iter().collect::<Vec<_>>(),
             vec![(0_u64, 1_u8), (3_u64, 2_u8), (4_u64, 3_u8)]
         );
 
         assert_eq!(
-            list_index.iter_from(0).collect::<Vec<(u64, u8)>>(),
+            list_index.iter_from(0).collect::<Vec<_>>(),
             vec![(0_u64, 1_u8), (3_u64, 2_u8), (4_u64, 3_u8)]
         );
         assert_eq!(
-            list_index.iter_from(1).collect::<Vec<(u64, u8)>>(),
+            list_index.iter_from(1).collect::<Vec<_>>(),
             vec![(3_u64, 2_u8), (4_u64, 3_u8)]
         );
-        assert_eq!(
-            list_index.iter_from(5).collect::<Vec<(u64, u8)>>(),
-            Vec::<(u64, u8)>::new()
-        );
+        assert_eq!(list_index.iter_from(5).count(), 0);
 
-        assert_eq!(
-            list_index.indexes().collect::<Vec<u64>>(),
-            vec![0_u64, 3, 4]
-        );
-        assert_eq!(list_index.values().collect::<Vec<u8>>(), vec![1_u8, 2, 3]);
+        assert_eq!(list_index.indexes().collect::<Vec<_>>(), vec![0_u64, 3, 4]);
+        assert_eq!(list_index.values().collect::<Vec<_>>(), vec![1_u8, 2, 3]);
     }
 
     #[test]

--- a/components/merkledb/src/indexes/value_set.rs
+++ b/components/merkledb/src/indexes/value_set.rs
@@ -108,7 +108,7 @@ where
     }
 
     /// Returns an iterator over set elements and their hashes. The elements are ordered as per
-    /// lexicorgraphic ordering of their hashes (i.e., effectively randomly).
+    /// lexicographic ordering of their hashes (i.e., effectively randomly).
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/value_set.rs
+++ b/components/merkledb/src/indexes/value_set.rs
@@ -34,7 +34,7 @@ use crate::{
 /// `ValueSetIndex` implements a set, storing an element as a value and using its hash as a key.
 /// `ValueSetIndex` requires that elements should implement the [`BinaryValue`] trait.
 ///
-/// [`BinaryValue`]: ../../trait.BinaryValue.html
+/// [`BinaryValue`]: ../trait.BinaryValue.html
 #[derive(Debug)]
 pub struct ValueSetIndex<T: RawAccess, V> {
     base: View<T>,

--- a/components/merkledb/src/indexes/value_set.rs
+++ b/components/merkledb/src/indexes/value_set.rs
@@ -24,7 +24,7 @@ use exonum_crypto::Hash;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    indexes::iter::{Entries, Keys},
+    indexes::iter::{Entries, IndexIterator, Keys},
     views::{IndexAddress, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryValue, ObjectHash,
 };
@@ -124,7 +124,7 @@ where
     /// }
     /// ```
     pub fn iter(&self) -> Entries<'_, Hash, V> {
-        Entries::new(&self.base, None)
+        self.index_iter(None)
     }
 
     /// Returns an iterator visiting hashes of all elements in ascending order. The iterator element type
@@ -167,7 +167,7 @@ where
     /// }
     /// ```
     pub fn iter_from(&self, from: &Hash) -> Entries<'_, Hash, V> {
-        Entries::new(&self.base, Some(from))
+        self.index_iter(Some(from))
     }
 
     /// Returns an iterator visiting hashes of all elements in ascending order starting from the specified
@@ -299,6 +299,19 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T, V> IndexIterator for ValueSetIndex<T, V>
+where
+    T: RawAccess,
+    V: BinaryValue + ObjectHash,
+{
+    type Key = Hash;
+    type Value = V;
+
+    fn index_iter(&self, from: Option<&Hash>) -> Entries<'_, Hash, V> {
+        Entries::new(&self.base, from)
     }
 }
 

--- a/components/merkledb/src/indexes/value_set.rs
+++ b/components/merkledb/src/indexes/value_set.rs
@@ -107,8 +107,8 @@ where
         self.base.contains(hash)
     }
 
-    /// Returns an iterator visiting all elements in arbitrary order. The iterator element type
-    /// is `(Hash, V)`.
+    /// Returns an iterator over set elements and their hashes. The elements are ordered as per
+    /// lexicorgraphic ordering of their hashes (i.e., effectively randomly).
     ///
     /// # Examples
     ///
@@ -127,8 +127,7 @@ where
         self.index_iter(None)
     }
 
-    /// Returns an iterator visiting hashes of all elements in ascending order. The iterator element type
-    /// is [Hash](../../../exonum_crypto/struct.Hash.html).
+    /// Returns an iterator over hashes of set elements in ascending order.
     ///
     /// # Examples
     ///
@@ -148,7 +147,7 @@ where
     }
 
     /// Returns an iterator visiting all elements in arbitrary order starting from the specified hash of
-    /// a value. The iterator element type is `(Hash, V)`.
+    /// a value. Elements are yielded together with their hashes.
     ///
     /// # Examples
     ///
@@ -171,7 +170,7 @@ where
     }
 
     /// Returns an iterator visiting hashes of all elements in ascending order starting from the specified
-    /// hash. The iterator element type is [Hash](../../../exonum_crypto/struct.Hash.html).
+    /// hash.
     ///
     /// # Examples
     ///

--- a/components/merkledb/src/indexes/value_set.rs
+++ b/components/merkledb/src/indexes/value_set.rs
@@ -24,9 +24,8 @@ use exonum_crypto::Hash;
 
 use crate::{
     access::{Access, AccessError, FromAccess},
-    views::{
-        IndexAddress, IndexType, Iter as ViewIter, RawAccess, RawAccessMut, View, ViewWithMetadata,
-    },
+    indexes::iter::{Entries, Keys},
+    views::{IndexAddress, IndexType, RawAccess, RawAccessMut, View, ViewWithMetadata},
     BinaryValue, ObjectHash,
 };
 
@@ -40,32 +39,6 @@ use crate::{
 pub struct ValueSetIndex<T: RawAccess, V> {
     base: View<T>,
     _v: PhantomData<V>,
-}
-
-/// Returns an iterator over the items of a `ValueSetIndex`.
-///
-/// This struct is created by the [`iter`] or
-/// [`iter_from`] method on [`ValueSetIndex`]. See its documentation for details.
-///
-/// [`iter`]: struct.ValueSetIndex.html#method.iter
-/// [`iter_from`]: struct.ValueSetIndex.html#method.iter_from
-/// [`ValueSetIndex`]: struct.ValueSetIndex.html
-#[derive(Debug)]
-pub struct Iter<'a, V> {
-    base_iter: ViewIter<'a, Hash, V>,
-}
-
-/// Returns an iterator over the hashes of items of a `ValueSetIndex`.
-///
-/// This struct is created by the [`hashes`] or
-/// [`hashes_from`] method on [`ValueSetIndex`]. See its documentation for details.
-///
-/// [`hashes`]: struct.ValueSetIndex.html#method.iter
-/// [`hashes_from`]: struct.ValueSetIndex.html#method.iter_from
-/// [`ValueSetIndex`]: struct.ValueSetIndex.html
-#[derive(Debug)]
-pub struct Hashes<'a> {
-    base_iter: ViewIter<'a, Hash, ()>,
 }
 
 impl<T, V> FromAccess<T> for ValueSetIndex<T::Base, V>
@@ -134,7 +107,8 @@ where
         self.base.contains(hash)
     }
 
-    /// Returns an iterator visiting all elements in arbitrary order. The iterator element type is V.
+    /// Returns an iterator visiting all elements in arbitrary order. The iterator element type
+    /// is `(Hash, V)`.
     ///
     /// # Examples
     ///
@@ -149,35 +123,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter(&()),
-        }
-    }
-
-    /// Returns an iterator visiting all elements in arbitrary order starting from the specified hash of
-    /// a value. The iterator element type is V.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exonum_merkledb::{access::CopyAccessExt, TemporaryDB, Database, ValueSetIndex};
-    /// use exonum_crypto::Hash;
-    ///
-    /// let db = TemporaryDB::new();
-    /// let fork = db.fork();
-    /// let index: ValueSetIndex<_, u8> = fork.get_value_set("name");
-    ///
-    /// let hash = Hash::default();
-    ///
-    /// for val in index.iter_from(&hash) {
-    ///     println!("{:?}", val);
-    /// }
-    /// ```
-    pub fn iter_from(&self, from: &Hash) -> Iter<'_, V> {
-        Iter {
-            base_iter: self.base.iter_from(&(), from),
-        }
+    pub fn iter(&self) -> Entries<'_, Hash, V> {
+        Entries::new(&self.base, None)
     }
 
     /// Returns an iterator visiting hashes of all elements in ascending order. The iterator element type
@@ -196,10 +143,31 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn hashes(&self) -> Hashes<'_> {
-        Hashes {
-            base_iter: self.base.iter(&()),
-        }
+    pub fn hashes(&self) -> Keys<'_, Hash> {
+        self.iter().skip_values()
+    }
+
+    /// Returns an iterator visiting all elements in arbitrary order starting from the specified hash of
+    /// a value. The iterator element type is `(Hash, V)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exonum_merkledb::{access::CopyAccessExt, TemporaryDB, Database, ValueSetIndex};
+    /// use exonum_crypto::Hash;
+    ///
+    /// let db = TemporaryDB::new();
+    /// let fork = db.fork();
+    /// let index: ValueSetIndex<_, u8> = fork.get_value_set("name");
+    ///
+    /// let hash = Hash::default();
+    ///
+    /// for val in index.iter_from(&hash) {
+    ///     println!("{:?}", val);
+    /// }
+    /// ```
+    pub fn iter_from(&self, from: &Hash) -> Entries<'_, Hash, V> {
+        Entries::new(&self.base, Some(from))
     }
 
     /// Returns an iterator visiting hashes of all elements in ascending order starting from the specified
@@ -221,10 +189,8 @@ where
     ///     println!("{:?}", val);
     /// }
     /// ```
-    pub fn hashes_from(&self, from: &Hash) -> Hashes<'_> {
-        Hashes {
-            base_iter: self.base.iter_from(&(), from),
-        }
+    pub fn hashes_from(&self, from: &Hash) -> Keys<'_, Hash> {
+        self.iter_from(from).skip_values()
     }
 }
 
@@ -323,40 +289,23 @@ where
     }
 }
 
-impl<'a, T, V> std::iter::IntoIterator for &'a ValueSetIndex<T, V>
+impl<'a, T, V> IntoIterator for &'a ValueSetIndex<T, V>
 where
     T: RawAccess,
     V: BinaryValue + ObjectHash,
 {
     type Item = (Hash, V);
-    type IntoIter = Iter<'a, V>;
+    type IntoIter = Entries<'a, Hash, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<'a, V> Iterator for Iter<'a, V>
-where
-    V: BinaryValue + ObjectHash,
-{
-    type Item = (Hash, V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next()
-    }
-}
-
-impl<'a> Iterator for Hashes<'a> {
-    type Item = Hash;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.base_iter.next().map(|(k, ..)| k)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use crate::{access::CopyAccessExt, Database, ObjectHash, TemporaryDB};
 
     #[test]
@@ -379,5 +328,29 @@ mod tests {
 
         index.clear();
         assert!(!index.contains(&2_u8));
+    }
+
+    #[test]
+    fn value_set_iter() {
+        let db = TemporaryDB::default();
+        let fork = db.fork();
+        let mut index = fork.get_value_set("index");
+        let mut sorted_map = BTreeMap::new();
+
+        for i in 0_u32..10 {
+            index.insert(i);
+            sorted_map.insert(i.object_hash(), i);
+        }
+
+        assert_eq!(index.iter().collect::<BTreeMap<_, _>>(), sorted_map);
+        for i in 0_u32..10 {
+            let start = i.object_hash();
+            let actual: BTreeMap<_, _> = index.iter_from(&start).collect();
+            let expected = sorted_map
+                .range(start..)
+                .map(|(hash, value)| (*hash, *value))
+                .collect::<BTreeMap<_, _>>();
+            assert_eq!(actual, expected);
+        }
     }
 }

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -118,15 +118,15 @@
 //! [`merge`]: trait.Database.html#tymethod.merge
 //! [`BinaryKey`]: trait.BinaryKey.html
 //! [`BinaryValue`]: trait.BinaryValue.html
-//! [`Entry`]: indexes/entry/struct.Entry.html
-//! [`ProofEntry`]: indexes/proof_entry/struct.ProofEntry.html
-//! [`ListIndex`]: indexes/list/struct.ListIndex.html
-//! [`SparseListIndex`]: indexes/sparse_list/struct.SparseListIndex.html
-//! [`MapIndex`]: indexes/map/struct.MapIndex.html
+//! [`Entry`]: indexes/struct.Entry.html
+//! [`ProofEntry`]: indexes/struct.ProofEntry.html
+//! [`ListIndex`]: indexes/struct.ListIndex.html
+//! [`SparseListIndex`]: indexes/struct.SparseListIndex.html
+//! [`MapIndex`]: indexes/struct.MapIndex.html
 //! [`ProofListIndex`]: indexes/proof_list/struct.ProofListIndex.html
 //! [`ProofMapIndex`]: indexes/proof_map/struct.ProofMapIndex.html
-//! [`KeySetIndex`]: indexes/key_set/struct.KeySetIndex.html
-//! [`ValueSetIndex`]: indexes/value_set/struct.ValueSetIndex.html
+//! [`KeySetIndex`]: indexes/struct.KeySetIndex.html
+//! [`ValueSetIndex`]: indexes/struct.ValueSetIndex.html
 //! [`ObjectHash`]: trait.ObjectHash.html
 //! [doc:storage]: https://exonum.com/doc/architecture/storage
 //! [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
@@ -187,14 +187,9 @@ pub use self::{
 // does not exist!'
 #[doc(no_inline)]
 pub use self::indexes::{
-    key_set::{self, KeySetIndex},
-    list::{self, ListIndex},
-    map::{self, MapIndex},
     proof_list::{self, ListProof, ProofListIndex},
     proof_map::{self, MapProof, ProofMapIndex, RawProofMapIndex},
-    sparse_list::{self, SparseListIndex},
-    value_set::{self, ValueSetIndex},
-    Entry, Group, ProofEntry,
+    Entry, Group, KeySetIndex, ListIndex, MapIndex, ProofEntry, SparseListIndex, ValueSetIndex,
 };
 
 #[macro_use]
@@ -215,6 +210,7 @@ mod values;
 mod views;
 
 #[cfg(feature = "with-protobuf")]
+#[doc(hidden)]
 pub mod proto;
 
 #[cfg(feature = "with-protobuf")]

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -737,7 +737,7 @@ mod tests {
         let migration = Migration::new("name", &fork);
         migration.get_proof_list("list").extend(vec![4_u64, 5]);
         migration.get_map("map").put(&1_u64, 42_i32);
-        migration.get_key_set("new").insert(0_u8);
+        migration.get_key_set("new").insert(&0_u8);
         migration.create_tombstone("removed");
 
         fork.flush_migration("name");
@@ -800,7 +800,7 @@ mod tests {
         let migration = Migration::new("name", &fork);
         migration.get_proof_list("list").extend(vec![4_u64, 5]);
         migration.get_map("map").put(&1_u64, 42_i32);
-        migration.get_key_set("new").insert(0_u8);
+        migration.get_key_set("new").insert(&0_u8);
         migration.create_tombstone(("name.family", &3_u8));
         // ^-- Removing non-existing indexes is weird, but should work fine.
         db.merge(fork.into_patch()).unwrap();

--- a/components/merkledb/src/migration.rs
+++ b/components/merkledb/src/migration.rs
@@ -119,7 +119,7 @@
 //! # }
 //! ```
 
-pub use self::persistent_iter::{ContinueIterator, PersistentIter, PersistentIters};
+pub use self::persistent_iter::{PersistentIter, PersistentIters, PersistentKeys};
 
 use exonum_crypto::Hash;
 use failure::Fail;

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -74,7 +74,7 @@ where
     V: BinaryValue,
 {
     type Key = u64;
-    type Iter = Zip<RangeFrom<u64>, indexes::proof_list::Iter<'a, V>>;
+    type Iter = Zip<RangeFrom<u64>, indexes::iter::Values<'a, V>>;
 
     fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
         if let Some(&from) = from {
@@ -140,7 +140,7 @@ where
     KeyMode: ToProofPath<K>,
 {
     type Key = K;
-    type Iter = indexes::proof_map::Iter<'a, K, V>;
+    type Iter = indexes::iter::Entries<'a, K, V>;
 
     fn continue_iter(self, from: Option<&K>) -> Self::Iter {
         if let Some(from) = from {

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -25,7 +25,7 @@ use std::{
 
 use crate::{
     access::{Access, AccessExt, RawAccess, RawAccessMut},
-    indexes::iter::{Entries, IndexIterator},
+    indexes::{Entries, IndexIterator},
     BinaryKey, BinaryValue, Entry,
 };
 

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -53,7 +53,7 @@ where
     V: BinaryValue,
 {
     type Key = u64;
-    type Iter = Zip<RangeFrom<u64>, indexes::list::Iter<'a, V>>;
+    type Iter = Zip<RangeFrom<u64>, indexes::iter::Values<'a, V>>;
 
     fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
         if let Some(&from) = from {
@@ -95,7 +95,7 @@ where
     V: BinaryValue,
 {
     type Key = u64;
-    type Iter = indexes::sparse_list::Iter<'a, V>;
+    type Iter = indexes::iter::Entries<'a, u64, V>;
 
     fn continue_iter(self, from: Option<&u64>) -> Self::Iter {
         if let Some(&from) = from {
@@ -117,7 +117,7 @@ where
     V: BinaryValue,
 {
     type Key = K;
-    type Iter = indexes::map::Iter<'a, K, V>;
+    type Iter = indexes::iter::Entries<'a, K, V>;
 
     fn continue_iter(self, from: Option<&K>) -> Self::Iter {
         if let Some(from) = from {
@@ -161,7 +161,7 @@ where
     K: BinaryKey,
 {
     type Key = K;
-    type Iter = indexes::key_set::Iter<'a, K>;
+    type Iter = indexes::iter::Keys<'a, K>;
 
     fn continue_iter(self, from: Option<&K>) -> Self::Iter {
         if let Some(from) = from {
@@ -182,7 +182,7 @@ where
     V: BinaryValue + ObjectHash,
 {
     type Key = Hash;
-    type Iter = indexes::value_set::Iter<'a, V>;
+    type Iter = indexes::iter::Entries<'a, Hash, V>;
 
     fn continue_iter(self, from: Option<&Hash>) -> Self::Iter {
         if let Some(from) = from {
@@ -622,7 +622,7 @@ mod tests {
         let db = TemporaryDB::new();
         let fork = db.fork();
         let mut set = fork.get_key_set("set");
-        for &i in &[0_u16, 1, 2, 3, 5, 8, 13, 21] {
+        for i in &[0_u16, 1, 2, 3, 5, 8, 13, 21] {
             set.insert(i);
         }
 

--- a/components/merkledb/src/migration/persistent_iter.rs
+++ b/components/merkledb/src/migration/persistent_iter.rs
@@ -214,8 +214,8 @@ where
         }
     }
 
-    /// FIXME
-    pub fn drop_values(self) -> PersistentKeys<'a, T, I> {
+    /// Skips values in the iterator output without parsing them.
+    pub fn skip_values(self) -> PersistentKeys<'a, T, I> {
         PersistentKeys { base_iter: self }
     }
 }
@@ -252,7 +252,12 @@ where
     }
 }
 
-/// FIXME
+/// Persistent iterator over index keys that stores its position in the database.
+///
+/// This iterator can be used similarly to [`PersistentIter`]; the only difference is the
+/// type of items yielded by the iterator.
+///
+/// [`PersistentIter`]: struct.PersistentIter.html
 pub struct PersistentKeys<'a, T: RawAccess, I: IndexIterator> {
     base_iter: PersistentIter<'a, T, I>,
 }
@@ -267,7 +272,7 @@ where
     where
         A: Access<Base = T>,
     {
-        PersistentIter::new(access, name, index).drop_values()
+        PersistentIter::new(access, name, index).skip_values()
     }
 }
 

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -302,6 +302,7 @@ impl<T: RawAccess> View<T> {
         Iter {
             base_iter: self.iter_bytes(&iter_prefix),
             prefix: iter_prefix,
+            detach_prefix: false,
             ended: false,
             _k: PhantomData,
             _v: PhantomData,
@@ -323,6 +324,32 @@ impl<T: RawAccess> View<T> {
         Iter {
             base_iter: self.iter_bytes(&iter_from),
             prefix: iter_prefix,
+            detach_prefix: false,
+            ended: false,
+            _k: PhantomData,
+            _v: PhantomData,
+        }
+    }
+
+    /// Returns an iterator over the entries of the index in ascending order, optionally
+    /// starting from the specified key. Unlike `iter_from`, the provided prefix will be detached
+    /// from the beginning of each key slice.
+    pub fn iter_detached<P, K, V>(&self, detached_prefix: &P, from: Option<&K>) -> Iter<'_, K, V>
+    where
+        P: BinaryKey,
+        K: BinaryKey + ?Sized,
+        V: BinaryValue,
+    {
+        let iter_prefix = key_bytes(detached_prefix);
+        let iter_from = if let Some(from) = from {
+            Cow::Owned(concat_keys!(detached_prefix, from))
+        } else {
+            Cow::Borrowed(&*iter_prefix)
+        };
+        Iter {
+            base_iter: self.iter_bytes(&iter_from),
+            prefix: iter_prefix,
+            detach_prefix: true,
             ended: false,
             _k: PhantomData,
             _v: PhantomData,
@@ -482,6 +509,7 @@ where
 pub struct Iter<'a, K: ?Sized, V> {
     base_iter: BytesIter<'a>,
     prefix: Vec<u8>,
+    detach_prefix: bool,
     ended: bool,
     _k: PhantomData<K>,
     _v: PhantomData<V>,
@@ -498,20 +526,24 @@ where
     K: BinaryKey + ?Sized,
     V: BinaryValue,
 {
+    /// Drops the keys returned by the underlying iterator without parsing them.
     pub(crate) fn drop_key_type(self) -> Iter<'a, (), V> {
         Iter {
             base_iter: self.base_iter,
             prefix: self.prefix,
+            detach_prefix: self.detach_prefix,
             ended: self.ended,
             _k: PhantomData,
             _v: PhantomData,
         }
     }
 
+    /// Drops the values returned by the underlying iterator without parsing them.
     pub(crate) fn drop_value_type(self) -> Iter<'a, K, ()> {
         Iter {
             base_iter: self.base_iter,
             prefix: self.prefix,
+            detach_prefix: self.detach_prefix,
             ended: self.ended,
             _k: PhantomData,
             _v: PhantomData,
@@ -531,12 +563,17 @@ where
             return None;
         }
 
-        if let Some((k, v)) = self.base_iter.next() {
-            if k.starts_with(&self.prefix) {
-                return Some((
-                    K::read(k),
-                    V::from_bytes(Cow::Borrowed(v)).expect("Unable to decode value from bytes"),
-                ));
+        if let Some((key_slice, value_slice)) = self.base_iter.next() {
+            if key_slice.starts_with(&self.prefix) {
+                let key = if self.detach_prefix {
+                    // Since we've checked `start_with`, slicing here cannot panic.
+                    K::read(&key_slice[self.prefix.len()..])
+                } else {
+                    K::read(key_slice)
+                };
+                let value = V::from_bytes(Cow::Borrowed(value_slice))
+                    .expect("Unable to decode value from bytes");
+                return Some((key, value));
             }
         }
 

--- a/components/merkledb/src/views/mod.rs
+++ b/components/merkledb/src/views/mod.rs
@@ -493,6 +493,32 @@ impl<'a, K: ?Sized, V> fmt::Debug for Iter<'a, K, V> {
     }
 }
 
+impl<'a, K, V> Iter<'a, K, V>
+where
+    K: BinaryKey + ?Sized,
+    V: BinaryValue,
+{
+    pub(crate) fn drop_key_type(self) -> Iter<'a, (), V> {
+        Iter {
+            base_iter: self.base_iter,
+            prefix: self.prefix,
+            ended: self.ended,
+            _k: PhantomData,
+            _v: PhantomData,
+        }
+    }
+
+    pub(crate) fn drop_value_type(self) -> Iter<'a, K, ()> {
+        Iter {
+            base_iter: self.base_iter,
+            prefix: self.prefix,
+            ended: self.ended,
+            _k: PhantomData,
+            _v: PhantomData,
+        }
+    }
+}
+
 impl<'a, K, V> Iterator for Iter<'a, K, V>
 where
     K: BinaryKey + ?Sized,
@@ -509,8 +535,7 @@ where
             if k.starts_with(&self.prefix) {
                 return Some((
                     K::read(k),
-                    V::from_bytes(Cow::Borrowed(v))
-                        .expect("Unable to decode value from bytes, an error occurred"),
+                    V::from_bytes(Cow::Borrowed(v)).expect("Unable to decode value from bytes"),
                 ));
             }
         }

--- a/components/merkledb/tests/persistent_iter.rs
+++ b/components/merkledb/tests/persistent_iter.rs
@@ -91,7 +91,7 @@ impl Collection {
             IndexType::KeySet => {
                 let mut set = fork.get_key_set(addr);
                 for _ in 0..item_count {
-                    set.insert(rng.gen::<u64>());
+                    set.insert(&rng.gen::<u64>());
                 }
             }
             IndexType::ValueSet => {

--- a/components/merkledb/tests/persistent_iter.rs
+++ b/components/merkledb/tests/persistent_iter.rs
@@ -24,8 +24,9 @@ use rand_xorshift::XorShiftRng;
 
 use exonum_merkledb::migration::{rollback_migration, Scratchpad};
 use exonum_merkledb::{
-    access::CopyAccessExt, migration::PersistentIter, Database, Fork, IndexAddress, IndexType,
-    TemporaryDB,
+    access::CopyAccessExt,
+    migration::{PersistentIter, PersistentKeys},
+    Database, Fork, IndexAddress, IndexType, TemporaryDB,
 };
 
 const ACTIONS_MAX_LEN: usize = 50;
@@ -209,7 +210,7 @@ impl IterState {
 
             IndexType::KeySet => {
                 let set = fork.get_key_set::<_, u64>(addr);
-                let iter = PersistentIter::new(&scratchpad, &self.name, &set);
+                let iter = PersistentKeys::new(&scratchpad, &self.name, &set);
                 self.items.extend(iter.take(amount));
             }
             IndexType::ValueSet => {

--- a/components/merkledb/tests/set.rs
+++ b/components/merkledb/tests/set.rs
@@ -82,7 +82,7 @@ impl Modifier<KeySetIndex<Rc<Fork>, u8>> for SetAction<u8> {
     fn modify(self, set: &mut KeySetIndex<Rc<Fork>, u8>) {
         match self {
             SetAction::Put(k) => {
-                set.insert(k);
+                set.insert(&k);
             }
             SetAction::Remove(k) => {
                 set.remove(&k);

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -220,7 +220,7 @@ impl BlockchainMut {
             .set(genesis_config.consensus_config);
 
         for spec in genesis_config.artifacts {
-            Dispatcher::commit_artifact(&fork, spec.artifact.clone(), spec.payload.clone());
+            Dispatcher::commit_artifact(&fork, &spec.artifact, spec.payload.clone());
             self.dispatcher
                 .deploy_artifact(spec.artifact, spec.payload)
                 .wait()

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -300,7 +300,7 @@ where
     /// be sure to decrement it when the transaction committed.
     #[doc(hidden)]
     pub fn add_transaction_into_pool(&mut self, tx: Verified<AnyTx>) {
-        self.transactions_pool().insert(tx.object_hash());
+        self.transactions_pool().insert(&tx.object_hash());
         let x = self.transactions_pool_len_index().get().unwrap_or(0);
         self.transactions_pool_len_index().set(x + 1);
         self.transactions().put(&tx.object_hash(), tx);

--- a/exonum/src/blockchain/tests.rs
+++ b/exonum/src/blockchain/tests.rs
@@ -193,7 +193,7 @@ impl Execute for Transaction {
                 // Code below will panic if there is already deployed artifact with the
                 // same ID. This sort of expected behavior, since we're intentionally skipping
                 // the `start_deploy` step (which will make the test nature much more complex).
-                Dispatcher::commit_artifact(&*context.fork, artifact_id, Vec::new());
+                Dispatcher::commit_artifact(context.fork, &artifact_id, Vec::new());
                 Ok(())
             }
 
@@ -202,7 +202,7 @@ impl Execute for Transaction {
             }
 
             Transaction::StopService(instance_id) => {
-                Dispatcher::initiate_stopping_service(&*context.fork, instance_id)
+                Dispatcher::initiate_stopping_service(context.fork, instance_id)
             }
         }
     }

--- a/exonum/src/runtime/dispatcher/migration_tests.rs
+++ b/exonum/src/runtime/dispatcher/migration_tests.rs
@@ -297,7 +297,7 @@ impl Rig {
         let artifact = ArtifactId::from_raw_parts(MigrationRuntime::ID, name.into(), version);
 
         let fork = self.blockchain.fork();
-        Dispatcher::commit_artifact(&fork, artifact.clone(), vec![]);
+        Dispatcher::commit_artifact(&fork, &artifact, vec![]);
         self.create_block(fork);
         artifact
     }
@@ -485,7 +485,7 @@ fn migration_immediate_errors() {
     assert_eq!(err, ErrorMatch::from_fail(&CoreError::UnknownArtifactId));
 
     // Mark the artifact as pending.
-    Dispatcher::commit_artifact(&fork, unknown_artifact.clone(), vec![]);
+    Dispatcher::commit_artifact(&fork, &unknown_artifact, vec![]);
     let err = rig
         .dispatcher()
         .initiate_migration(&fork, unknown_artifact, &old_service.name)

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -396,7 +396,7 @@ impl Dispatcher {
     /// `ArtifactId` and deployment was completed successfully.
     /// If any error happens within `commit_artifact`, it is considered either a bug in the
     /// `Supervisor` service or `Dispatcher` itself, and as a result, this method will panic.
-    pub(crate) fn commit_artifact(fork: &Fork, artifact: ArtifactId, deploy_spec: Vec<u8>) {
+    pub(crate) fn commit_artifact(fork: &Fork, artifact: &ArtifactId, deploy_spec: Vec<u8>) {
         debug_assert!(artifact.validate().is_ok(), "{:?}", artifact.validate());
         Schema::new(fork)
             .add_pending_artifact(artifact, deploy_spec)

--- a/exonum/src/runtime/dispatcher/schema.rs
+++ b/exonum/src/runtime/dispatcher/schema.rs
@@ -186,16 +186,16 @@ impl Schema<&Fork> {
     /// Adds artifact specification to the set of the pending artifacts.
     pub(super) fn add_pending_artifact(
         &mut self,
-        artifact: ArtifactId,
+        artifact: &ArtifactId,
         deploy_spec: Vec<u8>,
     ) -> Result<(), ExecutionError> {
         // Check that the artifact is absent among the deployed artifacts.
-        if self.artifacts().contains(&artifact) {
+        if self.artifacts().contains(artifact) {
             return Err(CoreError::ArtifactAlreadyDeployed.into());
         }
         // Add artifact to registry with pending status.
         self.artifacts().put(
-            &artifact,
+            artifact,
             ArtifactState::new(deploy_spec, ArtifactStatus::Pending),
         );
         // Add artifact to pending artifacts queue.

--- a/exonum/src/runtime/dispatcher/tests.rs
+++ b/exonum/src/runtime/dispatcher/tests.rs
@@ -101,7 +101,7 @@ impl Dispatcher {
         artifact: ArtifactId,
         payload: impl BinaryValue,
     ) {
-        Self::commit_artifact(fork, artifact.clone(), payload.to_bytes());
+        Self::commit_artifact(fork, &artifact, payload.to_bytes());
         self.block_until_deployed(artifact, payload.into_bytes());
     }
 }
@@ -773,7 +773,7 @@ fn delayed_deployment() {
     // Check that we don't require the runtime to deploy the artifact again if we mark it
     // as committed.
     let fork = db.fork();
-    Dispatcher::commit_artifact(&fork, artifact.clone(), spec);
+    Dispatcher::commit_artifact(&fork, &artifact, spec);
     let patch = dispatcher.commit_block_and_notify_runtimes(fork);
     db.merge_sync(patch).unwrap();
     assert_eq!(runtime.deploy_attempts(&artifact), 1);
@@ -800,7 +800,7 @@ fn test_failed_deployment(db: &Arc<TemporaryDB>, runtime: &DeploymentRuntime, ar
     assert_eq!(runtime.deploy_attempts(&artifact), 1);
 
     let fork = db.fork();
-    Dispatcher::commit_artifact(&fork, artifact, spec);
+    Dispatcher::commit_artifact(&fork, &artifact, spec);
     dispatcher.commit_block_and_notify_runtimes(fork); // << should panic
 }
 
@@ -841,7 +841,7 @@ fn failed_deployment_with_node_restart() {
     let spec = 100_u64.to_bytes();
 
     let fork = db.fork();
-    Dispatcher::commit_artifact(&fork, artifact.clone(), spec);
+    Dispatcher::commit_artifact(&fork, &artifact, spec);
     Dispatcher::activate_pending(&fork);
     let patch = dispatcher.commit_block_and_notify_runtimes(fork);
     db.merge_sync(patch).unwrap();
@@ -877,7 +877,7 @@ fn recoverable_error_during_deployment() {
     assert_eq!(runtime.deploy_attempts(&artifact), 1);
 
     let fork = db.fork();
-    Dispatcher::commit_artifact(&fork, artifact.clone(), spec);
+    Dispatcher::commit_artifact(&fork, &artifact, spec);
     dispatcher.commit_block_and_notify_runtimes(fork);
     // The dispatcher should try to deploy the artifact again despite a previous failure.
     assert!(dispatcher.is_artifact_deployed(&artifact));

--- a/exonum/src/runtime/execution_context.rs
+++ b/exonum/src/runtime/execution_context.rs
@@ -355,7 +355,7 @@ impl<'a> SupervisorExtensions<'a> {
     /// a requirement for all nodes in the network. A node that did not successfully
     /// deploy the artifact previously blocks until the artifact is deployed successfully.
     /// If a node cannot deploy the artifact, it panics.
-    pub fn start_artifact_registration(&self, artifact: ArtifactId, spec: Vec<u8>) {
+    pub fn start_artifact_registration(&self, artifact: &ArtifactId, spec: Vec<u8>) {
         Dispatcher::commit_artifact(self.0.fork, artifact, spec);
     }
 

--- a/runtimes/rust/tests/inspected/mod.rs
+++ b/runtimes/rust/tests/inspected/mod.rs
@@ -347,7 +347,7 @@ impl ToySupervisor<ExecutionContext<'_>> for ToySupervisorService {
     ) -> Self::Output {
         context
             .supervisor_extensions()
-            .start_artifact_registration(request.test_service_artifact, request.spec);
+            .start_artifact_registration(&request.test_service_artifact, request.spec);
         Ok(())
     }
 

--- a/services/supervisor/src/transactions.rs
+++ b/services/supervisor/src/transactions.rs
@@ -687,7 +687,7 @@ impl Supervisor {
             // if this action fails, this transaction will be canceled.
             context
                 .supervisor_extensions()
-                .start_artifact_registration(deploy_request.artifact, deploy_request.spec);
+                .start_artifact_registration(&deploy_request.artifact, deploy_request.spec);
         }
         Ok(())
     }


### PR DESCRIPTION
## Overview
 
The season of last-minute breaking changes continues! This time, it's unification of iterator types for all MerkleDB indexes. This is (hopefully) better for bindings (they can now deal with a single iterator type extracted via a unified interface for all indexes), and simplifies support.

There are also some moderately unrelated changes:

- `KeySetIndex::insert` now takes the element by reference.
- `KeySetIndex` now supports unsized keys and does not have `K: Borrow<Q>` shenanigans going on, similar to `MapIndex` / `ProofMapIndex`
- Maximum height in `ProofListIndex` was fixed from the bogus value 58 to 56 (needs more detailed testing; I'm not sure this is fixed *everywhere*, and that there are no off-by-one errors)
- Bogus setting of the empty key was removed for `ListIndex`. (This code is seemingly an artifact from an era where indexes did not have metadata.)

Discussion:

- Does this really help bindings?
- Does iteration with `Key = ()`  need to be implemented for `Entry` / `ProofEntry` for uniformity?

------

See: https://jira.bf.local/browse/ECR-4192