### PR TITLE
Cache `check_tx` results [ECR-4376]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Internal Improvements
+
+#### exonum
+
+- It is now possible cache results of transaction correctness verification,
+  which leads to a moderate improvement in node performance. (#1844)
+
 ## 1.0.0 - 2020-03-31
 
 ### Breaking Changes

--- a/exonum-node/src/consensus.rs
+++ b/exonum-node/src/consensus.rs
@@ -812,7 +812,8 @@ impl NodeHandler {
         }
 
         let outcome;
-        if let Err(e) = Blockchain::check_tx(&snapshot, &msg) {
+        let tx_check_cache = self.state.tx_check_cache_mut();
+        if let Err(e) = Blockchain::check_tx_with_cache(&snapshot, &msg, tx_check_cache) {
             // Store transaction as invalid to know it if it'll be included into a proposal.
             // Please note that it **must** happen before calling `check_incomplete_proposes`,
             // since the latter uses `invalid_txs` to recalculate the validity of proposals.

--- a/exonum-node/src/proposer.rs
+++ b/exonum-node/src/proposer.rs
@@ -55,7 +55,7 @@
 //! [Exonum white paper]: https://bitfury.com/content/downloads/wp_consensus_181227.pdf
 
 use exonum::{
-    blockchain::{Blockchain, ConsensusConfig, PersistentPool, TransactionCache},
+    blockchain::{Blockchain, ConsensusConfig, PersistentPool, TransactionCache, TxCheckCache},
     crypto::Hash,
     helpers::{Height, Round},
     merkledb::Snapshot,
@@ -185,6 +185,7 @@ impl ProposeBlock for StandardProposer {
     fn propose_block(&mut self, pool: Pool<'_>, params: ProposeParams<'_>) -> ProposeTemplate {
         let max_transactions = params.consensus_config.txs_block_limit;
         let snapshot = params.snapshot();
+        let mut cache = TxCheckCache::new();
 
         let tx_hashes = pool
             .transactions()
@@ -192,7 +193,7 @@ impl ProposeBlock for StandardProposer {
                 // TODO: this is wildly inefficient.
                 // It should be easy to cache tx status within single height; however,
                 // spanning cache across multiple heights would be significantly harder.
-                if Blockchain::check_tx(snapshot, tx.as_ref()).is_ok() {
+                if Blockchain::check_tx_with_cache(snapshot, tx.as_ref(), &mut cache).is_ok() {
                     Some(tx_hash)
                 } else {
                     None

--- a/exonum/Cargo.toml
+++ b/exonum/Cargo.toml
@@ -44,6 +44,7 @@ bincode = "1.2.0"
 bit-vec = "0.6.0"
 criterion = "0.3.0"
 pretty_assertions = "0.6.1"
+rand = "0.7.3"
 serde_json = "1.0.19"
 
 [[bench]]

--- a/exonum/benches/criterion/check_tx.rs
+++ b/exonum/benches/criterion/check_tx.rs
@@ -1,0 +1,169 @@
+// Copyright 2020 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{BatchSize, Bencher, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+use exonum::{
+    blockchain::{
+        config::GenesisConfigBuilder, ApiSender, Blockchain, BlockchainBuilder, ConsensusConfig,
+        TxCheckCache,
+    },
+    crypto::KeyPair,
+    merkledb::{Snapshot, TemporaryDB},
+    messages::{AnyTx, Verified},
+    runtime::{
+        migrations::{InitMigrationError, MigrationScript},
+        oneshot::Receiver,
+        versioning::Version,
+        ArtifactId, CallInfo, ExecutionContext, ExecutionError, InstanceId, InstanceState, Mailbox,
+        Runtime, WellKnownRuntime,
+    },
+};
+
+#[derive(Debug)]
+struct DummyRuntime;
+
+impl Runtime for DummyRuntime {
+    fn deploy_artifact(&mut self, _artifact: ArtifactId, _deploy_spec: Vec<u8>) -> Receiver {
+        Receiver::with_result(Ok(()))
+    }
+
+    fn is_artifact_deployed(&self, _artifact: &ArtifactId) -> bool {
+        true
+    }
+
+    fn initiate_adding_service(
+        &self,
+        _context: ExecutionContext<'_>,
+        _artifact: &ArtifactId,
+        _parameters: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn initiate_resuming_service(
+        &self,
+        _context: ExecutionContext<'_>,
+        _artifact: &ArtifactId,
+        _parameters: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn update_service_status(&mut self, _snapshot: &dyn Snapshot, _state: &InstanceState) {
+        // Do nothing.
+    }
+
+    fn migrate(
+        &self,
+        _new_artifact: &ArtifactId,
+        _data_version: &Version,
+    ) -> Result<Option<MigrationScript>, InitMigrationError> {
+        unimplemented!()
+    }
+
+    fn execute(
+        &self,
+        _context: ExecutionContext<'_>,
+        _method_id: u32,
+        _arguments: &[u8],
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn before_transactions(&self, _context: ExecutionContext<'_>) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn after_transactions(&self, _context: ExecutionContext<'_>) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn after_commit(&mut self, _snapshot: &dyn Snapshot, _mailbox: &mut Mailbox) {
+        // Do nothing.
+    }
+}
+
+impl WellKnownRuntime for DummyRuntime {
+    const ID: u32 = 255;
+}
+
+fn prepare_blockchain() -> Blockchain {
+    const SERVICE_ID: InstanceId = 100;
+
+    let (consensus_config, keys) = ConsensusConfig::for_tests(1);
+    let artifact = ArtifactId::new(DummyRuntime::ID, "ts", Version::new(1, 0, 0)).unwrap();
+    let service = artifact.clone().into_default_instance(SERVICE_ID, "ts");
+
+    let blockchain = Blockchain::new(TemporaryDB::new(), keys.service, ApiSender::closed());
+    let genesis_config = GenesisConfigBuilder::with_consensus_config(consensus_config)
+        .with_artifact(artifact)
+        .with_instance(service)
+        .build();
+    BlockchainBuilder::new(blockchain)
+        .with_genesis_config(genesis_config)
+        .with_runtime(DummyRuntime)
+        .build()
+        .immutable_view()
+}
+
+fn prepare_transactions(count: usize) -> Vec<Verified<AnyTx>> {
+    const RNG_SEED: u64 = 123_456_789;
+
+    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    (0..count)
+        .map(|_| {
+            let mut payload = [0_u8; 64];
+            rng.fill(&mut payload[..]);
+            let payload = AnyTx::new(CallInfo::new(100, 0), payload.to_vec());
+            payload.sign_with_keypair(&KeyPair::random())
+        })
+        .collect()
+}
+
+fn check_tx_no_cache(bencher: &mut Bencher) {
+    let blockchain = prepare_blockchain();
+    let transactions = prepare_transactions(128);
+    let snapshot = blockchain.snapshot();
+    bencher.iter(|| {
+        transactions
+            .iter()
+            .all(|tx| Blockchain::check_tx(&snapshot, tx).is_ok())
+    })
+}
+
+fn check_tx_cache(bencher: &mut Bencher) {
+    let blockchain = prepare_blockchain();
+    let transactions = prepare_transactions(128);
+    let snapshot = blockchain.snapshot();
+
+    bencher.iter_batched(
+        TxCheckCache::new,
+        |mut cache| {
+            transactions
+                .iter()
+                .all(|tx| Blockchain::check_tx_with_cache(&snapshot, tx, &mut cache).is_ok())
+        },
+        BatchSize::SmallInput,
+    )
+}
+
+pub fn bench_check_tx(c: &mut Criterion) {
+    let mut group = c.benchmark_group("check_tx/single_service");
+    group
+        .bench_function("no_cache", check_tx_no_cache)
+        .bench_function("cache", check_tx_cache);
+    group.finish();
+}

--- a/exonum/benches/criterion/check_tx.rs
+++ b/exonum/benches/criterion/check_tx.rs
@@ -138,9 +138,9 @@ fn check_tx_no_cache(bencher: &mut Bencher) {
     let transactions = prepare_transactions(128);
     let snapshot = blockchain.snapshot();
     bencher.iter(|| {
-        transactions
+        assert!(transactions
             .iter()
-            .all(|tx| Blockchain::check_tx(&snapshot, tx).is_ok())
+            .all(|tx| Blockchain::check_tx(&snapshot, tx).is_ok()));
     })
 }
 
@@ -152,9 +152,9 @@ fn check_tx_cache(bencher: &mut Bencher) {
     bencher.iter_batched(
         TxCheckCache::new,
         |mut cache| {
-            transactions
+            assert!(transactions
                 .iter()
-                .all(|tx| Blockchain::check_tx_with_cache(&snapshot, tx, &mut cache).is_ok())
+                .all(|tx| Blockchain::check_tx_with_cache(&snapshot, tx, &mut cache).is_ok()));
         },
         BatchSize::SmallInput,
     )

--- a/exonum/benches/criterion/crypto.rs
+++ b/exonum/benches/criterion/crypto.rs
@@ -42,7 +42,7 @@ fn bench_hash(b: &mut Bencher<'_>, &count: &usize) {
 }
 
 pub fn bench_crypto(c: &mut Criterion) {
-    ::exonum::crypto::init();
+    exonum::crypto::init();
 
     // Testing crypto functions with different data sizes.
     //

--- a/exonum/benches/criterion/lib.rs
+++ b/exonum/benches/criterion/lib.rs
@@ -14,9 +14,10 @@
 
 use criterion::{criterion_group, criterion_main};
 
-use crate::crypto::bench_crypto;
+use crate::{check_tx::bench_check_tx, crypto::bench_crypto};
 
+mod check_tx;
 mod crypto;
 
-criterion_group!(benches, bench_crypto);
+criterion_group!(benches, bench_check_tx, bench_crypto);
 criterion_main!(benches);

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -24,6 +24,7 @@ pub use self::{
     config::{ConsensusConfig, ConsensusConfigBuilder, ValidatorKeys},
     schema::{CallErrorsIter, CallInBlock, CallRecords, Schema, TxLocation},
 };
+pub use crate::runtime::TxCheckCache;
 
 pub mod config;
 
@@ -267,7 +268,16 @@ impl Blockchain {
     /// executed successfully, but returned `Err(..)` value means that this transaction is
     /// **obviously** incorrect and should be declined as early as possible.
     pub fn check_tx(snapshot: &dyn Snapshot, tx: &Verified<AnyTx>) -> Result<(), ExecutionError> {
-        Dispatcher::check_tx(snapshot, tx)
+        Dispatcher::check_tx(snapshot, tx, None)
+    }
+
+    /// Checks transaction with cache.
+    pub fn check_tx_with_cache(
+        snapshot: &dyn Snapshot,
+        tx: &Verified<AnyTx>,
+        cache: &mut TxCheckCache,
+    ) -> Result<(), ExecutionError> {
+        Dispatcher::check_tx(snapshot, tx, Some(cache))
     }
 }
 

--- a/exonum/src/blockchain/mod.rs
+++ b/exonum/src/blockchain/mod.rs
@@ -267,11 +267,20 @@ impl Blockchain {
     /// Returned `Ok(())` value doesn't necessarily mean that transaction is correct and will be
     /// executed successfully, but returned `Err(..)` value means that this transaction is
     /// **obviously** incorrect and should be declined as early as possible.
+    ///
+    /// See [`check_tx_with_cache`](#method.check_tx_with_cache) for a more efficient alternative
+    /// for repeated checks.
     pub fn check_tx(snapshot: &dyn Snapshot, tx: &Verified<AnyTx>) -> Result<(), ExecutionError> {
         Dispatcher::check_tx(snapshot, tx, None)
     }
 
-    /// Checks transaction with cache.
+    /// Performs several shallow checks that transaction is correct, using the provided cache
+    /// for speed-up.
+    ///
+    /// See [`TxCheckCache`] docs for the details how caching should be set up, and
+    /// [`check_tx`](#method.check_tx) for the semantics of the returned value.
+    ///
+    /// [`TxCheckCache`]: struct.TxCheckCache.html
     pub fn check_tx_with_cache(
         snapshot: &dyn Snapshot,
         tx: &Verified<AnyTx>,

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -224,6 +224,30 @@ impl Migrations {
 ///
 /// A single cache object is only valid for a single blockchain height, which **MUST** be ensured
 /// by the caller. Using the cache with multiple heights may lead to unpredictable results.
+///
+/// # Examples
+///
+/// ```
+/// # use exonum::{blockchain::{Blockchain, TxCheckCache}, messages::{AnyTx, Verified}};
+/// # use exonum::merkledb::{Database, TemporaryDB};
+/// let mut check_cache = TxCheckCache::new();
+/// let snapshot = // (blockchain snapshot)
+/// #   TemporaryDB::new().snapshot();
+/// let transactions: Vec<Verified<AnyTx>> = // ...
+/// #   vec![];
+///
+/// // Check that all `transactions` are correct.
+/// assert!(transactions
+///     .iter()
+///     .all(|transaction| {
+///         Blockchain::check_tx_with_cache(
+///             &snapshot,
+///             transaction,
+///             &mut check_cache,
+///         )
+///         .is_ok()
+///     }));
+/// ```
 #[derive(Debug, Default)]
 pub struct TxCheckCache {
     service_states: HashMap<InstanceId, Option<InstanceStatus>>,
@@ -246,7 +270,7 @@ impl TxCheckCache {
         CoreError::ServiceNotActive.with_description(msg)
     }
 
-    /// Creates a new cache for checking transaction validity.
+    /// Creates a new empty cache for checking transaction validity.
     pub fn new() -> Self {
         Self::default()
     }

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -220,6 +220,55 @@ impl Migrations {
     }
 }
 
+/// Opaque cache used for transaction checking.
+///
+/// A single cache object is only valid for a single blockchain height, which **MUST** be ensured
+/// by the caller. Using the cache with multiple heights may lead to unpredictable results.
+#[derive(Debug, Default)]
+pub struct TxCheckCache {
+    service_states: HashMap<InstanceId, Option<InstanceStatus>>,
+}
+
+impl TxCheckCache {
+    fn missing_error(service_id: InstanceId) -> ExecutionError {
+        let msg = format!(
+            "Cannot dispatch transaction to unknown service with ID {}",
+            service_id
+        );
+        CoreError::IncorrectInstanceId.with_description(msg)
+    }
+
+    fn non_active_error(service_id: InstanceId, status: &InstanceStatus) -> ExecutionError {
+        let msg = format!(
+            "Cannot dispatch transaction to non-active service `{}` (status: {})",
+            service_id, status
+        );
+        CoreError::ServiceNotActive.with_description(msg)
+    }
+
+    /// Creates a new cache for checking transaction validity.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn set_missing_service(&mut self, service_id: InstanceId) {
+        self.service_states.insert(service_id, None);
+    }
+
+    fn set_service_status(&mut self, service_id: InstanceId, status: InstanceStatus) {
+        self.service_states.insert(service_id, Some(status));
+    }
+
+    fn check_service_status(&self, service_id: InstanceId) -> Option<Result<(), ExecutionError>> {
+        let status = self.service_states.get(&service_id)?.as_ref();
+        Some(match status {
+            None => Err(Self::missing_error(service_id)),
+            Some(InstanceStatus::Active) => Ok(()),
+            Some(other_status) => Err(Self::non_active_error(service_id, other_status)),
+        })
+    }
+}
+
 /// A collection of `Runtime`s capable of modifying the blockchain state.
 #[derive(Debug)]
 pub struct Dispatcher {
@@ -551,30 +600,46 @@ impl Dispatcher {
     pub(crate) fn check_tx(
         snapshot: &dyn Snapshot,
         tx: &Verified<AnyTx>,
+        mut cache: Option<&mut TxCheckCache>,
     ) -> Result<(), ExecutionError> {
+        let service_id = tx.as_ref().call_info.instance_id;
+
+        if let Some(cache) = cache.as_deref_mut() {
+            if let Some(res) = cache.check_service_status(service_id) {
+                return res;
+            }
+        }
+
         // Currently the only check is that destination service exists, but later
         // functionality of this method can be extended.
-        let call_info = &tx.as_ref().call_info;
         let instance = Schema::new(snapshot)
-            .get_instance(call_info.instance_id)
+            .get_instance(service_id)
             .ok_or_else(|| {
-                let msg = format!(
-                    "Cannot dispatch transaction to unknown service with ID {}",
-                    call_info.instance_id
-                );
-                CoreError::IncorrectInstanceId.with_description(msg)
+                if let Some(cache) = cache.as_deref_mut() {
+                    cache.set_missing_service(service_id);
+                }
+                TxCheckCache::missing_error(service_id)
             })?;
 
         match instance.status {
-            Some(InstanceStatus::Active) => Ok(()),
-            status => {
-                let status_str = status.map_or_else(|| "none".to_owned(), |st| st.to_string());
-                let msg = format!(
-                    "Cannot dispatch transaction to non-active service `{}` (status: {})",
-                    instance.spec.as_descriptor(),
-                    status_str
-                );
-                Err(CoreError::ServiceNotActive.with_description(msg))
+            Some(InstanceStatus::Active) => {
+                if let Some(cache) = cache.as_deref_mut() {
+                    cache.set_service_status(service_id, InstanceStatus::Active);
+                }
+                Ok(())
+            }
+            Some(status) => {
+                let err = TxCheckCache::non_active_error(service_id, &status);
+                if let Some(cache) = cache.as_deref_mut() {
+                    cache.set_service_status(service_id, status);
+                }
+                Err(err)
+            }
+            None => {
+                if let Some(cache) = cache.as_deref_mut() {
+                    cache.set_missing_service(service_id);
+                }
+                Err(TxCheckCache::missing_error(service_id))
             }
         }
     }

--- a/exonum/src/runtime/mod.rs
+++ b/exonum/src/runtime/mod.rs
@@ -201,6 +201,8 @@
 //! [docs:lifecycle]: https://exonum.com/doc/version/latest/architecture/service-lifecycle/
 //! [blog:lifecycle]: https://medium.com/meetbitfury/about-service-lifecycles-in-exonum-58c67678c6bb
 
+#[doc(hidden)] // re-exported from the `blockchain` module
+pub use self::dispatcher::TxCheckCache;
 pub use self::{
     blockchain_data::{BlockchainData, SnapshotExt},
     dispatcher::{


### PR DESCRIPTION
## Overview

This PR caches results of `Blockchain::check_tx`. A simple benchmark included in the PR shows ~100x performance improvement, but it is unlikely that `check_tx` was a bottleneck before (it has provided throughput ~100K transactions per second even without caching).

---

See: https://jira.bf.local/browse/ECR-4376