### PR TITLE
Check index / height in `ProofListIndex` [ECR-4194]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,9 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 
 - Bogus setting of the empty key was removed for `ListIndex`. (#1762)
 
+- `ProofListIndex` now properly processes all index values; previously,
+  some of its methods panicked if called with an index exceeding `2 ** 56`. (#1768)
+
 ## 0.13.0-rc.2 - 2019-12-04
 
 ### Breaking changes

--- a/components/merkledb/src/indexes/proof_list/key.rs
+++ b/components/merkledb/src/indexes/proof_list/key.rs
@@ -41,6 +41,12 @@ impl ProofListKey {
         self.index
     }
 
+    /// Checks if a key is valid. An invalid key may be obtained, for example, by deserializing
+    /// untrusted input.
+    pub fn is_valid(&self) -> bool {
+        u64::from(self.height) <= HEIGHT_SHIFT && self.index <= MAX_INDEX
+    }
+
     pub fn leaf(index: u64) -> Self {
         Self::new(0, index)
     }

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -52,7 +52,29 @@ fn tree_height_by_length(len: u64) -> u8 {
 /// `ProofListIndex` implements a Merkle tree, storing elements as leaves and using `u64` as
 /// an index. `ProofListIndex` requires that elements implement the [`BinaryValue`] trait.
 ///
+/// # Safety
+///
+/// A `ProofListIndex` may contain at most `2 ** 56` elements (which is approximately `7.2e16`),
+/// **not** `2 ** 64` as [`ListIndex`]. Since this amount is still astronomically large,
+/// an index overflow is treated similar to an integer overflow; [`extend`] and [`push`]
+/// methods will panic if the index size exceeds `2 ** 56`. (Unlike integer overflows, the panic
+/// will occur in any compile mode, regardless of whether debug assertions are on.)
+/// For added safety, the application may check that an overflow does not occur before performing
+/// these operations. However, this check will be redundant in most realistic scenarios:
+/// even if 10,000,000 elements are added to a `ProofListIndex` every second, it will take
+/// ~228 years to overflow it.
+///
+/// Using readonly methods such as [`get`], [`iter_from`] and [`get_proof`] is safe for *all*
+/// index values; it is unnecessary to check on the calling side whether the index exceeds
+/// `2 ** 56 - 1` .
+///
 /// [`BinaryValue`]: ../../trait.BinaryValue.html
+/// [`ListIndex`]: ../struct.ListIndex.html
+/// [`extend`]: #method.extend
+/// [`push`]: #method.push
+/// [`get`]: #method.get
+/// [`iter_from`]: #method.iter_from
+/// [`get_proof`]: #method.get_proof
 #[derive(Debug)]
 pub struct ProofListIndex<T: RawAccess, V> {
     base: View<T>,

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -145,6 +145,9 @@ where
     /// assert_eq!(Some(10), index.get(0));
     /// ```
     pub fn get(&self, index: u64) -> Option<V> {
+        if index > MAX_INDEX {
+            return None;
+        }
         self.base.get(&ProofListKey::leaf(index))
     }
 

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -794,6 +794,20 @@ mod proto {
         }
     }
 
+    #[test]
+    fn proof_list_key_errors() {
+        let mut bogus_key = proto::ProofListKey::new();
+        bogus_key.set_height(57);
+        let err = ProofListKey::from_pb(bogus_key).unwrap_err();
+        assert!(err.to_string().contains("height is out of range"));
+
+        let mut bogus_key = proto::ProofListKey::new();
+        bogus_key.set_height(3);
+        bogus_key.set_index(1_u64 << 57);
+        let err = ProofListKey::from_pb(bogus_key).unwrap_err();
+        assert!(err.to_string().contains("index is out of range"));
+    }
+
     impl<V> ProtobufConvert for ListProof<V>
     where
         V: BinaryValue,

--- a/components/merkledb/src/indexes/proof_list/mod.rs
+++ b/components/merkledb/src/indexes/proof_list/mod.rs
@@ -21,7 +21,7 @@ use exonum_crypto::Hash;
 use std::{cmp, iter, marker::PhantomData, ops::RangeBounds};
 
 use self::{
-    key::ProofListKey,
+    key::{ProofListKey, MAX_INDEX},
     proof::HashedEntry,
     proof_builder::{BuildProof, MerkleTree},
 };
@@ -500,6 +500,20 @@ where
             // No elements in the iterator; we're done.
             return;
         }
+
+        // For efficiency, we check the constraint once rather than in a loop above.
+        // If the list length exceeds the allowed bounds, `ProofListKey::leaf` in the loop
+        // will panic in the debug mode, but we don't expect users to run MerkleDB in the debug mode
+        // in all cases.
+        assert!(
+            new_list_len < MAX_INDEX + 1,
+            "Length of a `ProofListIndex` exceeding the maximum allowed value ({}). \
+             This should never happen in realistic scenarios. If you feel this is not a bug, \
+             open an issue on https://github.com/exonum/exonum and tell us your use case \
+             for such a large list.",
+            MAX_INDEX + 1
+        );
+
         self.set_len(new_list_len);
         self.update_range(old_list_len, new_list_len - 1);
     }

--- a/components/merkledb/src/indexes/proof_list/tests.rs
+++ b/components/merkledb/src/indexes/proof_list/tests.rs
@@ -69,7 +69,7 @@ fn list_methods() {
 }
 
 #[test]
-fn get_with_overly_large_index() {
+fn get_and_iter_from_with_overly_large_index() {
     const LARGE_INDEXES: &[u64] = &[
         1_u64 << 56,
         (1_u64 << 56) + 10,
@@ -81,10 +81,12 @@ fn get_with_overly_large_index() {
 
     let db = TemporaryDB::new();
     let fork = db.fork();
-    let list = fork.get_proof_list::<_, u64>(IDX_NAME);
+    let mut list = fork.get_proof_list::<_, u64>(IDX_NAME);
+    list.extend(0..10);
 
     for &index in LARGE_INDEXES {
         assert_eq!(list.get(index), None);
+        assert_eq!(list.iter_from(index).count(), 0);
     }
 }
 

--- a/examples/cryptocurrency/src/tx_tests.rs
+++ b/examples/cryptocurrency/src/tx_tests.rs
@@ -256,7 +256,7 @@ fn init_testkit() -> TestKit {
     TestKit::for_rust_service(CryptocurrencyService, INSTANCE_NAME, INSTANCE_ID, ())
 }
 
-/// Returns the wallet identified by the given public key or `None` such wallet doesn't exist.
+/// Returns the wallet identified by the given public key or `None` if such a wallet doesn't exist.
 fn try_get_wallet(testkit: &TestKit, pubkey: &PublicKey) -> Option<Wallet> {
     let snapshot = testkit.snapshot();
     let schema = get_schema(&snapshot);


### PR DESCRIPTION
## Overview

This PR checks index / height "overflow" in `ListProof` and `ProofListIndex` methods. For example, `list.get(1 << 60)` previously panicked in the debug mode and returned garbage in the release mode; now it properly returns `None`.

Discussion:

- Is it appropriate to panic if the list length exceeds `1 << 56`? Is the error message output in this case good enough?

---

See: https://jira.bf.local/browse/ECR-4194