### PR TITLE
Allow to POST Protobuf messages from `TestKitApi` [ECR-3948]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### New Features
 
+#### exonum-cli
+
+- Several constants in the `command` module became public. (#1821)
+
 #### exonum-node
 
 - Exonum nodes can now customize how they create block proposals. This can be
@@ -41,11 +45,21 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   algorithm. This can be used to keep a "heartbeat" when the network load is low
   without bloating the storage used by the nodes. (#1820)
 
-#### exonum-cli
+#### exonum-rust-runtime
 
-- Several constants in the `command` module became public. (#1821)
+- `ServiceApiScope::pb_endpoint_mut` allows to accept Protobuf-encoded messages
+  with the request content type set to `application/octet-stream` in addition
+  to JSON-encoded messages. (#1829)
+
+#### exonum-testkit
+
+- Testkit can send Protobuf-encoded payloads to POST endpoints. (#1831)
 
 ### Bug Fixes
+
+#### exonum-api
+
+- Introduced a workaround for the HTTP restart hanging up on Windows. (#1828)
 
 #### exonum-node
 
@@ -53,16 +67,15 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   This could lead to consensus failure or weird error messages in the node log.
   (#1820)
 
+#### exonum-rust-runtime
+
+- Fixed updating HTTP endpoints if the Rust runtime does not contain
+  active services during node start. (#1831)
+
 #### exonum-supervisor
 
 - `DeployRequest` and `MigrationRequest` now have cryptographic seeds
   to retry the same request multiple times. (#1823)
-
-### Bug Fixes
-
-#### exonum-api
-
-- Introduced a workaround for the HTTP restart hanging up on Windows. (#1828)
 
 ## 1.0.0-rc.2 - 2020-03-13
 

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -53,6 +53,7 @@ deserializing
 DESTDIR
 diffie
 discriminants
+doctest
 doctests
 emsp
 encodable

--- a/runtimes/rust/src/lib.rs
+++ b/runtimes/rust/src/lib.rs
@@ -494,7 +494,10 @@ impl RustRuntimeBuilder {
             deployed_artifacts: HashSet::new(),
             started_services: BTreeMap::new(),
             started_services_by_name: HashMap::new(),
-            changed_services_since_last_block: false,
+            changed_services_since_last_block: true,
+            // ^-- We set this flag to `true` to propagate initial changes to API (which always
+            // include the runtime API) after the runtime is resumed or the genesis block
+            // is created.
         }
     }
 

--- a/test-suite/rust-runtime-proto/src/tests.rs
+++ b/test-suite/rust-runtime-proto/src/tests.rs
@@ -312,7 +312,7 @@ async fn request_to_pb_endpoint() -> anyhow::Result<()> {
         .await?;
     assert_eq!(response, transfer);
 
-    // Send `Transfer` using Protobuf encoding.
+    // Send `Transfer` using Protobuf encoding manually.
     let proto_bytes = transfer.to_bytes();
     let url = api.public_url("api/services/test-runtime-api/transfer");
     let response: Transfer = Client::new()
@@ -323,6 +323,14 @@ async fn request_to_pb_endpoint() -> anyhow::Result<()> {
         .await?
         .error_for_status()?
         .json()
+        .await?;
+    assert_eq!(response, transfer);
+
+    // Send `Transfer` using testkit API.
+    let response: Transfer = api
+        .public(ApiKind::Service("test-runtime-api"))
+        .query(&transfer)
+        .post_pb("transfer")
         .await?;
     assert_eq!(response, transfer);
 

--- a/test-suite/rust-runtime-proto/src/tests.rs
+++ b/test-suite/rust-runtime-proto/src/tests.rs
@@ -237,7 +237,6 @@ async fn core_protos_with_service() {
 }
 
 #[tokio::test]
-#[should_panic] // TODO: Remove `should_panic` after fix (ECR-3948)
 async fn core_protos_without_services() {
     let mut testkit = TestKitBuilder::validator().build();
     assert_exonum_core_protos(&testkit.api()).await;

--- a/test-suite/testkit/Cargo.toml
+++ b/test-suite/testkit/Cargo.toml
@@ -28,6 +28,7 @@ exonum-derive = { version = "1.0.0-rc.2", path = "../../components/derive" }
 exonum-explorer = { version = "1.0.0-rc.2", path = "../../components/explorer" }
 exonum-merkledb = { version = "1.0.0-rc.2", path = "../../components/merkledb" }
 exonum-node = { version = "1.0.0-rc.2", path = "../../exonum-node", optional = true }
+exonum-proto = { version = "1.0.0-rc.2", path = "../../components/proto" }
 exonum-rust-runtime = { version = "1.0.0-rc.2", path = "../../runtimes/rust" }
 
 actix = { version = "0.9.0", default-features = false }
@@ -35,6 +36,7 @@ actix-web = { version = "2.0.0", default-features = false }
 chrono = "0.4.6"
 futures = "0.3.4"
 log = "0.4.6"
+protobuf = "2.11.0"
 reqwest = { version = "0.10.2", features = ["json"] }
 serde = "1.0.10"
 serde_derive = "1.0"

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -72,8 +72,6 @@ impl fmt::Display for ApiKind {
     }
 }
 
-// TODO: Remove `no_run` in the doctest below after fix (ECR-3948)
-
 /// API encapsulation for the testkit. Allows to execute and asynchronously retrieve results
 /// for REST-ful endpoints of services.
 ///
@@ -89,7 +87,7 @@ impl fmt::Display for ApiKind {
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// # use exonum_testkit::{ApiKind, TestKitBuilder};
 /// use exonum_rust_runtime::{ProtoSourcesQuery, ProtoSourceFile};
 ///

--- a/test-suite/testkit/src/api.rs
+++ b/test-suite/testkit/src/api.rs
@@ -93,12 +93,15 @@ impl fmt::Display for ApiKind {
 ///
 /// #[tokio::test]
 /// async fn test_api() {
-/// # // Some shenanigans to not drop test code into the void
+/// # // Trick to execute the test code rather than dropping it; the content of `#[tokio::test]`s
+/// # // is dropped in doc tests.
 /// # }
 /// # #[tokio::main]
 /// # async fn main() {
 ///     let mut testkit = TestKitBuilder::validator().build();
 ///     let api = testkit.api();
+///     // Without services / plugins, API only contains endpoints
+///     // provided by the Rust runtime.
 ///     let proto_sources: Vec<ProtoSourceFile> = api
 ///         .public(ApiKind::RustRuntime)
 ///         .query(&ProtoSourcesQuery::Core)
@@ -432,10 +435,11 @@ where
     Q: ProtobufConvert,
     Q::ProtoStruct: protobuf::Message,
 {
-    /// Sends a POST request to the testing API endpoint and decodes response as
+    /// Sends a Protobuf-encoded POST request to the testing API endpoint and decodes response as
     /// the corresponding type.
     ///
     /// The query is serialized as Protobuf using `Content-Type: application/octet-stream`.
+    /// If the query was not specified, an empty buffer is used.
     pub async fn post_pb<R>(self, endpoint: &str) -> api::Result<R>
     where
         R: DeserializeOwned + 'static,


### PR DESCRIPTION
## Overview

This PR allows to send POST requests with Protobuf-encoded payloads, and also fixes a bug with API endpoints not being updated if there are no services associated with the Rust runtime.

---

See: https://jira.bf.local/browse/ECR-3948