### PR TITLE
Remove `MethodDescriptor.name` [ECR-4236]

### DIFF
--- a/components/derive/src/exonum_interface.rs
+++ b/components/derive/src/exonum_interface.rs
@@ -418,11 +418,9 @@ impl ExonumInterface {
 
         let impl_method = |descriptor: &ServiceMethodDescriptor| {
             let ServiceMethodDescriptor { name, arg_type, id } = descriptor;
-            let name_string = name.to_string();
             let descriptor = quote! {
                 #cr::MethodDescriptor::new(
                     #interface_name,
-                    #name_string,
                     #id,
                 )
             };

--- a/examples/cryptocurrency-advanced/backend/tests/multisig.rs
+++ b/examples/cryptocurrency-advanced/backend/tests/multisig.rs
@@ -166,7 +166,7 @@ impl MultisigInterface<ExecutionContext<'_>> for MultisigService {
         let current_votes: u32 = proposal.votes.iter().map(|flag| *flag as u32).sum();
         if current_votes == config.threshold {
             let call_info = proposal.action.call_info;
-            let method = MethodDescriptor::new("", "", call_info.method_id);
+            let method = MethodDescriptor::inherent(call_info.method_id);
             context.generic_call_mut(call_info.instance_id, method, proposal.action.arguments)?;
             MultisigSchema::new(context.service_data())
                 .proposals

--- a/runtimes/rust/src/stubs.rs
+++ b/runtimes/rust/src/stubs.rs
@@ -31,20 +31,25 @@ use exonum::{
 pub struct MethodDescriptor<'a> {
     /// Name of the interface.
     pub interface_name: &'a str,
-    /// Name of the method.
-    pub name: &'a str,
     /// Numerical ID of the method.
     pub id: MethodId,
 }
 
 impl<'a> MethodDescriptor<'a> {
     /// Creates the descriptor based on provided properties.
-    pub const fn new(interface_name: &'a str, name: &'a str, id: MethodId) -> Self {
-        Self {
-            interface_name,
-            name,
-            id,
-        }
+    pub const fn new(interface_name: &'a str, id: MethodId) -> Self {
+        Self { interface_name, id }
+    }
+
+    /// Creates a descriptor for an inherent method, that is, method in the default service
+    /// interface.
+    ///
+    /// See documentation of the `runtime` module in the `exonum` crate for mode details
+    /// about service interfaces. You may also consult [general Exonum docs].
+    ///
+    /// [general Exonum docs]: https://exonum.com/doc/version/latest/architecture/services/
+    pub const fn inherent(id: MethodId) -> Self {
+        Self::new("", id)
     }
 }
 
@@ -213,7 +218,6 @@ mod explanation {
         fn create_wallet(&self, context: Ctx, wallet: CreateWallet) -> Self::Output {
             const DESCRIPTOR: MethodDescriptor<'static> = MethodDescriptor {
                 interface_name: "",
-                name: "create_wallet",
                 id: 0,
             };
             self.generic_call(context, DESCRIPTOR, wallet.into_bytes())
@@ -222,7 +226,6 @@ mod explanation {
         fn transfer(&self, context: Ctx, transfer: Transfer) -> Self::Output {
             const DESCRIPTOR: MethodDescriptor<'static> = MethodDescriptor {
                 interface_name: "",
-                name: "transfer",
                 id: 1,
             };
             self.generic_call(context, DESCRIPTOR, transfer.into_bytes())

--- a/services/middleware/src/transactions.rs
+++ b/services/middleware/src/transactions.rs
@@ -197,7 +197,7 @@ impl MiddlewareInterface<ExecutionContext<'_>> for MiddlewareService {
         }
 
         // TODO: use interface name from `call_info` once it's added there
-        let method = MethodDescriptor::new("", "", arg.inner.call_info.method_id);
+        let method = MethodDescriptor::inherent(arg.inner.call_info.method_id);
         FallthroughAuth(context).generic_call_mut(instance_id, method, arg.inner.arguments)
     }
 
@@ -205,7 +205,7 @@ impl MiddlewareInterface<ExecutionContext<'_>> for MiddlewareService {
         let mut fallthrough_auth = FallthroughAuth(context);
         for call in arg.inner {
             // TODO: use interface name from `call_info` once it's added there
-            let method = MethodDescriptor::new("", "", call.call_info.method_id);
+            let method = MethodDescriptor::inherent(call.call_info.method_id);
             fallthrough_auth.generic_call_mut(
                 call.call_info.instance_id,
                 method,

--- a/services/supervisor/src/configure.rs
+++ b/services/supervisor/src/configure.rs
@@ -119,13 +119,13 @@ impl ConfigureMut<InstanceId> for ExecutionContext<'_> {
 
     fn verify_config(&mut self, instance_id: InstanceId, params: Vec<u8>) -> Self::Output {
         const METHOD_DESCRIPTOR: MethodDescriptor<'static> =
-            MethodDescriptor::new(CONFIGURE_INTERFACE_NAME, "verify_config", 0);
+            MethodDescriptor::new(CONFIGURE_INTERFACE_NAME, 0);
         self.generic_call_mut(instance_id, METHOD_DESCRIPTOR, params)
     }
 
     fn apply_config(&mut self, instance_id: InstanceId, params: Vec<u8>) -> Self::Output {
         const METHOD_DESCRIPTOR: MethodDescriptor<'static> =
-            MethodDescriptor::new(CONFIGURE_INTERFACE_NAME, "apply_config", 1);
+            MethodDescriptor::new(CONFIGURE_INTERFACE_NAME, 1);
         self.generic_call_mut(instance_id, METHOD_DESCRIPTOR, params)
     }
 }

--- a/test-suite/testkit/tests/interfaces/services.rs
+++ b/test-suite/testkit/tests/interfaces/services.rs
@@ -194,7 +194,7 @@ impl CallAny<ExecutionContext<'_>> for AnyCallService {
     fn call_any(&self, mut ctx: ExecutionContext<'_>, tx: AnyCall) -> Self::Output {
         let call_info = tx.inner.call_info;
         let args = tx.inner.arguments;
-        let method = MethodDescriptor::new(&tx.interface_name, "", call_info.method_id);
+        let method = MethodDescriptor::new(&tx.interface_name, call_info.method_id);
 
         if tx.fallthrough_auth {
             FallthroughAuth(ctx).generic_call_mut(call_info.instance_id, method, args)


### PR DESCRIPTION
## Overview

This PR removes `MethodDescriptor.name` since it isn't used by the framework.

---

See: https://jira.bf.local/browse/ECR-4236