### PR TITLE
Supervisor brush-up [ECR-4346]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,25 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Breaking changes
+
+#### exonum-supervisor
+
+- `MigrationRequest` was made non-exhaustive. (#1823)
+
+- `POST` endpoints now expect JSON-encoded input rather than
+  hex-encoded Protobuf. (#1823)
+
 ### New Features
 
 #### exonum-cli
 
 - Several constants in the `command` module became public. (#1821)
+
+#### exonum-supervisor
+
+- `DeployRequest` and `MigrationRequest` now have cryptographic seeds
+  to retry the same request multiple times. (#1823)
 
 ## 1.0.0-rc.2 - 2020-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `POST` endpoints now expect JSON-encoded input rather than
   hex-encoded Protobuf. (#1823)
 
+- `supervisor_name` method was removed. Use `Supervisor::NAME` instead. (#1823)
+
 ### New Features
 
 #### exonum-cli

--- a/examples/cryptocurrency-advanced/backend/src/migrations/tests.rs
+++ b/examples/cryptocurrency-advanced/backend/src/migrations/tests.rs
@@ -167,11 +167,11 @@ fn test_with_full_lifecycle() {
     assert!(block.errors.is_empty());
 
     // Then, we can launch the migration.
-    let migration_req = MigrationRequest {
-        new_artifact: CryptocurrencyService.artifact_id(),
-        service: OldService::INSTANCE_NAME.to_owned(),
-        deadline_height: Height(100),
-    };
+    let mut migration_req = MigrationRequest::new(
+        CryptocurrencyService.artifact_id(),
+        OldService::INSTANCE_NAME,
+        Height(100),
+    );
     let migration = admin_keys.request_migration(SUPERVISOR_ID, migration_req.clone());
     let block = testkit.create_block_with_transaction(migration);
     assert!(block.errors.is_empty());
@@ -192,10 +192,7 @@ fn test_with_full_lifecycle() {
     assert_eq!(*service_state.data_version(), new_version);
 
     // Reassign the service artifact and resume it.
-    let migration_req = MigrationRequest {
-        deadline_height: testkit.height(),
-        ..migration_req
-    };
+    migration_req.deadline_height = testkit.height();
     let resume_service = ConfigPropose::immediate(1).resume_service(SERVICE_ID, ());
     let block = testkit.create_block_with_transactions(vec![
         admin_keys.request_migration(SUPERVISOR_ID, migration_req),

--- a/services/supervisor/Cargo.toml
+++ b/services/supervisor/Cargo.toml
@@ -15,6 +15,7 @@ description = "Exonum supervisor service."
 [dependencies]
 anyhow = "1.0.26"
 byteorder = { version = "1.2.7", features = [ "i128" ] }
+hex-buffer-serde = "0.2.1"
 futures = "0.3.4"
 serde = "1.0.0"
 serde_derive = "1.0.0"

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -637,6 +637,9 @@ pub struct DeployInfoQuery {
     pub spec: String,
     /// Deadline height.
     pub deadline_height: u64,
+    /// Seed to distinguish among deploys with the same params.
+    #[serde(default)]
+    pub seed: u64,
 }
 
 impl TryFrom<DeployInfoQuery> for DeployRequest {
@@ -659,6 +662,7 @@ impl TryFrom<DeployInfoQuery> for DeployRequest {
             artifact,
             spec,
             deadline_height,
+            seed: query.seed,
         };
 
         Ok(request)
@@ -675,6 +679,7 @@ impl From<DeployRequest> for DeployInfoQuery {
             artifact,
             spec,
             deadline_height,
+            seed: request.seed,
         }
     }
 }
@@ -792,10 +797,10 @@ impl PrivateApi {
     /// by the current node, and returns its hash.
     async fn deploy_artifact(
         state: ServiceApiState,
-        artifact: DeployRequest,
+        request: DeployRequest,
     ) -> Result<Hash, api::Error> {
         Self::broadcaster(&state)?
-            .request_artifact_deploy((), artifact)
+            .request_artifact_deploy((), request)
             .await
             .map_err(|err| api::Error::internal(err).title("Artifact deploy request failed"))
     }

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -20,9 +20,9 @@
 //!
 //! - Public API:
 //!
-//!     - [Obtaining consensus configuration](#obtaining-consensus-configuration)
-//!     - [Obtaining pending configuration proposal](#obtaining-pending-configuration-proposal)
-//!     - [Obtaining deployed artifacts and services](#obtaining-deployed-artifacts-and-services)
+//!     - [Obtain consensus configuration](#obtain-consensus-configuration)
+//!     - [Obtain pending configuration proposal](#obtain-pending-configuration-proposal)
+//!     - [Obtain deployed artifacts and services](#obtain-deployed-artifacts-and-services)
 //!
 //! - Private API:
 //!
@@ -31,13 +31,13 @@
 //!     - [Request to accept new configuration](#request-to-accept-new-configuration)
 //!     - [Vote for configuration proposal](#vote-for-configuration-proposal)
 //!     - [Obtain current configuration number](#obtain-current-configuration-number)
-//!     - [Obtain current supervisor operating mode](#obtain-current-supervisor-operating-mode)
-//!     - [Check the deployment status](#check-deployment-status)
-//!     - [Check the migration status](#check-migration-status)
+//!     - [Obtain supervisor configuration](#obtain-supervisor-configuration)
+//!     - [Check deployment status](#check-deployment-status)
+//!     - [Check migration status](#check-migration-status)
 //!
 //! # Public API
 //!
-//! ## Obtaining Consensus Configuration
+//! ## Obtain Consensus Configuration
 //!
 //! | Property    | Value |
 //! |-------------|-------|
@@ -71,7 +71,7 @@
 //! # }
 //! ```
 //!
-//! ## Obtaining Pending Configuration Proposal
+//! ## Obtain Pending Configuration Proposal
 //!
 //! | Property    | Value |
 //! |-------------|-------|
@@ -107,7 +107,7 @@
 //! # }
 //! ```
 //!
-//! ## Obtaining Deployed Artifacts And Services
+//! ## Obtain Deployed Artifacts And Services
 //!
 //! | Property    | Value |
 //! |-------------|-------|
@@ -458,7 +458,7 @@
 //! # }
 //! ```
 //!
-//! ## Obtaining Supervisor Configuration
+//! ## Obtain Supervisor Configuration
 //!
 //! | Property    | Value |
 //! |-------------|-------|
@@ -492,7 +492,7 @@
 //! # }
 //! ```
 //!
-//! ## Check the Deployment Status
+//! ## Check Deployment Status
 //!
 //! | Property    | Value |
 //! |-------------|-------|
@@ -553,7 +553,7 @@
 //! # }
 //! ```
 //!
-//! ## Check the Migration Status
+//! ## Check Migration Status
 //!
 //! | Property    | Value |
 //! |-------------|-------|

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -253,11 +253,11 @@
 //! // Migration request creation skipped...
 //! let migration_request = // Migration of some service.
 //! #     // Request migration of supervisor for simplicity.
-//! #     MigrationRequest {
-//! #         new_artifact: Supervisor.artifact_id(),
-//! #         service: Supervisor::NAME.to_owned(),
-//! #         deadline_height: Height(10),
-//! #     };
+//! #     MigrationRequest::new(
+//! #         Supervisor.artifact_id(),
+//! #         Supervisor::NAME,
+//! #         Height(10),
+//! #     );
 //!
 //! // `migration_request` will be automatically serialized to hexadecimal string.
 //! let tx_hash: Hash = testkit
@@ -580,11 +580,11 @@
 //! let mut testkit = // Same as in previous example...
 //! #     TestKitBuilder::validator().with(Supervisor::simple()).build();
 //! let migration_request: MigrationRequest = // Some previously performed migration request.
-//! #     MigrationRequest {
-//! #         new_artifact: Supervisor.artifact_id(),
-//! #         service: Supervisor::NAME.to_owned(),
-//! #         deadline_height: Height(10),
-//! #     };
+//! #     MigrationRequest::new(
+//! #         Supervisor.artifact_id(),
+//! #         Supervisor::NAME,
+//! #         Height(10),
+//! #     );
 //! # // Request migration. It will fail, but we'll be able to request its state.
 //! # let _hash: Hash = testkit
 //! #     .api()

--- a/services/supervisor/src/api.rs
+++ b/services/supervisor/src/api.rs
@@ -696,6 +696,9 @@ pub struct MigrationInfoQuery {
     pub service: String,
     /// Deadline height.
     pub deadline_height: u64,
+    /// Seed to allow several migrations with the same params.
+    #[serde(default)]
+    pub seed: u64,
 }
 
 impl TryFrom<MigrationInfoQuery> for MigrationRequest {
@@ -713,6 +716,7 @@ impl TryFrom<MigrationInfoQuery> for MigrationRequest {
             new_artifact,
             service: query.service,
             deadline_height,
+            seed: query.seed,
         };
 
         Ok(request)
@@ -728,6 +732,7 @@ impl From<MigrationRequest> for MigrationInfoQuery {
             new_artifact,
             service: request.service,
             deadline_height,
+            seed: request.seed,
         }
     }
 }

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -45,7 +45,9 @@
 //! Key point here is that user **should not** send transactions to the supervisor by himself.
 //!
 //! To deploy an artifact, one (within the "simple" mode) or majority (within the "decentralized" mode)
-//! of the nodes should receive a [`DeployRequest`] message through API.
+//! of the nodes should receive a [`DeployRequest`] message through API. You may use the `seed`
+//! field of `DeployRequest` to retry the request with the same params. To check the current
+//! status of a request, you may use the `deploy-status` endpoint.
 //!
 //! To request a config change, one node should submit a [`ConfigPropose`] message through API.
 //! For the "simple" mode no more actions are required. For the "decentralized" mode the majority of the nodes
@@ -61,7 +63,8 @@
 //! Supervisor service provides a functionality to perform data migrations for services.
 //! Request for migration is sent through private REST API and contains the name of instance
 //! to migrate, end artifact version to achieve after migration, and deadline height until which
-//! migration should be completed.
+//! migration should be completed. Similar to artifact deployment, you may check the request
+//! status via the `migration-status` endpoint.
 //!
 //! ### Requirements
 //!
@@ -89,8 +92,8 @@
 //! lack of report at the deadline height), migration is considered failed and rolled back.
 //!
 //! After fixing the reason for migration failure, the migration attempt can be performed once again.
-//! It will require a different deadline height though, since `MigrationRequest` objects are considered
-//! unique and supervisor won't attempt to perform the same `MigrationRequest` again.
+//! It will require a different deadline height or a different seed, since `MigrationRequest` objects
+//! are considered unique and supervisor won't attempt to perform the same `MigrationRequest` again.
 //!
 //! ### Complex Migrations
 //!
@@ -99,7 +102,7 @@
 //! and 0.2 -> 0.3), supervisor will execute one migration script at the time.
 //!
 //! After the first migration request to version 0.3, migration will be performed for version 0.2,
-//! and you need to create the same migration request with a different deadline height.
+//! and you need to create the same migration request with a different deadline height or seed.
 //! After the second migration request, the version will be updated to 0.3.
 //!
 //! To put it simply, you may need to perform the same migration request several times until every

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -186,11 +186,6 @@ mod proto_structures;
 mod schema;
 mod transactions;
 
-/// Returns the `Supervisor` entity name.
-pub const fn supervisor_name() -> &'static str {
-    Supervisor::NAME
-}
-
 /// Error message emitted when the `Supervisor` is installed as a non-privileged service.
 const NOT_SUPERVISOR_MSG: &str = "`Supervisor` is installed as a non-privileged service. \
                                   For correct operation, `Supervisor` needs to have numeric ID 0.";

--- a/services/supervisor/src/proto/service.proto
+++ b/services/supervisor/src/proto/service.proto
@@ -33,6 +33,8 @@ message DeployRequest {
   bytes spec = 2;
   // The height until which the deployment procedure should be completed.
   uint64 deadline_height = 3;
+  // Seed to allow several deployments with the same params.
+  uint64 seed = 4;
 }
 
 // Confirmation that artifact deployment has ended for a validator.
@@ -143,6 +145,8 @@ message MigrationRequest {
   string service = 2;
   // The height until which the migration procedure should be completed.
   uint64 deadline_height = 3;
+  // Seed to allow several migrations with the same params.
+  uint64 seed = 4;
 }
 
 // Confirmation that migration has ended for a validator.

--- a/services/supervisor/src/proto_structures.rs
+++ b/services/supervisor/src/proto_structures.rs
@@ -55,12 +55,16 @@ pub struct DeployRequest {
     /// Artifact identifier.
     pub artifact: ArtifactId,
 
-    /// Additional information for the runtime to deploy.
+    /// Additional information for the runtime necessary to deploy the artifact.
     #[serde(with = "HexForm")]
     pub spec: Vec<u8>,
 
     /// The height until which the deployment procedure should be completed.
     pub deadline_height: Height,
+
+    /// Seed to allow several deployments with the same params.
+    #[serde(default)]
+    pub seed: u64,
 }
 
 impl DeployRequest {
@@ -70,6 +74,7 @@ impl DeployRequest {
             artifact,
             deadline_height,
             spec: Vec::new(),
+            seed: 0,
         }
     }
 
@@ -118,8 +123,10 @@ impl DeployResult {
 pub struct StartService {
     /// Artifact identifier.
     pub artifact: ArtifactId,
+
     /// Instance name.
     pub name: String,
+
     /// Instance configuration.
     #[serde(with = "HexForm")]
     pub config: Vec<u8>,
@@ -348,13 +355,36 @@ impl From<ConfigPropose> for ConfigVote {
 #[derive(Debug, Clone, PartialEq, ProtobufConvert, BinaryValue, ObjectHash)]
 #[derive(Serialize, Deserialize)]
 #[protobuf_convert(source = "proto::MigrationRequest")]
+#[non_exhaustive]
 pub struct MigrationRequest {
     /// New artifact identifier.
     pub new_artifact: ArtifactId,
+
     /// Name of service for a migration.
     pub service: String,
+
     /// The height until which the migration procedure should be completed.
     pub deadline_height: Height,
+
+    /// Seed to allow several migrations with the same params.
+    #[serde(default)]
+    pub seed: u64,
+}
+
+impl MigrationRequest {
+    /// Creates a new migration request.
+    pub fn new(
+        new_artifact: ArtifactId,
+        service: impl Into<String>,
+        deadline_height: Height,
+    ) -> Self {
+        Self {
+            new_artifact,
+            service: service.into(),
+            deadline_height,
+            seed: 0,
+        }
+    }
 }
 
 /// Confirmation that migration has ended for a validator.

--- a/services/supervisor/src/transactions.rs
+++ b/services/supervisor/src/transactions.rs
@@ -825,6 +825,12 @@ impl Supervisor {
         deploy_request: &DeployRequest,
         error: ExecutionError,
     ) {
+        log::warn!(
+            "Deploying artifact for request {:?} failed. Reason: {}",
+            deploy_request,
+            error
+        );
+
         let height = context.data().for_core().height();
         let mut schema = SchemaImpl::new(context.service_data());
 
@@ -912,14 +918,14 @@ impl Supervisor {
     ) -> Result<(), ExecutionError> {
         if initiate_rollback {
             log::warn!(
-                "Migration for a request {:?} failed. Error: '{}'. \
+                "Migration for a request {:?} failed. Reason: {}. \
                  This migration is going to be rolled back.",
                 request,
                 error
             );
         } else {
             log::warn!(
-                "Migration for a request {:?} failed to start. Error: '{}'.",
+                "Migration for a request {:?} failed to start. Reason: {}.",
                 request,
                 error
             );

--- a/services/supervisor/src/transactions.rs
+++ b/services/supervisor/src/transactions.rs
@@ -139,14 +139,14 @@ impl StartService {
             .ok_or_else(|| {
                 let msg = format!(
                     "Discarded start of service `{}` from the unknown artifact `{}`.",
-                    self.name, self.artifact.name,
+                    self.name, self.artifact,
                 );
                 ArtifactError::UnknownArtifact.with_description(msg)
             })?;
         if artifact_state.status != ArtifactStatus::Active {
             let msg = format!(
                 "Discarded start of service `{}` from the non-active artifact `{}`.",
-                self.name, self.artifact.name,
+                self.name, self.artifact,
             );
             return Err(ArtifactError::UnknownArtifact.with_description(msg));
         }

--- a/services/supervisor/tests/simple.rs
+++ b/services/supervisor/tests/simple.rs
@@ -34,8 +34,7 @@ use exonum_rust_runtime::{
 use exonum_testkit::{ApiKind, TestKit, TestKitBuilder};
 
 use exonum_supervisor::{
-    supervisor_name, ConfigPropose, Configure, DeployRequest, Schema, Supervisor,
-    SupervisorInterface,
+    ConfigPropose, Configure, DeployRequest, Schema, Supervisor, SupervisorInterface,
 };
 
 pub fn sign_config_propose_transaction(
@@ -118,7 +117,7 @@ impl Configure for ConfigChangeService {
 
 fn assert_config_change_is_applied(testkit: &TestKit) {
     let snapshot = testkit.snapshot();
-    let schema: Schema<_> = snapshot.service_schema(supervisor_name()).unwrap();
+    let schema: Schema<_> = snapshot.service_schema(Supervisor::NAME).unwrap();
     assert!(!schema.pending_proposal.exists());
 }
 
@@ -302,7 +301,7 @@ async fn test_send_proposal_with_api() {
 
     // Assert that config is now pending.
     let snapshot = testkit.snapshot();
-    let schema: Schema<_> = snapshot.service_schema(supervisor_name()).unwrap();
+    let schema: Schema<_> = snapshot.service_schema(Supervisor::NAME).unwrap();
     assert_eq!(
         schema.pending_proposal.get().unwrap().config_propose,
         config_propose

--- a/services/supervisor/tests/supervisor/migrations/mod.rs
+++ b/services/supervisor/tests/supervisor/migrations/mod.rs
@@ -237,11 +237,11 @@ async fn migration() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV02.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV02.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -289,11 +289,11 @@ async fn migration_two_scripts_sequential() {
 
     // Request migration to 0.2.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV02.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV02.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -312,11 +312,11 @@ async fn migration_two_scripts_sequential() {
 
     // Request migration to 0.5.
     let deadline_height = Height(DEADLINE_HEIGHT.0 * 2);
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV05.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV05.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -360,11 +360,11 @@ async fn migration_fail() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: FailingMigrationServiceV07.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        FailingMigrationServiceV07.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -389,11 +389,11 @@ async fn complex_migration() {
     // Request migration to 0.5.
     // This migration will require two migration requests.
     let deadline_height = DEADLINE_HEIGHT;
-    let mut request = MigrationRequest {
-        new_artifact: MigrationServiceV05.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let mut request = MigrationRequest::new(
+        MigrationServiceV05.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -443,11 +443,11 @@ async fn no_migration_support() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV05.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV05.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     // Despite the fact that migration should fail, the transaction with request
     // should be executed successfully.
@@ -481,11 +481,11 @@ async fn migration_consensus() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV02.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV02.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -540,11 +540,11 @@ async fn migration_no_consensus() {
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
     let new_artifact = MigrationServiceV02.artifact_id();
-    let request = MigrationRequest {
-        new_artifact: new_artifact.clone(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        new_artifact.clone(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
     send_migration_request(&mut testkit, request.clone()).await;
 
     // Check that the target artifact cannot be unloaded now.
@@ -619,11 +619,11 @@ async fn migration_hash_divergence() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV02.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV02.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -683,11 +683,11 @@ async fn fast_forward_migration() {
 
     // Request migration.
     let deadline_height = DEADLINE_HEIGHT;
-    let request = MigrationRequest {
-        new_artifact: MigrationServiceV01_1.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let request = MigrationRequest::new(
+        MigrationServiceV01_1.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 
@@ -711,11 +711,11 @@ async fn mixed_migration() {
     // Request migration to 0.5.1.
     // This migration will require three migration requests.
     let deadline_height = DEADLINE_HEIGHT;
-    let mut request = MigrationRequest {
-        new_artifact: MigrationServiceV05_1.artifact_id(),
-        service: MigrationService::INSTANCE_NAME.into(),
+    let mut request = MigrationRequest::new(
+        MigrationServiceV05_1.artifact_id(),
+        MigrationService::INSTANCE_NAME,
         deadline_height,
-    };
+    );
 
     send_migration_request(&mut testkit, request.clone()).await;
 

--- a/services/supervisor/tests/supervisor/supervisor_config.rs
+++ b/services/supervisor/tests/supervisor/supervisor_config.rs
@@ -19,14 +19,14 @@
 use exonum::runtime::{SnapshotExt, SUPERVISOR_INSTANCE_ID};
 use exonum_testkit::{ApiKind, Spec, TestKit, TestKitBuilder};
 
-use exonum_supervisor::{supervisor_name, ConfigPropose, Schema, Supervisor, SupervisorConfig};
+use exonum_supervisor::{ConfigPropose, Schema, Supervisor, SupervisorConfig};
 
 use crate::{config_api::create_proposal, utils::CFG_CHANGE_HEIGHT};
 
 /// Asserts that current supervisor configuration equals to the provided one.
 fn assert_supervisor_config(testkit: &TestKit, config: SupervisorConfig) {
     let snapshot = testkit.snapshot();
-    let schema: Schema<_> = snapshot.service_schema(supervisor_name()).unwrap();
+    let schema: Schema<_> = snapshot.service_schema(Supervisor::NAME).unwrap();
     let current_config = schema.configuration.get().unwrap();
     assert_eq!(current_config, config);
 }

--- a/services/supervisor/tests/supervisor/utils.rs
+++ b/services/supervisor/tests/supervisor/utils.rs
@@ -27,8 +27,7 @@ use crate::{
     SERVICE_NAME as CONFIG_SERVICE_NAME,
 };
 use exonum_supervisor::{
-    supervisor_name, ConfigChange, ConfigPropose, ConfigVote, Schema, Supervisor,
-    SupervisorInterface,
+    ConfigChange, ConfigPropose, ConfigVote, Schema, Supervisor, SupervisorInterface,
 };
 
 pub const CFG_CHANGE_HEIGHT: Height = Height(3);
@@ -37,7 +36,7 @@ pub const SECOND_SERVICE_NAME: &str = "change-service";
 
 pub fn config_propose_entry(testkit: &TestKit) -> Option<ConfigPropose> {
     let snapshot = testkit.snapshot();
-    let schema: Schema<_> = snapshot.service_schema(supervisor_name()).unwrap();
+    let schema: Schema<_> = snapshot.service_schema(Supervisor::NAME).unwrap();
     schema
         .pending_proposal
         .get()


### PR DESCRIPTION
## Overview

This PR fixes miscellaneous issues with the supervisor service:

- Error descriptions are made more complete and are logged when appropriate.
- `seed` fields are added into `DeployRequest` and `MigrateRequest`
- Navigation in the API docs is fixed
- ⚠️ Serialization is changed for supervisor POST endpoints, from hex-encoded Protobuf to ordinary JSON. This certainly breaks launcher and may break other stuff. It *seems* that the change doesn't affect supervisor soundness, but I may be mistaken.

---

See: https://jira.bf.local/browse/ECR-4346