### PR TITLE
Rework exonum_cli::RunDev [ECR-4354]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   after the launch. `artifacts-dir` parameter has been renamed to
   `blockchain-path`. Configuration files are now stored inside `config`
   subdirectory. (#1822)
+
 ### New Features
 
 #### exonum-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Breaking changes
+
+#### exonum-cli
+
+- `run-dev` command has been reworked. It now does not clear database files
+  after the launch. `artifacts-dir` parameter has been renamed to
+  `blockchain-path`. Configuration files are now stored inside `config`
+  subdirectory. (#1822)
+
 ## 1.0.0-rc.2 - 2020-03-13
 
 ### Breaking changes

--- a/cli/src/command/run_dev.rs
+++ b/cli/src/command/run_dev.rs
@@ -104,7 +104,7 @@ impl ExonumCommand for RunDev {
 
         let generate_config = GenerateConfig {
             common_config: common_config_path,
-            output_dir: config_dir.clone(),
+            output_dir: config_dir,
             peer_address: "127.0.0.1:6200".parse().unwrap(),
             listen_address: None,
             no_password: true,
@@ -118,7 +118,7 @@ impl ExonumCommand for RunDev {
         let finalize = Finalize {
             private_config_path,
             output_config_path: node_config_path.clone(),
-            public_configs: vec![public_config_path.clone()],
+            public_configs: vec![public_config_path],
             public_api_address: Some(self.public_api_address),
             private_api_address: Some(self.private_api_address),
             public_allow_origin: Some(public_origins),

--- a/cli/src/command/run_dev.rs
+++ b/cli/src/command/run_dev.rs
@@ -40,7 +40,7 @@ pub struct RunDev {
     /// are located in <blockchain_path>/config directory. Existing files and directories are
     /// reused. To generate new node configuration and start a new blockchain, the user must
     /// use --clean flag or specify an another directory.
-    #[structopt(long)]
+    #[structopt(long, short = "-p")]
     pub blockchain_path: PathBuf,
     /// Listen address for node public API.
     ///

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -217,7 +217,7 @@ impl NodeBuilder {
         let temp_dir = TempDir::new()?;
         let mut this = Self::with_args(vec![
             OsString::from("run-dev"),
-            OsString::from("--artifacts-dir"),
+            OsString::from("--blockchain-path"),
             temp_dir.path().into(),
         ]);
         this.temp_dir = Some(temp_dir);

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -190,14 +190,6 @@ fn is_run_node_config(result: StandardResult) -> bool {
     }
 }
 
-fn touch(path: impl AsRef<Path>) {
-    OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path)
-        .unwrap();
-}
-
 fn copy_secured(from: impl AsRef<Path>, to: impl AsRef<Path>) -> anyhow::Result<()> {
     let mut source_file = fs::File::open(&from)?;
 
@@ -469,21 +461,14 @@ fn test_full_workflow() {
 fn test_run_dev() {
     let env = ConfigSpec::new_without_pass();
 
-    let artifacts_dir = env.output_dir().join("artifacts");
-    // Mocks existence of old DB files that are supposed to be cleaned up.
-    let db_dir = artifacts_dir.join("db");
-    fs::create_dir_all(&db_dir).unwrap();
-    let old_db_file = db_dir.join("content.foo");
-    touch(&old_db_file);
+    let blockchain_dir = env.output_dir().join("blockchain");
     // Checks run-dev command.
     let feedback = env
         .command("run-dev")
-        .with_arg("-a")
-        .with_arg(&artifacts_dir)
+        .with_arg("--blockchain-path")
+        .with_arg(&blockchain_dir)
         .run();
     assert!(is_run_node_config(feedback.unwrap()));
-    // Tests cleaning up.
-    assert!(!old_db_file.exists());
 }
 
 #[test]

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -470,6 +470,8 @@ fn test_run_dev() {
     let env = ConfigSpec::new_without_pass();
 
     let blockchain_dir = env.output_dir().join("blockchain");
+
+    let old_db_file = mock_old_db_files(&blockchain_dir);
     // Checks run-dev command.
     let feedback = env
         .command("run-dev")
@@ -477,6 +479,8 @@ fn test_run_dev() {
         .with_arg(&blockchain_dir)
         .run();
     assert!(is_run_node_config(feedback.unwrap()));
+    // By default, no cleanup is done
+    assert!(old_db_file.exists());
 }
 
 #[test]
@@ -484,11 +488,8 @@ fn test_run_dev_with_cleanup() {
     let env = ConfigSpec::new_without_pass();
 
     let blockchain_dir = env.output_dir().join("blockchain");
-    // Mocks existence of old DB files that are supposed to be cleaned up.
-    let db_dir = blockchain_dir.join("db");
-    fs::create_dir_all(&db_dir).unwrap();
-    let old_db_file = db_dir.join("content.foo");
-    touch(&old_db_file);
+
+    let old_db_file = mock_old_db_files(&blockchain_dir);
     // Checks run-dev command.
     let feedback = env
         .command("run-dev")
@@ -576,6 +577,14 @@ fn different_supervisor_modes_in_public_configs() -> anyhow::Result<()> {
         .to_string()
         .contains("Found public configs with different general configuration."));
     Ok(())
+}
+
+fn mock_old_db_files(blockchain_dir: &PathBuf) -> PathBuf {
+    let db_dir = blockchain_dir.join("db");
+    fs::create_dir_all(&db_dir).unwrap();
+    let old_db_file = db_dir.join("content.foo");
+    touch(&old_db_file);
+    old_db_file
 }
 
 fn public_config(supervisor_mode: SupervisorMode) -> NodePublicConfig {

--- a/cli/tests/node.rs
+++ b/cli/tests/node.rs
@@ -95,7 +95,7 @@ async fn node_basic_workflow() -> anyhow::Result<()> {
     let dir_path = dir.path().as_os_str();
     let args = vec![
         "run-dev".as_ref(),
-        "-a".as_ref(),
+        "--blockchain-path".as_ref(),
         dir_path,
         "--public-api-address".as_ref(),
         public_addr.as_ref(),


### PR DESCRIPTION
## Overview

- `artifacts_dir` param renamed to `blockchain_path`
- removed cleaning of database files
- configuration files now stored in `config` subdirectory.

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-4354
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
