### PR TITLE
Use generic access in execution context

### DIFF
--- a/exonum/src/runtime/blockchain_data.rs
+++ b/exonum/src/runtime/blockchain_data.rs
@@ -14,6 +14,7 @@
 
 use exonum_merkledb::{
     access::{AsReadonly, FromAccess, Prefixed, RawAccess},
+    generic::GenericRawAccess,
     Snapshot, SystemSchema,
 };
 
@@ -126,6 +127,16 @@ impl BlockchainData<&dyn Snapshot> {
     pub fn proof_for_service_index(&self, index_name: &str) -> Option<IndexProof> {
         let full_index_name = [&self.instance_name, ".", index_name].concat();
         self.access.proof_for_index(&full_index_name)
+    }
+}
+
+impl<'a, T> BlockchainData<T>
+where
+    T: Into<GenericRawAccess<'a>>,
+{
+    /// Erases the enclosed access, converting it to the generic form.
+    pub fn erase_access(self) -> BlockchainData<GenericRawAccess<'a>> {
+        BlockchainData::new(self.access.into(), self.instance_name)
     }
 }
 


### PR DESCRIPTION
## Overview

I've actually understood that Java binding can't use `BlockchainData<GenericRawAccess>` everywhere and suddenly use `BlockchainData<&Fork>` from ExecutionContext.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-XYZW
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
