### PR TITLE
Fix `Propose` invalidation logic [ECR-4223]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ jobs:
     - cargo test --all --lib --tests --benches
     - cargo test --all --doc
 
-  # Run examples.
+  # Run examples and soak tests.
   - name: examples
     script:
     - cargo run -p exonum-merkledb --example manual_migration
@@ -146,6 +146,7 @@ jobs:
     - cargo run -p exonum-testkit --example timestamping
     - cargo run -p exonum-supervisor --example configuration_change
     - cargo run -p exonum-time --example simple_service
+    - cargo run -p exonum-soak-tests --bin toggle -- -H 10
 
   # Integration tests.
   - name: integration-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+#### exonum-node
+
+- Fixed incorrect invalidation of block proposals. (#1782)
+
 ## 1.0.0-rc.1 - 2020-02-07
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "test-suite/testkit",
     "test-suite/testkit/server",
     "test-suite/rust-runtime-proto",
+    "test-suite/soak-tests",
 
     "runtimes/rust",
 

--- a/exonum-node/src/sandbox/tests/round_details.rs
+++ b/exonum-node/src/sandbox/tests/round_details.rs
@@ -788,6 +788,51 @@ fn not_sending_precommit_for_proposal_with_incorrect_tx() {
     sandbox.add_time(Duration::from_millis(0));
 }
 
+#[test]
+fn invalid_tx_does_not_invalidate_unrelated_proposes() {
+    let sandbox = timestamping_sandbox();
+    let invalid_tx = gen_incorrect_tx();
+
+    let propose = ProposeBuilder::new(&sandbox).with_tx_hashes(&[]).build();
+    sandbox.recv(&propose);
+    let our_prevote = sandbox.create_prevote(
+        ValidatorId(0),
+        Height(1),
+        Round(1),
+        propose.object_hash(),
+        NOT_LOCKED,
+        sandbox.secret_key(ValidatorId(0)),
+    );
+    sandbox.broadcast(&our_prevote);
+
+    sandbox.recv(&invalid_tx);
+    {
+        let inner = sandbox.inner.borrow();
+        let propose_state = inner.handler.state.propose(&propose.object_hash()).unwrap();
+        assert!(!propose_state.has_invalid_txs());
+    }
+
+    let block = sandbox.create_block(&[]);
+    let precommits = (1..4).map(|i| {
+        let validator_id = ValidatorId(i);
+        sandbox.create_precommit(
+            validator_id,
+            Height(1),
+            Round(1),
+            propose.object_hash(),
+            block.object_hash(),
+            sandbox.time().into(),
+            sandbox.secret_key(validator_id),
+        )
+    });
+
+    for precommit in precommits {
+        sandbox.recv(&precommit);
+    }
+    sandbox.assert_state(Height(2), Round(1));
+    sandbox.check_broadcast_status(Height(2), block.object_hash());
+}
+
 /// scenario: // HANDLE PRECOMMIT positive scenario with commit
 #[test]
 fn handle_precommit_positive_scenario_commit() {

--- a/exonum-node/src/state.rs
+++ b/exonum-node/src/state.rs
@@ -822,9 +822,8 @@ impl State {
     pub(super) fn check_incomplete_proposes(&mut self, tx_hash: Hash) -> Vec<(Hash, Round)> {
         let mut full_proposes = Vec::new();
         for (propose_hash, propose_state) in &mut self.proposes {
-            propose_state.unknown_txs.remove(&tx_hash);
-
-            if self.invalid_txs.contains(&tx_hash) {
+            let contained_tx = propose_state.unknown_txs.remove(&tx_hash);
+            if contained_tx && self.invalid_txs.contains(&tx_hash) {
                 // Mark prevote with newly received invalid transaction as invalid.
                 propose_state.is_valid = false;
             }

--- a/test-suite/soak-tests/Cargo.toml
+++ b/test-suite/soak-tests/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "exonum-soak-tests"
+version = "0.0.0"
+edition = "2018"
+authors = ["The Exonum Team <exonum@bitfury.com>"]
+homepage = "https://exonum.com/"
+repository = "https://github.com/exonum/exonum"
+readme = "README.md"
+description = "The crate for soak testing of Exonum node."
+publish = false
+
+[[bin]]
+name = "toggle"
+path = "src/toggle.rs"
+
+[dependencies]
+exonum = { version = "1.0.0-rc.1", path = "../../exonum" }
+exonum-derive = { version = "1.0.0-rc.1", path = "../../components/derive" }
+exonum-merkledb = { version = "1.0.0-rc.1", path = "../../components/merkledb" }
+exonum-node = { version = "1.0.0-rc.1", path = "../../exonum-node" }
+exonum-rust-runtime = { version = "1.0.0-rc.1", path = "../../runtimes/rust" }
+
+futures = "0.1.29"
+log = "0.4.6"
+structopt = "0.3.9"

--- a/test-suite/soak-tests/README.md
+++ b/test-suite/soak-tests/README.md
@@ -1,0 +1,25 @@
+# Soak Tests for Exonum Nodes
+
+This is an internal crate for subjecting Exonum networks to [soak tests].
+
+## Contents
+
+The crate exposes the following binaries:
+
+- [`toggle`](src/toggle.rs). Tests repeatedly switching a service on and off.
+  The service generates transactions in the `after_commit` hook.
+
+## Usage
+
+Run the selected binary like this:
+
+```sh
+cargo run -p exonum-soak-tests --bin $binary
+```
+
+Use `--help` option to find out command-line options specific to the binary.
+
+You may want to set up `RUST_LOG` env variable to check events in the nodes
+and/or the core library, for example, `RUST_LOG=exonum_node=info,warn`.
+
+[soak tests]: https://en.wikipedia.org/wiki/Soak_testing

--- a/test-suite/soak-tests/src/services.rs
+++ b/test-suite/soak-tests/src/services.rs
@@ -1,0 +1,103 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use exonum::runtime::SUPERVISOR_INSTANCE_ID;
+use exonum::{
+    helpers::Height,
+    merkledb::access::AccessExt,
+    runtime::{ExecutionContext, ExecutionError, InstanceId},
+};
+use exonum_derive::*;
+use exonum_rust_runtime::{AfterCommitContext, DefaultInstance, Service, ServiceFactory};
+
+#[exonum_interface(auto_ids)]
+pub trait MainServiceInterface<Ctx> {
+    type Output;
+
+    fn timestamp(&self, context: Ctx, height: Height) -> Self::Output;
+}
+
+#[derive(Debug, Clone, Copy, ServiceDispatcher, ServiceFactory)]
+#[service_dispatcher(implements("MainServiceInterface"))]
+#[service_factory(artifact_name = "main", artifact_version = "1.0.0")]
+pub struct MainService;
+
+impl MainServiceInterface<ExecutionContext<'_>> for MainService {
+    type Output = Result<(), ExecutionError>;
+
+    fn timestamp(&self, _context: ExecutionContext<'_>, _height: Height) -> Self::Output {
+        Ok(())
+    }
+}
+
+impl Service for MainService {
+    fn after_transactions(&self, context: ExecutionContext<'_>) -> Result<(), ExecutionError> {
+        let height = context.data().for_core().next_height();
+        let height_str = height.0.to_string();
+
+        let mut map = context
+            .service_data()
+            .get_proof_map::<_, u64, String>("some");
+        map.put(&0, height_str.clone());
+        map.put(&(height.0 / 2), height_str.clone());
+        map.put(&height.0, height_str.clone());
+        map.put(&(height.0 + 1), height_str);
+
+        Ok(())
+    }
+
+    fn after_commit(&self, context: AfterCommitContext<'_>) {
+        if let Some(broadcaster) = context.broadcaster() {
+            if let Err(e) = broadcaster.timestamp((), context.height()) {
+                log::error!(
+                    "[{}] Failed to broadcast transaction at height {}: {}",
+                    context.service_key(),
+                    context.height(),
+                    e
+                );
+            }
+        }
+    }
+}
+
+impl DefaultInstance for MainService {
+    const INSTANCE_ID: InstanceId = 100;
+    const INSTANCE_NAME: &'static str = "main";
+}
+
+#[derive(Debug, Clone, Copy, ServiceDispatcher, ServiceFactory)]
+#[service_factory(artifact_name = "supervisor", artifact_version = "1.0.0")]
+pub struct TogglingSupervisor;
+
+impl Service for TogglingSupervisor {
+    fn after_transactions(&self, mut context: ExecutionContext<'_>) -> Result<(), ExecutionError> {
+        let height = context.data().for_core().next_height();
+        let mut extensions = context.supervisor_extensions();
+
+        match height.0 % 5 {
+            1 => extensions.initiate_stopping_service(MainService::INSTANCE_ID),
+            4 => extensions.initiate_resuming_service(
+                MainService::INSTANCE_ID,
+                MainService.artifact_id(),
+                (),
+            ),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl DefaultInstance for TogglingSupervisor {
+    const INSTANCE_ID: InstanceId = SUPERVISOR_INSTANCE_ID;
+    const INSTANCE_NAME: &'static str = "supervisor";
+}

--- a/test-suite/soak-tests/src/services.rs
+++ b/test-suite/soak-tests/src/services.rs
@@ -19,7 +19,7 @@ use exonum::{
     runtime::{ExecutionContext, ExecutionError, InstanceId},
 };
 use exonum_derive::*;
-use exonum_rust_runtime::{AfterCommitContext, DefaultInstance, Service, ServiceFactory};
+use exonum_rust_runtime::{AfterCommitContext, DefaultInstance, Service};
 
 #[exonum_interface(auto_ids)]
 pub trait MainServiceInterface<Ctx> {
@@ -87,11 +87,7 @@ impl Service for TogglingSupervisor {
 
         match height.0 % 5 {
             1 => extensions.initiate_stopping_service(MainService::INSTANCE_ID),
-            4 => extensions.initiate_resuming_service(
-                MainService::INSTANCE_ID,
-                MainService.artifact_id(),
-                (),
-            ),
+            4 => extensions.initiate_resuming_service(MainService::INSTANCE_ID, ()),
             _ => Ok(()),
         }
     }

--- a/test-suite/soak-tests/src/toggle.rs
+++ b/test-suite/soak-tests/src/toggle.rs
@@ -1,0 +1,164 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runs a network with a service that is frequently switched on / off and that generates
+//! transactions in `after_commit` hook.
+
+use exonum::{
+    blockchain::config::GenesisConfigBuilder,
+    crypto::KeyPair,
+    helpers::Height,
+    merkledb::{Database, ObjectHash, TemporaryDB},
+    runtime::SnapshotExt,
+};
+use exonum_node::{generate_testnet_config, Node, NodeBuilder, ShutdownHandle};
+use exonum_rust_runtime::{DefaultInstance, RustRuntime, ServiceFactory};
+use futures::Future;
+use structopt::StructOpt;
+
+use std::{sync::Arc, thread, time::Duration};
+
+use crate::services::{MainService, MainServiceInterface, TogglingSupervisor};
+
+mod services;
+
+#[derive(Debug)]
+struct RunHandle {
+    node_thread: thread::JoinHandle<()>,
+    service_keys: KeyPair,
+    shutdown_handle: ShutdownHandle,
+}
+
+impl RunHandle {
+    fn new(node: Node, service_keys: KeyPair) -> Self {
+        let shutdown_handle = node.shutdown_handle();
+        Self {
+            node_thread: thread::spawn(|| node.run().unwrap()),
+            shutdown_handle,
+            service_keys,
+        }
+    }
+
+    fn join(self) -> KeyPair {
+        self.shutdown_handle.shutdown().wait().unwrap();
+        // FIXME: use `expect` once "cannot send internal event" panic is removed.
+        self.node_thread.join().ok();
+        self.service_keys
+    }
+}
+
+fn run_nodes(count: u16, start_port: u16) -> (Vec<RunHandle>, Arc<TemporaryDB>) {
+    let mut node_threads = Vec::with_capacity(count as usize);
+    let inspected_db = Arc::new(TemporaryDB::new());
+
+    let configs = generate_testnet_config(count, start_port);
+    for (i, (node_cfg, node_keys)) in configs.into_iter().enumerate() {
+        let genesis_cfg = GenesisConfigBuilder::with_consensus_config(node_cfg.consensus.clone())
+            .with_artifact(MainService.artifact_id())
+            .with_instance(MainService.default_instance())
+            .with_artifact(TogglingSupervisor.artifact_id())
+            .with_instance(TogglingSupervisor.default_instance())
+            .build();
+
+        let db = if i == 0 {
+            Arc::clone(&inspected_db)
+        } else {
+            Arc::new(TemporaryDB::new())
+        };
+
+        let service_keys = node_keys.service.clone();
+        let node = NodeBuilder::new(db as Arc<dyn Database>, node_cfg, node_keys)
+            .with_genesis_config(genesis_cfg)
+            .with_runtime_fn(|channel| {
+                RustRuntime::builder()
+                    .with_factory(MainService)
+                    .with_factory(TogglingSupervisor)
+                    .build(channel.endpoints_sender())
+            })
+            .build();
+
+        node_threads.push(RunHandle::new(node, service_keys));
+    }
+    (node_threads, inspected_db)
+}
+
+fn get_height(db: &TemporaryDB) -> Height {
+    db.snapshot().for_core().height()
+}
+
+/// Runs a network with a service that is frequently switched on / off and that generates
+/// transactions in `after_commit` hook.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "toggle", set_term_width = 80)]
+struct Args {
+    /// Number of nodes in the network.
+    #[structopt(name = "nodes", default_value = "4")]
+    node_count: u16,
+
+    /// Blockchain height to reach. If not specified, the test will run infinitely.
+    #[structopt(name = "max-height", long, short = "H")]
+    max_height: Option<u64>,
+}
+
+fn main() {
+    exonum::crypto::init();
+    exonum::helpers::init_logger().ok();
+
+    let args = Args::from_args();
+    println!("Running test with {:?}", args);
+
+    let (nodes, db) = run_nodes(args.node_count, 2_000);
+    loop {
+        let height = get_height(&db);
+        println!("Blockchain height: {:?}", height);
+        if args.max_height.map_or(false, |max| height >= Height(max)) {
+            break;
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    let snapshot = db.snapshot();
+    let core_schema = snapshot.for_core();
+    let transactions = core_schema.transactions();
+    let height = core_schema.height();
+
+    let keys: Vec<_> = nodes.into_iter().map(RunHandle::join).collect();
+    let mut committed_timestamps = 0;
+    for (node_i, keys) in keys.into_iter().enumerate() {
+        let timestamps = (1..=height.0)
+            .filter_map(|i| match i % 5 {
+                0 | 4 => Some(Height(i)),
+                _ => None,
+            })
+            .map(|i| (i, keys.timestamp(MainService::INSTANCE_ID, i)));
+
+        for (i, timestamp) in timestamps {
+            if transactions.contains(&timestamp.object_hash()) {
+                committed_timestamps += 1;
+            } else {
+                println!(
+                    "Did not commit transaction for node {} at height {:?}",
+                    node_i, i
+                );
+            }
+        }
+    }
+
+    let committed_txs = core_schema.transactions_len();
+    println!("Total committed transactions: {}", committed_txs);
+    assert_eq!(
+        committed_timestamps, committed_txs,
+        "There are unknown transactions on the blockchain"
+    );
+}


### PR DESCRIPTION
## Overview

This PR fixes `Propose` invalidation logic. A `Propose` could be marked as invalid even if it did not contain invalid transactions, simply as a result of processing an unrelated invalid transaction.

Not done:

- Add tests for service switching on / off into the sandbox. Switching on / off seems to work fine, but more test coverage is always good.
- Fix panics on node shutdown (I'll create a separate Jira task for this).

---

See: https://jira.bf.local/browse/ECR-4223