### PR TITLE
Make public constants in cli::command::generate_config module [ECR-4341]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### New Features
+
+#### exonum-cli
+
+- Several constants in the `command` module became public. (#1821)
+
 ## 1.0.0-rc.2 - 2020-03-13
 
 ### Breaking changes

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -16,7 +16,10 @@
 
 pub use self::{
     finalize::Finalize,
-    generate_config::GenerateConfig,
+    generate_config::{
+        GenerateConfig, DEFAULT_EXONUM_LISTEN_PORT, MASTER_KEY_FILE_NAME, PRIVATE_CONFIG_FILE_NAME,
+        PUBLIC_CONFIG_FILE_NAME,
+    },
     generate_template::GenerateTemplate,
     maintenance::{Maintenance, MaintenanceAction},
     run::{NodeRunConfig, Run},


### PR DESCRIPTION
Make constants in `cli::command::generate_config` module public, as they are important for implementation of custom commands.