### PR TITLE
Signal handling by Exonum nodes [ECR-4374]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ jobs:
   # Unit tests (including test runs for benchmarks).
   - name: unit-test
     script:
-    - cargo test --all --lib --tests --benches
+    - cargo test --all --lib --tests --benches --bins
 
   # Doc tests.
   - name: doc-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Replaced `CoreError::ServiceNotStopped` with the more general `InvalidServiceTransition`
   error. (#1806)
 
-### exonum-api
+#### exonum-api
 
 - Data types were made non-exhaustive where appropriate. (#1799)
 
@@ -173,7 +173,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - API data types were made non-exhaustive where appropriate. (#1799)
 
-### exonum-testkit
+#### exonum-testkit
 
 - `TestKitBuilder` was refactored to use a more intuitive set of interfaces
   for adding built-in artifacts and services to the blockchain. (#1800)
@@ -400,6 +400,12 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Protobuf declarations were organized according to their packages. (#1756)
 
+#### exonum-explorer
+
+- The field `content` of the `CommittedTransaction` struct and
+  the `InPool` variant of the `TransactionInfo` enum has been renamed
+  to `message`. (#1721)
+
 #### exonum-supervisor
 
 - `Supervisor` structure isn't generic anymore. (#1587)
@@ -454,7 +460,7 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 
 - Service interface methods now can be marked as removed. (#1707)
 
-### exonum-testkit
+#### exonum-testkit
 
 - The following public APIs were removed/made private: (#1629)
 
@@ -467,16 +473,10 @@ Indexes iterators names has been shortened to `Iter`, `Keys` and `Values`. (#162
 - `TestNode` now returns `KeyPair` instead of a `(PublicKey, SecretKey)`
   tuple. (#1761)
 
-### exonum-time
+#### exonum-time
 
 - Modules were made private, crate now provides re-exports of necessary types
   instead. (#1716)
-
-### exonum-explorer
-
-- The field `content` of the `CommittedTransaction` struct and
-  the `InPool` variant of the `TransactionInfo` enum has been renamed
-  to `message`. (#1721)
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### New Features
+
+#### exonum-node
+
+- Exonum nodes now gracefully terminate on receiving SIGINT or SIGTERM signals
+  (on Unix platforms), or a `ctrl + c` break (on Windows). (#1834)
+
 ## 1.0.0-rc.3 - 2020-03-25
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Breaking Changes
+
+#### exonum-api
+
+- `ApiManagerConfig` was made non-exhaustive. (#1834)
+
 ### New Features
 
 #### exonum-node
 
-- Exonum nodes now gracefully terminate on receiving SIGINT or SIGTERM signals
-  (on Unix platforms), or a `ctrl + c` break (on Windows). (#1834)
+- Exonum nodes now gracefully terminate on receiving SIGINT, SIGTERM
+  and SIGQUIT signals (on Unix platforms), or a `ctrl + c` break (on Windows).
+  These signal handlers may be switched off by using `NodeBuilder::disable_signals()`.
+  (#1834)
 
 ### Bug Fixes
 

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -169,8 +169,10 @@ serializable
 serialize
 serializer
 sharded
+SIGHUP
 SIGINT
 signum
+SIGQUIT
 SIGTERM
 smallvec
 socketaddr

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -169,7 +169,9 @@ serializable
 serialize
 serializer
 sharded
+SIGINT
 signum
+SIGTERM
 smallvec
 socketaddr
 sodiumoxide

--- a/exonum-node/Cargo.toml
+++ b/exonum-node/Cargo.toml
@@ -55,6 +55,11 @@ toml = "0.5.6"
 
 exonum-rust-runtime = { version = "1.0.0-rc.3", path = "../runtimes/rust" }
 
+# Unix-specific dependencies for the `signals` test.
+[target.'cfg(unix)'.dev_dependencies]
+nix = "0.17.0"
+rusty-fork = "0.2.2"
+
 [build-dependencies]
 exonum-build = { version = "1.0.0-rc.3", path = "../components/build" }
 

--- a/exonum-node/Cargo.toml
+++ b/exonum-node/Cargo.toml
@@ -55,9 +55,10 @@ toml = "0.5.6"
 
 exonum-rust-runtime = { version = "1.0.0-rc.3", path = "../runtimes/rust" }
 
-# Unix-specific dependencies for the `signals` test.
+# Dependencies for the Unix-specific `signals` test.
 [target.'cfg(unix)'.dev_dependencies]
 nix = "0.17.0"
+reqwest = { version = "0.10.2", features = ["blocking"] }
 rusty-fork = "0.2.2"
 
 [build-dependencies]

--- a/exonum-node/Cargo.toml
+++ b/exonum-node/Cargo.toml
@@ -43,7 +43,7 @@ exonum_sodiumoxide = { version = "0.0.23", optional = true }
 
 [dependencies.tokio]
 version = "0.2.13"
-features = ["blocking", "dns", "io-util", "macros", "rt-threaded", "tcp", "time"]
+features = ["blocking", "dns", "io-util", "macros", "rt-threaded", "signal", "tcp", "time"]
 
 [dev-dependencies]
 bincode = "1.2.1"

--- a/exonum-node/benches/transactions.rs
+++ b/exonum-node/benches/transactions.rs
@@ -40,7 +40,8 @@ use std::sync::{Arc, RwLock};
 use exonum_node::{
     EventsPoolCapacity, ExternalMessage, NodeChannel,
     _bench_types::{
-        Event, EventHandler, HandlerPart, InternalPart, InternalRequest, NetworkEvent, PeerMessage,
+        Event, EventHandler, EventOutcome, HandlerPart, InternalPart, InternalRequest,
+        NetworkEvent, PeerMessage,
     },
 };
 
@@ -68,7 +69,7 @@ impl MessagesHandler {
 }
 
 impl EventHandler for MessagesHandler {
-    fn handle_event(&mut self, event: Event) {
+    fn handle_event(&mut self, event: Event) -> EventOutcome {
         if let Event::Internal(event) = event {
             if event.is_message_verified() {
                 assert!(!self.is_finished(), "unexpected `MessageVerified`");
@@ -84,6 +85,7 @@ impl EventHandler for MessagesHandler {
                 }
             }
         }
+        EventOutcome::Ok
     }
 }
 
@@ -120,8 +122,9 @@ impl MessagesHandlerRef {
 }
 
 impl EventHandler for MessagesHandlerRef {
-    fn handle_event(&mut self, event: Event) {
+    fn handle_event(&mut self, event: Event) -> EventOutcome {
         self.inner.write().unwrap().handle_event(event);
+        EventOutcome::Ok
     }
 }
 

--- a/exonum-node/src/events/internal.rs
+++ b/exonum-node/src/events/internal.rs
@@ -78,11 +78,6 @@ impl InternalPart {
                     let event = InternalEvent::jump_to_round(height, round);
                     tokio::spawn(Self::send_event(internal_tx, event));
                 }
-
-                InternalRequest::Shutdown => {
-                    let event = InternalEvent::shutdown();
-                    tokio::spawn(Self::send_event(internal_tx, event));
-                }
             }
         }
     }

--- a/exonum-node/src/lib.rs
+++ b/exonum-node/src/lib.rs
@@ -942,6 +942,18 @@ pub trait ConfigManager: Send {
 
 /// Node capable of processing requests from external clients and participating in the consensus
 /// algorithm.
+///
+/// # Signal Handling
+///
+/// By default, the node installs several signal hooks. This can be disabled by using
+/// [`disable_signals()`] method in `NodeBuilder`.
+///
+/// On Unix, the node will gracefully shut down on receiving any of SIGINT, SIGTERM
+/// or SIGQUIT and will ignore SIGHUP. On Windows, the node will gracefully shut down on
+/// receiving `Ctrl + C` break. Graceful shutdown means, among other things, flushing uncommitted
+/// transactions into the persistent storage.
+///
+/// [`disable_signals()`]: struct.NodeBuilder.html#method.disable_signals
 #[derive(Debug)]
 pub struct Node {
     api_manager_config: ApiManagerConfig,
@@ -1096,7 +1108,15 @@ impl NodeBuilder {
         self
     }
 
-    /// Switches of signal handling for the node.
+    /// Switches off [default signal handling] for the node.
+    /// This is useful to implement more complex signal handling, or one that differs
+    /// from the default.
+    ///
+    /// If you use custom signal handlers, the node may be shut down gracefully using
+    /// [`ShutdownHandle`].
+    ///
+    /// [`ShutdownHandle`]: struct.ShutdownHandle.html
+    /// [default signal handling]: struct.Node.html#signal-handling
     pub fn disable_signals(mut self) -> Self {
         self.disable_signals = true;
         self

--- a/exonum-node/src/sandbox/mod.rs
+++ b/exonum-node/src/sandbox/mod.rs
@@ -141,9 +141,10 @@ impl SandboxInner {
             match internal {
                 InternalRequest::Timeout(t) => self.timers.push(t),
 
-                InternalRequest::JumpToRound(height, round) => self
-                    .handler
-                    .handle_event(InternalEvent::jump_to_round(height, round).into()),
+                InternalRequest::JumpToRound(height, round) => {
+                    self.handler
+                        .handle_event(InternalEvent::jump_to_round(height, round).into());
+                }
 
                 InternalRequest::VerifyMessage(raw) => {
                     let msg = SignedMessage::from_bytes(raw.into())
@@ -152,10 +153,8 @@ impl SandboxInner {
                         .unwrap();
 
                     self.handler
-                        .handle_event(InternalEvent::message_verified(msg).into())
+                        .handle_event(InternalEvent::message_verified(msg).into());
                 }
-
-                InternalRequest::Shutdown => unreachable!(),
             }
         }
     }

--- a/exonum-node/tests/common/mod.rs
+++ b/exonum-node/tests/common/mod.rs
@@ -50,6 +50,11 @@ impl RunHandle {
         }
     }
 
+    /// Returns the shutdown handle for this node.
+    pub fn shutdown_handle(&self) -> ShutdownHandle {
+        self.shutdown_handle.clone()
+    }
+
     /// Waits for the node to shut down without terminating it.
     pub async fn run(self) {
         self.node_task.await.unwrap()
@@ -126,6 +131,7 @@ pub struct Options {
     pub slow_blocks: bool,
     pub skip_empty_blocks: bool,
     pub http_start_port: Option<u16>,
+    pub disable_signals: bool,
 }
 
 pub fn run_nodes(
@@ -172,8 +178,11 @@ pub fn run_nodes(
         if options.skip_empty_blocks {
             node_builder = node_builder.with_block_proposer(SkipEmptyBlocks);
         }
-        let node = node_builder.build();
+        if options.disable_signals {
+            node_builder = node_builder.disable_signals();
+        }
 
+        let node = node_builder.build();
         node_handles.push(RunHandle::new(node));
         commit_rxs.push(commit_rx);
     }

--- a/exonum-node/tests/common/mod.rs
+++ b/exonum-node/tests/common/mod.rs
@@ -1,0 +1,182 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use exonum::{
+    blockchain::{config::GenesisConfigBuilder, Blockchain},
+    merkledb::TemporaryDB,
+    runtime::{ExecutionContext, ExecutionError, InstanceId},
+};
+use exonum_derive::*;
+use exonum_rust_runtime::{AfterCommitContext, RustRuntime, Service, ServiceFactory};
+use futures::{channel::mpsc, prelude::*};
+use tokio::task::JoinHandle;
+
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    sync::{Arc, Mutex},
+};
+
+use exonum_node::{
+    generate_testnet_config, proposer::SkipEmptyBlocks, Node, NodeBuilder, ShutdownHandle,
+};
+
+#[derive(Debug)]
+pub struct RunHandle {
+    pub blockchain: Blockchain,
+    node_task: JoinHandle<()>,
+    shutdown_handle: ShutdownHandle,
+}
+
+impl RunHandle {
+    pub fn new(node: Node) -> Self {
+        let blockchain = node.blockchain().to_owned();
+        let shutdown_handle = node.shutdown_handle();
+        let node_task = node.run().unwrap_or_else(|err| panic!("{}", err));
+        Self {
+            blockchain,
+            shutdown_handle,
+            node_task: tokio::spawn(node_task),
+        }
+    }
+
+    /// Waits for the node to shut down without terminating it.
+    pub async fn run(self) {
+        self.node_task.await.unwrap()
+    }
+
+    /// Terminates the node and waits for it to shut down.
+    pub async fn join(self) {
+        self.shutdown_handle.shutdown().await.unwrap();
+        self.node_task.await.unwrap();
+    }
+}
+
+#[exonum_interface(auto_ids)]
+pub trait DummyInterface<Ctx> {
+    type Output;
+    fn timestamp(&self, context: Ctx, _value: u64) -> Self::Output;
+}
+
+#[derive(Debug, Clone, ServiceDispatcher, ServiceFactory)]
+#[service_dispatcher(implements("DummyInterface"))]
+#[service_factory(
+    artifact_name = "after-commit",
+    artifact_version = "1.0.0",
+    proto_sources = "exonum::proto::schema",
+    service_constructor = "CommitWatcherService::new_instance"
+)]
+pub struct CommitWatcherService(mpsc::UnboundedSender<()>);
+
+impl CommitWatcherService {
+    pub const ID: InstanceId = 2;
+
+    fn new_instance(&self) -> Box<dyn Service> {
+        Box::new(self.clone())
+    }
+}
+
+impl Service for CommitWatcherService {
+    fn after_commit(&self, _context: AfterCommitContext<'_>) {
+        self.0.unbounded_send(()).ok();
+    }
+}
+
+impl DummyInterface<ExecutionContext<'_>> for CommitWatcherService {
+    type Output = Result<(), ExecutionError>;
+
+    fn timestamp(&self, _context: ExecutionContext<'_>, _value: u64) -> Self::Output {
+        Ok(())
+    }
+}
+
+#[derive(Debug, ServiceDispatcher)]
+struct StartCheckerService;
+
+impl Service for StartCheckerService {}
+
+#[derive(Debug, ServiceFactory)]
+#[service_factory(
+    artifact_name = "configure",
+    artifact_version = "1.0.2",
+    proto_sources = "exonum::proto::schema",
+    service_constructor = "StartCheckerServiceFactory::new_instance"
+)]
+pub struct StartCheckerServiceFactory(pub Arc<Mutex<u64>>);
+
+impl StartCheckerServiceFactory {
+    fn new_instance(&self) -> Box<dyn Service> {
+        *self.0.lock().unwrap() += 1;
+        Box::new(StartCheckerService)
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct Options {
+    pub slow_blocks: bool,
+    pub skip_empty_blocks: bool,
+    pub http_start_port: Option<u16>,
+}
+
+pub fn run_nodes(
+    count: u16,
+    start_port: u16,
+    options: Options,
+) -> (Vec<RunHandle>, Vec<mpsc::UnboundedReceiver<()>>) {
+    let mut node_handles = Vec::new();
+    let mut commit_rxs = Vec::new();
+
+    let it = generate_testnet_config(count, start_port)
+        .into_iter()
+        .enumerate();
+    for (i, (mut node_cfg, node_keys)) in it {
+        let (commit_tx, commit_rx) = mpsc::unbounded();
+        if options.slow_blocks {
+            node_cfg.consensus.first_round_timeout = 20_000;
+            node_cfg.consensus.min_propose_timeout = 10_000;
+            node_cfg.consensus.max_propose_timeout = 10_000;
+        }
+        if let Some(start_port) = options.http_start_port {
+            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), start_port + i as u16);
+            node_cfg.api.public_api_address = Some(addr);
+        }
+
+        let service = CommitWatcherService(commit_tx);
+        let artifact = service.artifact_id();
+        let instance = artifact
+            .clone()
+            .into_default_instance(CommitWatcherService::ID, "commit-watcher");
+        let genesis_cfg = GenesisConfigBuilder::with_consensus_config(node_cfg.consensus.clone())
+            .with_artifact(artifact)
+            .with_instance(instance)
+            .build();
+
+        let db = TemporaryDB::new();
+        let mut node_builder = NodeBuilder::new(db, node_cfg, node_keys)
+            .with_genesis_config(genesis_cfg)
+            .with_runtime_fn(|channel| {
+                RustRuntime::builder()
+                    .with_factory(service)
+                    .build(channel.endpoints_sender())
+            });
+        if options.skip_empty_blocks {
+            node_builder = node_builder.with_block_proposer(SkipEmptyBlocks);
+        }
+        let node = node_builder.build();
+
+        node_handles.push(RunHandle::new(node));
+        commit_rxs.push(commit_rx);
+    }
+
+    (node_handles, commit_rxs)
+}

--- a/exonum-node/tests/node.rs
+++ b/exonum-node/tests/node.rs
@@ -15,19 +15,15 @@
 //! High-level tests for the Exonum node.
 
 use exonum::{
-    blockchain::{config::GenesisConfigBuilder, Blockchain},
+    blockchain::config::GenesisConfigBuilder,
     crypto::KeyPair,
     helpers::Height,
     merkledb::{Database, ObjectHash, TemporaryDB},
-    runtime::{ExecutionContext, ExecutionError, InstanceId, SnapshotExt},
+    runtime::SnapshotExt,
 };
-use exonum_derive::*;
-use exonum_rust_runtime::{AfterCommitContext, RustRuntime, Service, ServiceFactory};
-use futures::{channel::mpsc, prelude::*};
-use tokio::{
-    task::JoinHandle,
-    time::{delay_for, timeout},
-};
+use exonum_rust_runtime::{RustRuntime, ServiceFactory};
+use futures::prelude::*;
+use tokio::time::{delay_for, timeout};
 
 use std::{
     net::{Ipv4Addr, SocketAddr, TcpListener},
@@ -35,154 +31,12 @@ use std::{
     time::Duration,
 };
 
-use exonum_node::{
-    generate_testnet_config, proposer::SkipEmptyBlocks, Node, NodeBuilder, NodeConfig,
-    ShutdownHandle,
+use exonum_node::{generate_testnet_config, NodeBuilder, NodeConfig};
+
+pub mod common;
+use crate::common::{
+    run_nodes, CommitWatcherService, DummyInterface, Options, RunHandle, StartCheckerServiceFactory,
 };
-
-#[derive(Debug)]
-struct RunHandle {
-    blockchain: Blockchain,
-    node_task: JoinHandle<()>,
-    shutdown_handle: ShutdownHandle,
-}
-
-impl RunHandle {
-    fn new(node: Node) -> Self {
-        let blockchain = node.blockchain().to_owned();
-        let shutdown_handle = node.shutdown_handle();
-        let node_task = node.run().unwrap_or_else(|err| panic!("{}", err));
-        Self {
-            blockchain,
-            shutdown_handle,
-            node_task: tokio::spawn(node_task),
-        }
-    }
-
-    async fn join(self) {
-        self.shutdown_handle.shutdown().await.unwrap();
-        self.node_task.await.unwrap();
-    }
-}
-
-#[exonum_interface(auto_ids)]
-trait DummyInterface<Ctx> {
-    type Output;
-    fn timestamp(&self, context: Ctx, _value: u64) -> Self::Output;
-}
-
-#[derive(Debug, Clone, ServiceDispatcher, ServiceFactory)]
-#[service_dispatcher(implements("DummyInterface"))]
-#[service_factory(
-    artifact_name = "after-commit",
-    artifact_version = "1.0.0",
-    proto_sources = "exonum::proto::schema",
-    service_constructor = "CommitWatcherService::new_instance"
-)]
-struct CommitWatcherService(mpsc::UnboundedSender<()>);
-
-impl CommitWatcherService {
-    const ID: InstanceId = 2;
-
-    fn new_instance(&self) -> Box<dyn Service> {
-        Box::new(self.clone())
-    }
-}
-
-impl Service for CommitWatcherService {
-    fn after_commit(&self, _context: AfterCommitContext<'_>) {
-        self.0.unbounded_send(()).ok();
-    }
-}
-
-impl DummyInterface<ExecutionContext<'_>> for CommitWatcherService {
-    type Output = Result<(), ExecutionError>;
-
-    fn timestamp(&self, _context: ExecutionContext<'_>, _value: u64) -> Self::Output {
-        Ok(())
-    }
-}
-
-#[derive(Debug, ServiceDispatcher)]
-struct StartCheckerService;
-
-impl Service for StartCheckerService {}
-
-#[derive(Debug, ServiceFactory)]
-#[service_factory(
-    artifact_name = "configure",
-    artifact_version = "1.0.2",
-    proto_sources = "exonum::proto::schema",
-    service_constructor = "StartCheckerServiceFactory::new_instance"
-)]
-struct StartCheckerServiceFactory(pub Arc<Mutex<u64>>);
-
-impl StartCheckerServiceFactory {
-    fn new_instance(&self) -> Box<dyn Service> {
-        *self.0.lock().unwrap() += 1;
-        Box::new(StartCheckerService)
-    }
-}
-
-#[derive(Clone, Copy, Default)]
-struct Options {
-    slow_blocks: bool,
-    skip_empty_blocks: bool,
-    http_start_port: Option<u16>,
-}
-
-fn run_nodes(
-    count: u16,
-    start_port: u16,
-    options: Options,
-) -> (Vec<RunHandle>, Vec<mpsc::UnboundedReceiver<()>>) {
-    let mut node_handles = Vec::new();
-    let mut commit_rxs = Vec::new();
-
-    let it = generate_testnet_config(count, start_port)
-        .into_iter()
-        .enumerate();
-    for (i, (mut node_cfg, node_keys)) in it {
-        let (commit_tx, commit_rx) = mpsc::unbounded();
-        if options.slow_blocks {
-            node_cfg.consensus.first_round_timeout = 20_000;
-            node_cfg.consensus.min_propose_timeout = 10_000;
-            node_cfg.consensus.max_propose_timeout = 10_000;
-        }
-        if let Some(start_port) = options.http_start_port {
-            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), start_port + i as u16);
-            node_cfg.api.public_api_address = Some(addr);
-        }
-
-        let service = CommitWatcherService(commit_tx);
-        let artifact = service.artifact_id();
-        let instance = artifact
-            .clone()
-            .into_default_instance(CommitWatcherService::ID, "commit-watcher");
-        let genesis_cfg = GenesisConfigBuilder::with_consensus_config(node_cfg.consensus.clone())
-            .with_artifact(artifact)
-            .with_instance(instance)
-            .build();
-
-        let db = TemporaryDB::new();
-        let mut node_builder = NodeBuilder::new(db, node_cfg, node_keys)
-            .with_genesis_config(genesis_cfg)
-            .with_runtime_fn(|channel| {
-                RustRuntime::builder()
-                    .with_factory(service)
-                    .build(channel.endpoints_sender())
-            });
-        if options.skip_empty_blocks {
-            node_builder = node_builder.with_block_proposer(SkipEmptyBlocks);
-        }
-        let node = node_builder.build();
-
-        node_handles.push(RunHandle::new(node));
-        commit_rxs.push(commit_rx);
-    }
-
-    (node_handles, commit_rxs)
-}
 
 #[tokio::test]
 async fn nodes_commit_blocks() {
@@ -199,7 +53,6 @@ async fn nodes_commit_blocks() {
 }
 
 #[tokio::test]
-#[cfg_attr(windows, ignore)]
 async fn node_frees_sockets_on_shutdown() {
     let options = Options {
         http_start_port: Some(16_351),

--- a/exonum-node/tests/signals.rs
+++ b/exonum-node/tests/signals.rs
@@ -115,7 +115,7 @@ fn interrupt_node_with_http() {
         |child, output| check_child(child, output, Signal::SIGINT),
         || {
             let mut runtime = Runtime::new().unwrap();
-            runtime.block_on(start_node(16_470, true));
+            runtime.block_on(start_node(16_460, true));
         },
     )
     .unwrap();
@@ -130,7 +130,7 @@ fn terminate_node_without_http() {
         |child, output| check_child(child, output, Signal::SIGTERM),
         || {
             let mut runtime = Runtime::new().unwrap();
-            runtime.block_on(start_node(16_480, false));
+            runtime.block_on(start_node(16_470, false));
         },
     )
     .unwrap();
@@ -145,7 +145,7 @@ fn terminate_node_with_http() {
         |child, output| check_child(child, output, Signal::SIGTERM),
         || {
             let mut runtime = Runtime::new().unwrap();
-            runtime.block_on(start_node(16_460, true));
+            runtime.block_on(start_node(16_480, true));
         },
     )
     .unwrap();

--- a/exonum-node/tests/signals.rs
+++ b/exonum-node/tests/signals.rs
@@ -14,7 +14,7 @@
 
 //! Tests related to signal handling by the nodes.
 
-// cspell:ignore SIGINT, SIGTERM, unistd
+// cspell:ignore unistd
 
 #![cfg(unix)]
 

--- a/exonum-node/tests/signals.rs
+++ b/exonum-node/tests/signals.rs
@@ -1,0 +1,122 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests related to signal handling by the nodes.
+
+#![cfg(unix)]
+
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+use rusty_fork::{fork, rusty_fork_id, ChildWrapper};
+use tokio::runtime::Runtime;
+
+use std::{
+    env,
+    fs::File,
+    io::{BufRead, BufReader, Seek, SeekFrom},
+    time::Duration,
+};
+
+pub mod common;
+use crate::common::{run_nodes, Options};
+
+fn check_child(child: &mut ChildWrapper, output: &mut File) {
+    // Sleep several seconds in order for the node to launch.
+    let maybe_status = child
+        .wait_timeout(Duration::from_secs(5))
+        .expect("Failed to wait for node to function");
+    if let Some(status) = maybe_status {
+        panic!(
+            "Node exited unexpectedly with this exit status: {:?}",
+            status
+        );
+    }
+
+    // Send a SIGINT to the node.
+    let pid = Pid::from_raw(child.id() as i32);
+    kill(pid, Signal::SIGINT).unwrap();
+
+    // Check that the child has exited.
+    let exit_status = child
+        .wait_timeout(Duration::from_secs(2))
+        .expect("Failed to wait for node exit")
+        .unwrap_or_else(|| {
+            child.kill().ok();
+            panic!("Node did not exit in 2 secs after being sent SIGINT");
+        });
+
+    assert!(
+        exit_status.success(),
+        "Node exited with unexpected status: {:?}",
+        exit_status
+    );
+
+    output.seek(SeekFrom::Start(0)).unwrap();
+    let reader = BufReader::new(&*output);
+    for line_res in reader.lines() {
+        if let Ok(line) = line_res {
+            if line.contains("Shutting down node handler") {
+                return;
+            }
+        }
+    }
+    panic!("Node did not shut down properly");
+}
+
+async fn start_node(start_port: u16, with_http: bool) {
+    // Enable logs in order to check that the node shuts down properly.
+    env::set_var("RUST_LOG", "exonum_node=info");
+    exonum::helpers::init_logger().ok();
+
+    let mut options = Options::default();
+    if with_http {
+        options.http_start_port = Some(start_port + 1);
+    }
+
+    let (mut nodes, _) = run_nodes(1, start_port, options);
+    let node = nodes.pop().unwrap();
+    node.run().await
+}
+
+#[test]
+fn interrupt_node_without_http() {
+    fork(
+        "interrupt_node_without_http",
+        rusty_fork_id!(),
+        |_| {},
+        check_child,
+        || {
+            let mut runtime = Runtime::new().unwrap();
+            runtime.block_on(start_node(16_450, false));
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn interrupt_node_with_http() {
+    fork(
+        "interrupt_node_with_http",
+        rusty_fork_id!(),
+        |_| {},
+        check_child,
+        || {
+            let mut runtime = Runtime::new().unwrap();
+            runtime.block_on(start_node(16_460, true));
+        },
+    )
+    .unwrap();
+}

--- a/exonum-node/tests/signals.rs
+++ b/exonum-node/tests/signals.rs
@@ -14,6 +14,8 @@
 
 //! Tests related to signal handling by the nodes.
 
+// cspell:ignore SIGINT, SIGTERM, unistd
+
 #![cfg(unix)]
 
 use nix::{
@@ -55,7 +57,7 @@ fn check_child(child: &mut ChildWrapper, output: &mut File, signal: Signal) {
         .expect("Failed to wait for node exit")
         .unwrap_or_else(|| {
             child.kill().ok();
-            panic!("Node did not exit in 2 secs after being sent SIGINT");
+            panic!("Node did not exit in 2 secs after being sent the signal");
         });
 
     assert!(

--- a/test-suite/testkit/src/lib.rs
+++ b/test-suite/testkit/src/lib.rs
@@ -137,7 +137,6 @@ use exonum_explorer::{BlockWithTransactions, BlockchainExplorer};
 use exonum_rust_runtime::{RustRuntimeBuilder, ServiceFactory};
 use futures::{
     channel::mpsc,
-    future,
     prelude::*,
     stream::{self, BoxStream},
     StreamExt,
@@ -721,32 +720,32 @@ impl TestKit {
         &mut self.network
     }
 
+    #[allow(clippy::mut_mut)] // occurs withing `select!` macro
     async fn run(mut self, public_api_address: SocketAddr, private_api_address: SocketAddr) {
-        let events_task = self.remove_events_stream();
-        let endpoints_rx = mem::replace(&mut self.api_notifier_channel.1, mpsc::channel(0).1);
+        let events_task = self.remove_events_stream().fuse();
+        futures::pin_mut!(events_task);
 
+        let endpoints_rx = mem::replace(&mut self.api_notifier_channel.1, mpsc::channel(0).1);
         let (api_aggregator, actor_task) = TestKitActor::spawn(self).await;
+        let mut actor_task = actor_task.fuse();
+
         let mut servers = HashMap::new();
         servers.insert(ApiAccess::Public, WebServerConfig::new(public_api_address));
         servers.insert(
             ApiAccess::Private,
             WebServerConfig::new(private_api_address),
         );
-        let api_manager_config = ApiManagerConfig {
-            servers,
-            api_aggregator,
-            server_restart_max_retries: 5,
-            server_restart_retry_timeout: 500,
-        };
+        let api_manager_config = ApiManagerConfig::new(servers, api_aggregator);
+        let manager_task = ApiManager::new(api_manager_config).run(endpoints_rx).fuse();
+        futures::pin_mut!(manager_task);
 
-        let manager_task = ApiManager::new(api_manager_config)
-            .run(endpoints_rx)
-            .unwrap_or_else(|e| {
+        futures::select! {
+            () = events_task => (),
+            () = actor_task => (),
+            res = manager_task => if let Err(e) = res {
                 log::error!("Error running testkit server API: {}", e);
-            });
-
-        // FIXME: what's the appropriate strategy here?
-        future::join3(events_task, manager_task, actor_task).await;
+            }
+        }
     }
 
     /// Extracts the event stream from this testkit, replacing it with `futures::stream::empty()`.


### PR DESCRIPTION
## Overview

This PR makes nodes process OS signals (namely, cross-platform "ctrl-c" corresponding to Unix's SIGINT; and SIGTERM on Unix).

Discussion:

- [x] ~Should the docs mention / link to [the caveats](https://docs.rs/tokio/0.2.13/tokio/signal/fn.ctrl_c.html#caveats) associated with signal processing using `tokio`?~ Added a note about signal handling to `Node` docs.
- [x] ~Should other signals be handled (e.g., SIGHUP)?~ SIGHUP is ignored, SIGQUIT gracefully shuts down the node.

---

See: https://jira.bf.local/browse/ECR-4374