### PR TITLE
Add TestKitApiClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   similar to real Exonum nodes. (#1785)
 
 - Added method to get reference to the underlying API client for the `TestKitApi`.
+  (#1811)
 
 ## 1.0.0-rc.1 - 2020-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Testkit now does not include incorrect transactions into blocks or memory pool,
   similar to real Exonum nodes. (#1785)
 
-- Added method to get reference to the underlying API client for the `TestKitApi`.
+- Added a method to get reference to the underlying API client for the `TestKitApi`.
   (#1811)
 
 ## 1.0.0-rc.1 - 2020-02-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Testkit now does not include incorrect transactions into blocks or memory pool,
   similar to real Exonum nodes. (#1785)
 
+- Added method to get reference to the underlying API client for the `TestKitApi`.
+
 ## 1.0.0-rc.1 - 2020-02-07
 
 ### Breaking changes

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -178,7 +178,7 @@ impl TestKitApi {
 
 /// An asynchronous API client to make Requests with.
 ///
-/// This client is wrapper around the `reqwest::Client` to provide more convenient
+/// This client is a wrapper around the `reqwest::Client` to provide more convenient
 /// way to test API.
 #[derive(Debug, Clone)]
 pub struct TestKitApiClient {
@@ -197,7 +197,7 @@ impl TestKitApiClient {
         [&self.test_server_url, "private/", url].concat()
     }
 
-    /// Creates a requests builder for the public API scope.
+    /// Creates a request builder for the public API scope.
     pub fn public(&self, kind: impl Display) -> RequestBuilder<'_, '_> {
         RequestBuilder::new(
             &self.test_server_url,

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -177,7 +177,7 @@ impl TestKitApi {
 }
 
 /// An asynchronous API client to make Requests with.
-/// 
+///
 /// This client is wrapper around the `reqwest::Client` to provide more convenient
 /// way to test API.
 #[derive(Debug, Clone)]
@@ -189,12 +189,12 @@ pub struct TestKitApiClient {
 impl TestKitApiClient {
     /// Returns the resolved URL for the public API.
     pub fn public_url(&self, url: &str) -> String {
-        format!("{}/public/{}", self.test_server_url, url)
+        [&self.test_server_url, "public/", url].concat()
     }
 
     /// Returns the resolved URL for the private API.
     pub fn private_url(&self, url: &str) -> String {
-        format!("{}/private/{}", self.test_server_url, url)
+        [&self.test_server_url, "private/", url].concat()
     }
 
     /// Creates a requests builder for the public API scope.

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -101,8 +101,8 @@ impl fmt::Display for ApiKind {
 /// }
 /// ```
 pub struct TestKitApi {
-    test_server: TestServer,
-    test_client: Client,
+    _test_server_handle: TestServer,
+    test_client: TestKitApiClient,
     api_sender: ApiSender,
 }
 
@@ -121,20 +121,22 @@ impl TestKitApi {
     pub(crate) fn from_raw_parts(aggregator: ApiAggregator, api_sender: ApiSender) -> Self {
         // Testkit is intended for manual testing, so we don't want `reqwest` to handle redirects
         // automatically.
-        let test_client = ClientBuilder::new()
+        let inner = ClientBuilder::new()
             .redirect(RedirectPolicy::none())
             .build()
             .unwrap();
+
+        let test_server = create_test_server(aggregator);
+        let test_client = TestKitApiClient {
+            test_server_url: test_server.url(""),
+            inner,
+        };
+
         Self {
-            test_server: create_test_server(aggregator),
+            _test_server_handle: test_server,
             test_client,
             api_sender,
         }
-    }
-
-    /// Returns the resolved URL for the public API.
-    pub fn public_url(&self, url: &str) -> String {
-        self.test_server.url(&format!("public/{}", url))
     }
 
     /// Sends a transaction to the node.
@@ -148,11 +150,58 @@ impl TestKitApi {
             .expect("Cannot broadcast transaction");
     }
 
+    /// Returns the resolved URL for the public API.
+    pub fn public_url(&self, url: &str) -> String {
+        self.test_client.public_url(url)
+    }
+
+    /// Returns the resolved URL for the private API.
+    pub fn private_url(&self, url: &str) -> String {
+        self.test_client.private_url(url)
+    }
+
+    /// Creates a requests builder for the public API scope.
+    pub fn public(&self, kind: impl Display) -> RequestBuilder<'_, '_> {
+        self.test_client.public(kind)
+    }
+
+    /// Creates a requests builder for the private API scope.
+    pub fn private(&self, kind: impl Display) -> RequestBuilder<'_, '_> {
+        self.test_client.private(kind)
+    }
+
+    /// Return reference to the underlying API client.
+    pub fn client(&self) -> &TestKitApiClient {
+        &self.test_client
+    }
+}
+
+/// An asynchronous API client to make Requests with.
+/// 
+/// This client is wrapper around the `reqwest::Client` to provide more convenient
+/// way to test API.
+#[derive(Debug, Clone)]
+pub struct TestKitApiClient {
+    test_server_url: String,
+    inner: Client,
+}
+
+impl TestKitApiClient {
+    /// Returns the resolved URL for the public API.
+    pub fn public_url(&self, url: &str) -> String {
+        format!("{}/public/{}", self.test_server_url, url)
+    }
+
+    /// Returns the resolved URL for the private API.
+    pub fn private_url(&self, url: &str) -> String {
+        format!("{}/private/{}", self.test_server_url, url)
+    }
+
     /// Creates a requests builder for the public API scope.
     pub fn public(&self, kind: impl Display) -> RequestBuilder<'_, '_> {
         RequestBuilder::new(
-            self.test_server.url(""),
-            &self.test_client,
+            &self.test_server_url,
+            &self.inner,
             ApiAccess::Public,
             kind.to_string(),
         )
@@ -161,11 +210,16 @@ impl TestKitApi {
     /// Creates a requests builder for the private API scope.
     pub fn private(&self, kind: impl Display) -> RequestBuilder<'_, '_> {
         RequestBuilder::new(
-            self.test_server.url(""),
-            &self.test_client,
+            &self.test_server_url,
+            &self.inner,
             ApiAccess::Private,
             kind.to_string(),
         )
+    }
+
+    /// Return reference to the inner Reqwest client.
+    pub fn inner(&self) -> &Client {
+        &self.inner
     }
 }
 
@@ -174,7 +228,7 @@ type ReqwestModifier<'b> = Box<dyn FnOnce(ReqwestBuilder) -> ReqwestBuilder + 'b
 /// An HTTP requests builder. This type can be used to send requests to
 /// the appropriate `TestKitApi` handlers.
 pub struct RequestBuilder<'a, 'b, Q = ()> {
-    test_server_url: String,
+    test_server_url: &'a str,
     test_client: &'a Client,
     access: ApiAccess,
     prefix: String,
@@ -201,7 +255,7 @@ where
     Q: 'b + Serialize,
 {
     fn new(
-        test_server_url: String,
+        test_server_url: &'a str,
         test_client: &'a Client,
         access: ApiAccess,
         prefix: String,

--- a/test-suite/testkit/src/lib.rs
+++ b/test-suite/testkit/src/lib.rs
@@ -114,7 +114,7 @@
 )]
 
 pub use crate::{
-    api::{ApiKind, RequestBuilder, TestKitApi},
+    api::{ApiKind, RequestBuilder, TestKitApi, TestKitApiClient},
     builder::TestKitBuilder,
     network::{TestNetwork, TestNode},
 };


### PR DESCRIPTION
This client allows to write code such this.

```rust
let client = testkit_api.client();
// This code doesn't work with the `testkit_api` because it doesn't implement `Send`.
tokio::spawn(async move {
    // But works fine with the underlying client.
    client.get(...)
});
```