### PR TITLE
Fix panic during node shutdown [ECR-4254]

### DIFF
--- a/exonum-node/src/events/internal.rs
+++ b/exonum-node/src/events/internal.rs
@@ -76,7 +76,7 @@ impl InternalPart {
 
             match request {
                 InternalRequest::VerifyMessage(tx) => {
-                    let fut = Self::verify_message(tx, internal_tx.clone());
+                    let fut = Self::verify_message(tx, internal_tx);
                     verify_executor
                         .execute(Box::new(fut))
                         .expect("cannot schedule message verification");

--- a/exonum-node/src/lib.rs
+++ b/exonum-node/src/lib.rs
@@ -1107,12 +1107,11 @@ impl Node {
 
     /// Launches only consensus messages handler.
     /// This may be used if you want to customize api with the `ApiContext`.
-    fn run_handler(mut self, handshake_params: &HandshakeParams) -> Result<(), Error> {
+    fn run_handler(mut self, handshake_params: HandshakeParams) -> Result<(), Error> {
         self.handler.initialize();
 
         let pool_size = self.thread_pool_size;
         let (handler_part, network_part, internal_part) = self.into_reactor();
-        let handshake_params = handshake_params.clone();
 
         let network_thread = thread::spawn(move || {
             let mut core = Core::new().map_err(into_failure)?;
@@ -1152,8 +1151,7 @@ impl Node {
             self.state().our_connect_message().clone(),
             self.max_message_len,
         );
-        self.run_handler(&handshake_params)?;
-        Ok(())
+        self.run_handler(handshake_params)
     }
 
     fn into_reactor(self) -> (HandlerPart<impl EventHandler>, NetworkPart, InternalPart) {

--- a/test-suite/soak-tests/src/toggle.rs
+++ b/test-suite/soak-tests/src/toggle.rs
@@ -51,8 +51,13 @@ impl RunHandle {
     }
 
     fn join(self) -> KeyPair {
-        self.shutdown_handle.shutdown().wait().expect("Cannot shut down node");
-        self.node_thread.join().expect("Node panicked during shutdown");
+        self.shutdown_handle
+            .shutdown()
+            .wait()
+            .expect("Cannot shut down node");
+        self.node_thread
+            .join()
+            .expect("Node panicked during shutdown");
         self.service_keys
     }
 }

--- a/test-suite/soak-tests/src/toggle.rs
+++ b/test-suite/soak-tests/src/toggle.rs
@@ -51,9 +51,8 @@ impl RunHandle {
     }
 
     fn join(self) -> KeyPair {
-        self.shutdown_handle.shutdown().wait().unwrap();
-        // FIXME: use `expect` once "cannot send internal event" panic is removed.
-        self.node_thread.join().ok();
+        self.shutdown_handle.shutdown().wait().expect("Cannot shut down node");
+        self.node_thread.join().expect("Node panicked during shutdown");
         self.service_keys
     }
 }


### PR DESCRIPTION
## Overview

This PR fixes useless panic during node shutdown. While a panic doesn't make much difference in a typical app (the app is shut down together with a node, anyway), the panic led to complications in some high-level tests.

---

See: https://jira.bf.local/browse/ECR-4254