### PR TITLE
Faster block proposals [ECR-4375]

### DIFF
--- a/exonum-node/src/basic.rs
+++ b/exonum-node/src/basic.rs
@@ -227,8 +227,8 @@ impl NodeHandler {
 
     /// Handles `NodeTimeout::Status`, broadcasts the `Status` message if it isn't outdated as
     /// result.
-    pub(crate) fn handle_status_timeout(&mut self, height: Height) {
-        if self.state.epoch() == height {
+    pub(crate) fn handle_status_timeout(&mut self, epoch: Height) {
+        if self.state.epoch() == epoch {
             self.broadcast_status();
             self.add_status_timeout();
         }

--- a/exonum-node/src/consensus.rs
+++ b/exonum-node/src/consensus.rs
@@ -952,38 +952,29 @@ impl NodeHandler {
 
     /// Handles round timeout. As result node sends `Propose` if it is a leader or `Prevote` if it
     /// is locked to some round.
-    pub(crate) fn handle_round_timeout(&mut self, height: Height, round: Round) {
+    pub(crate) fn handle_round_timeout(&mut self, epoch: Height, round: Round) {
         // TODO: Debug asserts? (ECR-171)
-        if height != self.state.epoch() {
+        if epoch != self.state.epoch() || round != self.state.round() {
             return;
         }
-        if round != self.state.round() {
-            return;
-        }
-        warn!("ROUND TIMEOUT height={}, round={}", height, round);
+        warn!("ROUND TIMEOUT epoch={}, round={}", epoch, round);
 
-        // Update state to new round
+        // Update the node state to the new round.
         self.state.new_round();
-
-        // Add timeout for this round
+        // Add a timeout for this round.
         self.add_round_timeout();
         self.process_new_round();
     }
 
-    /// Handles propose timeout. Node sends `Propose` and `Prevote` if it is a leader as result.
-    pub(crate) fn handle_propose_timeout(&mut self, height: Height, round: Round) {
+    /// Handles propose timeout. Node sends `Propose` and `Prevote` as a result.
+    ///
+    /// Invariants: it is assumed that this node is a leader for `(epoch, round)`.
+    pub(crate) fn handle_propose_timeout(&mut self, epoch: Height, round: Round) {
         // TODO debug asserts (ECR-171)?
-        if height != self.state.epoch() {
-            // It is too late
+        if epoch != self.state.epoch() || round != self.state.round() {
             return;
         }
-        if round != self.state.round() {
-            return;
-        }
-        if self.state.locked_propose().is_some() {
-            return;
-        }
-        if self.state.have_prevote(round) {
+        if self.state.locked_propose().is_some() || self.state.have_prevote(round) {
             return;
         }
 
@@ -992,7 +983,7 @@ impl NodeHandler {
         } else {
             return;
         };
-        let round = self.state.round();
+        debug_assert!(self.state.is_leader());
 
         let propose_template = self.get_propose_template();
         let propose = match propose_template {

--- a/exonum-node/src/events_impl.rs
+++ b/exonum-node/src/events_impl.rs
@@ -91,12 +91,12 @@ impl NodeHandler {
 
     fn handle_timeout(&mut self, timeout: NodeTimeout) {
         match timeout {
-            NodeTimeout::Round(height, round) => self.handle_round_timeout(height, round),
+            NodeTimeout::Round(epoch, round) => self.handle_round_timeout(epoch, round),
             NodeTimeout::Request(data, peer) => self.handle_request_timeout(&data, peer),
-            NodeTimeout::Status(height) => self.handle_status_timeout(height),
+            NodeTimeout::Status(epoch) => self.handle_status_timeout(epoch),
             NodeTimeout::PeerExchange => self.handle_peer_exchange_timeout(),
             NodeTimeout::UpdateApiState => self.handle_update_api_state_timeout(),
-            NodeTimeout::Propose(height, round) => self.handle_propose_timeout(height, round),
+            NodeTimeout::Propose(epoch, round) => self.handle_propose_timeout(epoch, round),
             NodeTimeout::FlushPool => {
                 self.flush_txs_into_pool();
                 self.maybe_add_flush_pool_timeout();

--- a/exonum-node/src/sandbox/mod.rs
+++ b/exonum-node/src/sandbox/mod.rs
@@ -667,7 +667,8 @@ impl Sandbox {
             time.add_assign(duration);
             *time.deref()
         };
-        // handle timeouts if occurs
+
+        // Handle timeouts.
         loop {
             let timeout = {
                 let timers = &mut self.inner.borrow_mut().timers;
@@ -962,9 +963,10 @@ impl Sandbox {
             keys,
         };
 
+        let shared_time = SharedTime::new(Mutex::new(time));
         let system_state = SandboxSystemStateProvider {
             listen_address: address,
-            shared_time: SharedTime::new(Mutex::new(time)),
+            shared_time: shared_time.clone(),
         };
 
         let blockchain = inner.handler.blockchain;
@@ -989,7 +991,7 @@ impl Sandbox {
             api_requests_rx: api_channel.1,
             transactions_rx: tx_channel.1,
             handler,
-            time: Arc::clone(&inner.time),
+            time: shared_time,
         };
         let sandbox = Self {
             inner: RefCell::new(inner),

--- a/exonum-node/src/sandbox/sandbox_tests_helper.rs
+++ b/exonum-node/src/sandbox/sandbox_tests_helper.rs
@@ -193,7 +193,7 @@ pub struct SandboxState {
     pub accepted_propose_hash: RefCell<Hash>,
     pub accepted_block_hash: RefCell<Hash>,
     pub committed_transaction_hashes: RefCell<Vec<Hash>>,
-    pub time_millis_since_round_start: RefCell<Milliseconds>,
+    pub time_since_round_start: RefCell<Milliseconds>,
 }
 
 impl SandboxState {
@@ -208,7 +208,7 @@ impl Default for SandboxState {
             accepted_block_hash: RefCell::new(Hash::zero()),
             accepted_propose_hash: RefCell::new(Hash::zero()),
             committed_transaction_hashes: RefCell::new(Vec::new()),
-            time_millis_since_round_start: RefCell::new(0),
+            time_since_round_start: RefCell::new(0),
         }
     }
 }
@@ -225,16 +225,16 @@ pub fn add_round_with_transactions(
     sandbox_state: &SandboxState,
     transactions: &[Hash],
 ) -> Option<Verified<Propose>> {
-    try_add_round_with_transactions(sandbox, sandbox_state, transactions).unwrap()
+    try_add_round_with_transactions(sandbox, sandbox_state, transactions, false).unwrap()
 }
 
 pub fn try_add_round_with_transactions(
     sandbox: &TimestampingSandbox,
     sandbox_state: &SandboxState,
     transactions: &[Hash],
+    fast_track: bool,
 ) -> Result<Option<Verified<Propose>>, String> {
-    let mut res = None;
-    let round_timeout = sandbox.current_round_timeout(); //use local var to save long code call
+    let round_timeout = sandbox.current_round_timeout();
 
     trace!("-------------------------add_round_with_transactions started-------------------------");
     trace!("round before: {:?}", sandbox.current_round());
@@ -242,28 +242,33 @@ pub fn try_add_round_with_transactions(
     trace!("is_leader before time adding: {:?}", sandbox.is_leader());
 
     if sandbox.is_leader() {
-        res = check_and_broadcast_propose_and_prevote(sandbox, sandbox_state, transactions);
+        let res =
+            try_check_and_broadcast_propose_and_prevote(sandbox, sandbox_state, transactions)?;
+        if fast_track {
+            if let Some(propose) = res {
+                return Ok(Some(propose));
+            }
+        }
     }
 
-    // how much time left till next round_timeout
-    let time_till_next_round: Milliseconds =
-        round_timeout - *sandbox_state.time_millis_since_round_start.borrow() % round_timeout;
+    // How much time left till next round_timeout
+    let time_till_next_round =
+        round_timeout - *sandbox_state.time_since_round_start.borrow() % round_timeout;
 
     trace!("going to add {:?} millis", time_till_next_round);
-    sandbox.add_time(Duration::from_millis(time_till_next_round)); //here next round begins
+    sandbox.add_time(Duration::from_millis(time_till_next_round));
     trace!("sandbox_time after adding: {:?}", sandbox.time());
     trace!("round after: {:?}", sandbox.current_round());
     trace!("sandbox.current_round: {:?}", sandbox.current_round());
 
     trace!("is_leader after time adding: {:?}", sandbox.is_leader());
-    {
-        *sandbox_state.time_millis_since_round_start.borrow_mut() = 0;
-    }
+    *sandbox_state.time_since_round_start.borrow_mut() = 0;
 
     if sandbox.is_leader() {
-        res = try_check_and_broadcast_propose_and_prevote(sandbox, sandbox_state, transactions)?;
+        try_check_and_broadcast_propose_and_prevote(sandbox, sandbox_state, transactions)
+    } else {
+        Ok(None)
     }
-    Ok(res)
 }
 
 pub fn gen_timestamping_tx() -> Verified<AnyTx> {
@@ -323,17 +328,18 @@ where
     let new_height = initial_height.next();
 
     if n_validators == 1 {
-        try_add_round_with_transactions(sandbox, sandbox_state, hashes.as_ref())?;
+        try_add_round_with_transactions(sandbox, sandbox_state, &hashes, true)?;
         let block = sandbox.last_block();
-        assert_eq!(block.tx_count, hashes.len() as u32);
         assert_eq!(block.height, initial_height);
+        assert_eq!(block.tx_count, hashes.len() as u32);
         assert_eq!(block.tx_hash, compute_txs_merkle_root(&hashes));
         sandbox.assert_state(new_height, Round(1));
 
         return Ok(hashes);
     }
+
     for _ in 0..n_validators {
-        let propose = try_add_round_with_transactions(sandbox, sandbox_state, hashes.as_ref())?;
+        let propose = try_add_round_with_transactions(sandbox, sandbox_state, &hashes, false)?;
         let round = sandbox.current_round();
         if sandbox.is_leader() {
             // ok, we are leader
@@ -403,7 +409,7 @@ where
             }
 
             sandbox.assert_state(new_height, Round(1));
-            *sandbox_state.time_millis_since_round_start.borrow_mut() = 0;
+            *sandbox_state.time_since_round_start.borrow_mut() = 0;
             sandbox.check_broadcast_status(new_height, block.object_hash());
 
             return Ok(hashes);
@@ -494,7 +500,7 @@ pub fn add_one_height_with_transactions_from_other_validator(
             sandbox.assert_state(new_height, Round(1));
             sandbox.check_broadcast_status(new_height, block.object_hash());
 
-            *sandbox_state.time_millis_since_round_start.borrow_mut() = 0;
+            *sandbox_state.time_since_round_start.borrow_mut() = 0;
             return hashes;
         }
     }
@@ -525,40 +531,25 @@ fn get_propose_with_transactions_for_validator(
     )
 }
 
-/// assumptions:
-/// - that we come in this function with leader state
-/// - in current round `propose_timeout` is not triggered yet
-/// - `propose_timeout` < `round_timeout`
-fn check_and_broadcast_propose_and_prevote(
-    sandbox: &TimestampingSandbox,
-    sandbox_state: &SandboxState,
-    transactions: &[Hash],
-) -> Option<Verified<Propose>> {
-    try_check_and_broadcast_propose_and_prevote(sandbox, sandbox_state, transactions).unwrap()
-}
-
 fn try_check_and_broadcast_propose_and_prevote(
     sandbox: &TimestampingSandbox,
     sandbox_state: &SandboxState,
     transactions: &[Hash],
 ) -> Result<Option<Verified<Propose>>, String> {
-    if *sandbox_state.time_millis_since_round_start.borrow() > PROPOSE_TIMEOUT {
+    let millis_since_round_start = *sandbox_state.time_since_round_start.borrow();
+    if millis_since_round_start > PROPOSE_TIMEOUT {
         return Ok(None);
     }
-
-    let time_millis_since_round_start_copy = *sandbox_state.time_millis_since_round_start.borrow();
-    let time_increment_millis = PROPOSE_TIMEOUT - time_millis_since_round_start_copy + 1;
+    let time_increment_millis = PROPOSE_TIMEOUT - millis_since_round_start + 1;
 
     trace!(
         "time elapsed in current round: {:?}",
-        sandbox_state.time_millis_since_round_start
+        millis_since_round_start
     );
     trace!("going to add {:?} millis", time_increment_millis);
     sandbox.add_time(Duration::from_millis(time_increment_millis));
-    {
-        *sandbox_state.time_millis_since_round_start.borrow_mut() =
-            time_millis_since_round_start_copy + time_increment_millis;
-    }
+    *sandbox_state.time_since_round_start.borrow_mut() =
+        millis_since_round_start + time_increment_millis;
     trace!("sandbox_time after adding: {:?}", sandbox.time());
 
     // ok, we are leader

--- a/exonum-node/src/sandbox/tests/recovery.rs
+++ b/exonum-node/src/sandbox/tests/recovery.rs
@@ -36,8 +36,8 @@ fn should_not_send_propose_after_node_restart() {
     // Round happens.
     let round_timeout = sandbox.current_round_timeout();
     sandbox.add_time(Duration::from_millis(round_timeout));
-    let round_timeout = sandbox.current_round_timeout();
-    sandbox.add_time(Duration::from_millis(round_timeout + PROPOSE_TIMEOUT));
+    let new_round_timeout = sandbox.current_round_timeout();
+    sandbox.add_time(Duration::from_millis(new_round_timeout + PROPOSE_TIMEOUT));
 
     assert!(sandbox.is_leader());
     sandbox.assert_state(Height(1), Round(3));

--- a/exonum-node/src/sandbox/tests/round_details.rs
+++ b/exonum-node/src/sandbox/tests/round_details.rs
@@ -1678,7 +1678,7 @@ fn commit_as_leader_send_propose_round_timeout() {
         // here round 1 is just started
         sandbox.assert_state(Height(2), Round(1));
         {
-            assert_eq!(*sandbox_state.time_millis_since_round_start.borrow(), 0);
+            assert_eq!(*sandbox_state.time_since_round_start.borrow(), 0);
         }
         // assert!(sandbox.is_leader());
     }

--- a/exonum-node/src/sandbox/tests/timeouts.rs
+++ b/exonum-node/src/sandbox/tests/timeouts.rs
@@ -276,7 +276,7 @@ fn test_round_timeout_increase() {
     sandbox.add_time(Duration::from_millis(1));
     sandbox.assert_state(Height(1), Round(3));
 
-    //to make sure that there are no unchecked messages from validator 0 we skip round 3
+    // To make sure that there are no unchecked messages from validator 0, we skip round 3.
     add_round_with_transactions(&sandbox, &sandbox_state, &[]);
     sandbox.assert_state(Height(1), Round(4));
 

--- a/exonum-node/src/state.rs
+++ b/exonum-node/src/state.rs
@@ -831,9 +831,14 @@ impl State {
         self.blockchain_height
     }
 
-    /// Returns start time of the current height.
+    /// Returns the start time of the current consensus epoch.
     pub(super) fn epoch_start_time(&self) -> SystemTime {
         self.epoch_start_time
+    }
+
+    /// Sets the start time of the current consensus epoch.
+    pub(super) fn set_epoch_start_time(&mut self, time: SystemTime) {
+        self.epoch_start_time = time;
     }
 
     /// Returns the current round.

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -103,13 +103,10 @@ pub struct ConsensusConfig {
     /// between the moment a new block is committed to the blockchain and the
     /// time when second round starts, regardless of whether a new block has
     /// been committed during this period or not.
-    /// Each consecutive round will be longer then previous by constant factor determined
-    /// by ConsensusConfig::TIMEOUT_LINEAR_INCREASE_PERCENT constant.
+    /// Each consecutive round will be longer then previous by a constant factor, 10%.
     ///
-    /// Note that rounds in Exonum
-    /// do not have a defined end time. Nodes in a new round can
-    /// continue to vote for proposals and process messages related to previous
-    /// rounds.
+    /// Note that rounds in Exonum do not have a defined end time. Nodes in a new round can
+    /// continue to vote for proposals and process messages related to previous rounds.
     pub first_round_timeout: Milliseconds,
     /// Period of sending a Status message. This parameter defines the frequency
     /// with which a node broadcasts its status message to the network.
@@ -141,10 +138,10 @@ impl Default for ConsensusConfig {
     fn default() -> Self {
         Self {
             validator_keys: Vec::default(),
-            first_round_timeout: 3000,
-            status_timeout: 5000,
+            first_round_timeout: 3_000,
+            status_timeout: 5_000,
             peers_timeout: 10_000,
-            txs_block_limit: 1000,
+            txs_block_limit: 1_000,
             max_message_len: Self::DEFAULT_MAX_MESSAGE_LEN,
             min_propose_timeout: 10,
             max_propose_timeout: 200,


### PR DESCRIPTION
## Overview

This PR enables creating block proposals after a node is started, i.e., not waiting for a round timeout (which is order of 3s with standard settings).

Discussion:

- Is the standard proposal timeout sufficient to establish connections with peers, etc.? (AFAIK, there is no way to rebroadcast a proposal to connecting peers.)
 
---

See: https://jira.bf.local/browse/ECR-4375