### PR TITLE
Remove `Runtime::shutdown()` [ECR-4359]

### DIFF
--- a/exonum-node/src/events_impl.rs
+++ b/exonum-node/src/events_impl.rs
@@ -115,8 +115,6 @@ impl NodeHandler {
         self.execute_later(InternalRequest::Shutdown);
         // Flush transactions stored in tx_cache to persistent pool.
         self.flush_txs_into_pool();
-        // Notify the blockchain about the shutdown.
-        self.blockchain.shutdown();
     }
 
     pub(crate) fn flush_txs_into_pool(&mut self) {

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -768,10 +768,4 @@ impl BlockchainMut {
         db.merge(fork.into_patch())
             .expect("Cannot update transaction pool");
     }
-
-    /// Shuts down the service dispatcher enclosed by this blockchain. This must be
-    /// the last operation performed on the blockchain.
-    pub fn shutdown(&mut self) {
-        self.dispatcher.shutdown();
-    }
 }

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -966,13 +966,6 @@ impl Dispatcher {
         }
     }
 
-    /// Notify the runtimes that it has to shutdown.
-    pub(crate) fn shutdown(&mut self) {
-        for runtime in self.runtimes.values_mut() {
-            runtime.shutdown();
-        }
-    }
-
     /// Commits service instance status to the corresponding runtime.
     ///
     /// # Panics

--- a/exonum/src/runtime/dispatcher/tests.rs
+++ b/exonum/src/runtime/dispatcher/tests.rs
@@ -758,8 +758,10 @@ impl Runtime for ShutdownRuntime {
     }
 
     fn after_commit(&mut self, _snapshot: &dyn Snapshot, _mailbox: &mut Mailbox) {}
+}
 
-    fn shutdown(&mut self) {
+impl Drop for ShutdownRuntime {
+    fn drop(&mut self) {
         self.turned_off.store(true, Ordering::Relaxed);
     }
 }
@@ -771,11 +773,11 @@ fn test_shutdown() {
     let runtime_a = ShutdownRuntime::new(turned_off_a.clone());
     let runtime_b = ShutdownRuntime::new(turned_off_b.clone());
 
-    let mut dispatcher = DispatcherBuilder::new()
+    let dispatcher = DispatcherBuilder::new()
         .with_runtime(2, runtime_a)
         .with_runtime(3, runtime_b)
         .finalize(&Blockchain::build_for_tests());
-    dispatcher.shutdown();
+    drop(dispatcher);
 
     assert_eq!(turned_off_a.load(Ordering::Relaxed), true);
     assert_eq!(turned_off_b.load(Ordering::Relaxed), true);

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -663,16 +663,6 @@ pub trait Runtime: Send + fmt::Debug + 'static {
     /// by the supervisor service to enqueue artifact deployment. A runtime may ignore `mailbox`
     /// if its services (or the runtime itself) do not require privileged access to the dispatcher.
     fn after_commit(&mut self, snapshot: &dyn Snapshot, mailbox: &mut Mailbox);
-
-    /// Notifies the runtime that it has to shutdown.
-    ///
-    /// This callback is invoked sequentially for each runtime just before the node shutdown.
-    /// Thus, the runtimes can stop themselves gracefully.
-    ///
-    /// Invoking this callback is the last operation for the runtime.
-    /// This method is a part of shutdown process. Thus, the runtimes can block and perform
-    /// heavy operations here if needed.
-    fn shutdown(&mut self) {}
 }
 
 #[allow(clippy::use_self)] // false positive

--- a/runtimes/rust/tests/inspected/mod.rs
+++ b/runtimes/rust/tests/inspected/mod.rs
@@ -123,7 +123,6 @@ pub enum RuntimeEvent {
     CommitService(Height, InstanceSpec, InstanceStatus),
     AfterTransactions(Height, InstanceId),
     AfterCommit(Height),
-    Shutdown,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -289,11 +288,6 @@ impl<T: Runtime> Runtime for Inspected<T> {
         let height = CoreSchema::new(snapshot).next_height();
         self.events.push(RuntimeEvent::AfterCommit(height));
         self.runtime.after_commit(snapshot, mailbox);
-    }
-
-    fn shutdown(&mut self) {
-        self.events.push(RuntimeEvent::Shutdown);
-        self.runtime.shutdown();
     }
 }
 


### PR DESCRIPTION
## Overview

This PR removes `Runtime::shutdown()` method as redundant (runtimes can shut down in their `Drop` implementation).

---

See: https://jira.bf.local/browse/ECR-4359