### PR TITLE
Readonly fork with static lifetime [ECR-4196]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,12 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 - Unsafe optimizations / experimental features are now behind a `yolo` feature,
   which is off by default. (#1740)
 
+- MerkleDB now provides enumerations for all supported types of DB accesses
+  which can be used to simplify generic code (e.g., in bindings). (#1747)
+
+- It is now possible to obtain readonly access to fork data with static lifetime.
+  (#1763)
+
 #### exonum-node
 
 - Node logic (including P2P networking and consensus algorithm) was moved

--- a/components/merkledb/src/db.rs
+++ b/components/merkledb/src/db.rs
@@ -925,26 +925,26 @@ impl<'a> RawAccess for ReadonlyFork<'a> {
 ///
 /// Beware that producing an instance increases the reference counter of the underlying fork.
 /// If you need to obtain `Fork` from `Rc<Fork>` via [`Rc::try_unwrap`], make sure that all
-/// `ReadonlyRcFork` instances are dropped by this time.
+/// `OwnedReadonlyFork` instances are dropped by this time.
 ///
 /// [`Rc::try_unwrap`]: https://doc.rust-lang.org/std/rc/struct.Rc.html#method.try_unwrap
 ///
 /// # Examples
 ///
 /// ```
-/// # use exonum_merkledb::{access::AccessExt, AsReadonly, Database, ReadonlyRcFork, TemporaryDB};
+/// # use exonum_merkledb::{access::AccessExt, AsReadonly, Database, OwnedReadonlyFork, TemporaryDB};
 /// # use std::rc::Rc;
 /// let db = TemporaryDB::new();
 /// let fork = Rc::new(db.fork());
 /// fork.get_proof_list("list").extend(vec![1_u32, 2, 3]);
-/// let ro_fork: ReadonlyRcFork = fork.as_readonly();
+/// let ro_fork: OwnedReadonlyFork = fork.as_readonly();
 /// let list = ro_fork.get_proof_list::<_, u32>("list");
 /// assert_eq!(list.len(), 3);
 /// ```
 #[derive(Debug, Clone)]
-pub struct ReadonlyRcFork(Rc<Fork>);
+pub struct OwnedReadonlyFork(Rc<Fork>);
 
-impl RawAccess for ReadonlyRcFork {
+impl RawAccess for OwnedReadonlyFork {
     type Changes = ChangesRef<'static>;
 
     fn snapshot(&self) -> &dyn Snapshot {
@@ -959,7 +959,7 @@ impl RawAccess for ReadonlyRcFork {
     }
 }
 
-impl AsReadonly for ReadonlyRcFork {
+impl AsReadonly for OwnedReadonlyFork {
     type Readonly = Self;
 
     fn as_readonly(&self) -> Self::Readonly {
@@ -968,10 +968,10 @@ impl AsReadonly for ReadonlyRcFork {
 }
 
 impl AsReadonly for Rc<Fork> {
-    type Readonly = ReadonlyRcFork;
+    type Readonly = OwnedReadonlyFork;
 
     fn as_readonly(&self) -> Self::Readonly {
-        ReadonlyRcFork(self.clone())
+        OwnedReadonlyFork(self.clone())
     }
 }
 

--- a/components/merkledb/src/db.rs
+++ b/components/merkledb/src/db.rs
@@ -923,7 +923,7 @@ impl<'a> RawAccess for ReadonlyFork<'a> {
 /// Version of `ReadonlyFork` with a static lifetime. Can be produced from an `Rc<Fork>` using
 /// the `AsReadonly` trait.
 ///
-/// Beware that producing an instance increases the reference counter of the unrelying fork.
+/// Beware that producing an instance increases the reference counter of the underlying fork.
 /// If you need to obtain `Fork` from `Rc<Fork>` via [`Rc::try_unwrap`], make sure that all
 /// `ReadonlyRcFork` instances are dropped by this time.
 ///

--- a/components/merkledb/src/generic.rs
+++ b/components/merkledb/src/generic.rs
@@ -103,7 +103,7 @@ use crate::{
     db::{ChangesMut, ChangesRef, ViewChanges},
     migration::{Migration, Scratchpad},
     views::{ChangeSet, GroupKeys, IndexMetadata, RawAccess, RawAccessMut, ViewWithMetadata},
-    BinaryKey, Fork, IndexAddress, IndexType, ReadonlyFork, ReadonlyRcFork, ResolvedAddress,
+    BinaryKey, Fork, IndexAddress, IndexType, OwnedReadonlyFork, ReadonlyFork, ResolvedAddress,
     Snapshot,
 };
 
@@ -134,7 +134,7 @@ pub enum GenericRawAccess<'a> {
     /// Readonly fork.
     ReadonlyFork(ReadonlyFork<'a>),
     /// Owned readonly fork.
-    OwnedReadonlyFork(ReadonlyRcFork),
+    OwnedReadonlyFork(OwnedReadonlyFork),
 
     /// Never actually generated.
     #[doc(hidden)]
@@ -181,8 +181,8 @@ impl<'a> From<ReadonlyFork<'a>> for GenericRawAccess<'a> {
     }
 }
 
-impl From<ReadonlyRcFork> for GenericRawAccess<'_> {
-    fn from(ro_fork: ReadonlyRcFork) -> Self {
+impl From<OwnedReadonlyFork> for GenericRawAccess<'_> {
+    fn from(ro_fork: OwnedReadonlyFork) -> Self {
         GenericRawAccess::OwnedReadonlyFork(ro_fork)
     }
 }

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -174,7 +174,9 @@ pub mod _reexports {
 
 pub use self::{
     backends::{rocksdb::RocksDB, temporarydb::TemporaryDB},
-    db::{Database, DatabaseExt, Fork, Iter, Iterator, Patch, ReadonlyFork, Snapshot},
+    db::{
+        Database, DatabaseExt, Fork, Iter, Iterator, Patch, ReadonlyFork, ReadonlyRcFork, Snapshot,
+    },
     error::Error,
     hash::{root_hash, HashTag, ObjectHash, ValidationError},
     keys::BinaryKey,

--- a/components/merkledb/src/lib.rs
+++ b/components/merkledb/src/lib.rs
@@ -175,7 +175,8 @@ pub mod _reexports {
 pub use self::{
     backends::{rocksdb::RocksDB, temporarydb::TemporaryDB},
     db::{
-        Database, DatabaseExt, Fork, Iter, Iterator, Patch, ReadonlyFork, ReadonlyRcFork, Snapshot,
+        Database, DatabaseExt, Fork, Iter, Iterator, OwnedReadonlyFork, Patch, ReadonlyFork,
+        Snapshot,
     },
     error::Error,
     hash::{root_hash, HashTag, ObjectHash, ValidationError},


### PR DESCRIPTION
## Overview

This PR implements a version of `ReadonlyFork` with static lifetime. This version is then added to `GenericRawAccess` and used to implement `AsReadonly` for `GenericRawAccess`.

Discussion:

- Is `ReadonlyRcFork` a good name?

---

See: https://jira.bf.local/browse/ECR-4196