### PR TITLE
Pin `hex` crate to version 0.4.0

### DIFF
--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -14,7 +14,7 @@ description = "Cryptography related types, constants, traits and functions."
 links = "exonum_protobuf_crypto"
 
 [dependencies]
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 serde = "1.0.101"
 serde_derive = "1.0.101"
 failure = "0.1.5"

--- a/components/explorer/Cargo.toml
+++ b/components/explorer/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "exonum/exonum" }
 exonum = { version = "1.0.0-rc.1", path = "../../exonum" }
 
 chrono = { version = "0.4.6", features = ["serde"] }
-hex = "0.4.0"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -25,4 +25,4 @@ exonum-crypto = { version = "1.0.0-rc.1", path = "../crypto" }
 
 [dev-dependencies]
 tempdir = "0.3.7"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -40,7 +40,7 @@ exonum-derive = { version = "1.0.0-rc.1", path = "../derive" }
 assert_matches = "1.3.0"
 bincode = "1.1"
 criterion = "0.3"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 modifier = "0.1"
 proptest = "0.9"
 pretty_assertions = "0.6"

--- a/examples/cryptocurrency-advanced/backend/Cargo.toml
+++ b/examples/cryptocurrency-advanced/backend/Cargo.toml
@@ -33,7 +33,7 @@ exonum-testkit = { version = "1.0.0-rc.1", path = "../../../test-suite/testkit" 
 
 assert_matches = "1.2.0"
 bincode = "1.2.1"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 pretty_assertions = "0.6.1"
 serde_json = "1.0.0"
 

--- a/exonum-node/Cargo.toml
+++ b/exonum-node/Cargo.toml
@@ -46,7 +46,7 @@ exonum_sodiumoxide = { version = "0.0.23", optional = true }
 [dev-dependencies]
 bincode = "1.2.1"
 criterion = "0.3.0"
-hex = "0.4.0"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 pretty_assertions = "0.6.1"
 serde_json = "1.0.44"
 

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "exonum/exonum" }
 
 [dependencies]
 log = "0.4.6"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 serde = "1.0.101"
 serde_derive = "1.0.101"
 serde_str = "0.1.0"

--- a/services/explorer/Cargo.toml
+++ b/services/explorer/Cargo.toml
@@ -26,7 +26,7 @@ actix = "0.7.9"
 actix-web = { version = "0.7.18", default-features = false }
 failure = "0.1.5"
 futures = "0.1.25"
-hex = "0.4.0"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 log = "0.4.6"
 rand = "0.7"
 serde = "1.0"

--- a/services/supervisor/Cargo.toml
+++ b/services/supervisor/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.0"
 serde_str = "0.1.0"
 protobuf = "2.8.0"
 log = "0.4.6"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 
 exonum = { version = "1.0.0-rc.1", path = "../../exonum" }
 exonum-derive = { version = "1.0.0-rc.1", path = "../../components/derive" }

--- a/test-suite/testkit/Cargo.toml
+++ b/test-suite/testkit/Cargo.toml
@@ -47,7 +47,7 @@ tokio-core = "0.1.17"
 [dev-dependencies]
 assert_matches = "1.2.0"
 bincode = "1.2.1"
-hex = "0.4"
+hex = "=0.4.0" # 0.4.1 is not compatible with Rust 1.36
 lazy_static = "1.0.0"
 pretty_assertions = "0.6.1"
 rand = "0.7"


### PR DESCRIPTION
## Overview

Exactly what it says in the title. The reasoning is that we (yet?) need to support Rust 1.36 compilation target.