### PR TITLE
Error backtrace [ECR-4353]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - It is now possible cache results of transaction correctness verification,
   which leads to a moderate improvement in node performance. (#1844)
 
+- Backtrace is now included into `ExecutionError`s. (#1850)
+
 ## 1.0.0 - 2020-03-31
 
 ### Breaking Changes

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -5,6 +5,7 @@ appveyor
 atomicity
 backend
 backends
+backtrace
 bigint
 bincode
 bitfury

--- a/exonum/src/blockchain/schema.rs
+++ b/exonum/src/blockchain/schema.rs
@@ -472,9 +472,9 @@ impl<T: Access> CallRecords<T> {
         let block_proof = Schema::new(self.access.clone())
             .block_and_precommits(self.height)
             .unwrap();
-        let error_description = self.errors_aux.get(&call).map(|aux| aux.description);
+        let error_aux = self.errors_aux.get(&call);
         let call_proof = self.errors.get_proof(call);
-        CallProof::new(block_proof, call_proof, error_description)
+        CallProof::new(block_proof, call_proof, error_aux)
     }
 }
 

--- a/exonum/src/proto/schema/exonum/proofs.proto
+++ b/exonum/src/proto/schema/exonum/proofs.proto
@@ -20,6 +20,7 @@ option java_package = "com.exonum.messages.core";
 
 import "exonum/blockchain.proto";
 import "exonum/messages.proto";
+import "exonum/runtime/errors.proto";
 import "exonum/proof/map_proof.proto";
 
 // Block with its `Precommit` messages.
@@ -55,4 +56,7 @@ message CallProof {
   proof.MapProof call_proof = 2;
   // Human-readable description of an error if the call status is erroneous.
   string error_description = 3;
+  // Error backtrace. The backtrace excludes the call in which the error has occurred
+  // (it is recorded directly in `ExecutionError`). The most recent call is first.
+  repeated runtime.CallSite error_backtrace = 4;
 }

--- a/exonum/src/proto/schema/exonum/runtime/errors.proto
+++ b/exonum/src/proto/schema/exonum/runtime/errors.proto
@@ -77,6 +77,10 @@ message ExecutionError {
     // There was no service to process an erroneous call.
     google.protobuf.Empty no_call_site = 7;
   }
+
+  // Error backtrace. The backtrace excludes the call in which the error has occurred
+  // (it is recorded in `call_site`). The most recent call is first.
+  repeated CallSite backtrace = 8;
 }
 
 // Additional details about an `ExecutionError` that do not influence
@@ -84,6 +88,9 @@ message ExecutionError {
 message ExecutionErrorAux {
   // Human-readable error description.
   string description = 1;
+  // Error backtrace. The backtrace excludes the call in which the error has occurred
+  // (it is recorded directly in `ExecutionError`). The most recent call is first.
+  repeated CallSite backtrace = 2;
 }
 
 // Call site associated with an error.

--- a/exonum/src/runtime/dispatcher/mod.rs
+++ b/exonum/src/runtime/dispatcher/mod.rs
@@ -728,7 +728,7 @@ impl Dispatcher {
             fork.rollback();
 
             err.set_runtime_id(runtime_id)
-                .set_call_site(|| CallSite::from_call_info(call_info, ""));
+                .set_call_site(CallSite::from_call_info(call_info, ""));
             Self::report_error(err, fork, CallInBlock::transaction(tx_index));
         } else {
             fork.flush();
@@ -766,7 +766,7 @@ impl Dispatcher {
                 if let Err(mut err) = res {
                     fork.rollback();
                     err.set_runtime_id(runtime_id)
-                        .set_call_site(|| CallSite::new(instance.id, call_type.clone()));
+                        .set_call_site(CallSite::new(instance.id, call_type.clone()));
 
                     let call = match &call_type {
                         CallType::BeforeTransactions => {

--- a/exonum/src/runtime/error/error_match.rs
+++ b/exonum/src/runtime/error/error_match.rs
@@ -203,6 +203,7 @@ mod tests {
             description: "Panic!".to_string(),
             runtime_id: None,
             call_site: None,
+            backtrace: vec![],
         };
         let mut matcher = ErrorMatch {
             kind: ErrorKind::Unexpected,

--- a/exonum/src/runtime/error/execution_error.rs
+++ b/exonum/src/runtime/error/execution_error.rs
@@ -113,9 +113,17 @@ impl ExecutionError {
         self.call_site.as_ref()
     }
 
-    pub(crate) fn set_call_site(&mut self, call_site: impl FnOnce() -> CallSite) -> &mut Self {
+    /// Returns the error backtrace. The backtrace excludes the call in which the error has occurred
+    /// (it is recorded in [`call_site`](#method.call_site)). The most recent call is first.
+    pub fn backtrace(&self) -> &[CallSite] {
+        &self.backtrace
+    }
+
+    pub(crate) fn set_call_site(&mut self, call_site: CallSite) -> &mut Self {
         if self.call_site.is_none() {
-            self.call_site = Some(call_site());
+            self.call_site = Some(call_site);
+        } else {
+            self.backtrace.push(call_site);
         }
         self
     }

--- a/exonum/src/runtime/error/execution_status.rs
+++ b/exonum/src/runtime/error/execution_status.rs
@@ -99,6 +99,8 @@ pub mod serde {
         runtime_id: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         call_site: Option<CallSite>,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        backtrace: Vec<CallSite>,
     }
 
     impl From<Result<(), &ExecutionError>> for ExecutionStatus {
@@ -118,6 +120,7 @@ pub mod serde {
                     code,
                     runtime_id: err.runtime_id,
                     call_site: err.call_site.clone(),
+                    backtrace: err.backtrace.clone(),
                 }
             } else {
                 Self {
@@ -126,6 +129,7 @@ pub mod serde {
                     code: None,
                     runtime_id: None,
                     call_site: None,
+                    backtrace: vec![],
                 }
             }
         }
@@ -165,6 +169,7 @@ pub mod serde {
                     description: self.description,
                     runtime_id: self.runtime_id,
                     call_site: self.call_site,
+                    backtrace: self.backtrace,
                 })
             })
         }

--- a/exonum/src/runtime/error/mod.rs
+++ b/exonum/src/runtime/error/mod.rs
@@ -120,6 +120,7 @@ pub struct ExecutionError {
     description: String,
     runtime_id: Option<u32>,
     call_site: Option<CallSite>,
+    backtrace: Vec<CallSite>,
 }
 
 /// Additional details about an `ExecutionError` that do not influence blockchain state hash.
@@ -128,6 +129,9 @@ pub struct ExecutionError {
 pub(crate) struct ExecutionErrorAux {
     /// Human-readable error description.
     pub description: String,
+    /// Backtrace. The backtrace excludes the call in which the error has occurred (it is recorded
+    /// in `ExecutionError.call_site`). The most recent call is first.
+    pub backtrace: Vec<CallSite>,
 }
 
 /// Invokes closure, capturing the cause of the unwinding panic if one occurs.

--- a/exonum/src/runtime/error/mod.rs
+++ b/exonum/src/runtime/error/mod.rs
@@ -101,17 +101,27 @@ pub trait ExecutionFail {
 /// - an [error kind][`ErrorKind`]
 /// - call information (runtime ID and, if appropriate, [`CallSite`] where the error has occurred)
 /// - an optional description
+/// - an error backtrace
 ///
-/// Call information is added by the core automatically; it is impossible to add from the service
-/// code. It *is* possible to inspect the call info for an error that was returned by a service
-/// though.
+/// Call information and backtrace are added by the core automatically; they are impossible
+/// to add from the service code. It *is* possible to inspect the call info / backtrace for an error
+/// that was returned by a service though.
 ///
-/// The error kind and call info affect the blockchain state hash, while the description does not.
+/// The error kind and call info affect the blockchain state hash, while the description
+/// and backtrace do not.
 /// Therefore descriptions are mostly used for developer purposes, not for interaction with users.
+///
+/// # Display Formats
+///
+/// - The default debug format `{:?}` on an `ExecutionError` will output complete
+///   information about the error, including the error backtrace.
+/// - To output an ordinary debug structure, use the alternate debug format `{:#?}`.
+/// - The default display format `{}` does not include the backtrace, but includes
+///   other error details.
 ///
 /// [`ErrorKind`]: enum.ErrorKind.html
 /// [`CallSite`]: struct.CallSite.html
-#[derive(Clone, Debug, Error, BinaryValue)]
+#[derive(Clone, Error, BinaryValue)]
 #[cfg_attr(test, derive(PartialEq))]
 // ^-- Comparing `ExecutionError`s directly is error-prone, since the call info is not controlled
 // by the caller. It is useful for roundtrip tests, though.

--- a/exonum/src/runtime/error/tests.rs
+++ b/exonum/src/runtime/error/tests.rs
@@ -207,6 +207,43 @@ fn execution_error_display() {
     assert!(err.to_string().contains("in Java runtime"));
 }
 
+fn create_error() -> ExecutionError {
+    ExecutionError {
+        kind: ErrorKind::Service { code: 10 },
+        description: "That is wrong!".to_owned(),
+        runtime_id: Some(1),
+        call_site: Some(CallSite::new(100, CallType::Resume)),
+        backtrace: vec![
+            CallSite::new(
+                10,
+                CallType::Method {
+                    interface: "exonum.Token".to_owned(),
+                    id: 1,
+                },
+            ),
+            CallSite::new(0, CallType::AfterTransactions),
+        ],
+    }
+}
+
+#[test]
+fn execution_error_debug_format() {
+    let message = format!("{:?}", create_error());
+    assert!(message.contains("occurred: That is wrong!\n"));
+    assert!(message.contains("Error backtrace (most recent call first)"));
+    assert!(message.contains("   0: resuming routine of service 100"));
+    assert!(message.contains("   1: exonum.Token::(method 1) of service 10"));
+    assert!(message.contains("   2: after_transactions hook of service 0"));
+}
+
+#[test]
+fn execution_error_alternate_debug_format() {
+    let message = format!("{:#?}", create_error());
+    assert!(!message.contains("occurred: That is wrong!\n"));
+    assert!(!message.contains("   0: resuming routine of service 100"));
+    assert!(message.contains("backtrace: ["));
+}
+
 #[test]
 fn execution_result_serde_presentation() {
     let result = ExecutionStatus(Ok(()));

--- a/exonum/src/runtime/error/tests.rs
+++ b/exonum/src/runtime/error/tests.rs
@@ -173,6 +173,7 @@ fn execution_error_display() {
         description: String::new(),
         runtime_id: Some(1),
         call_site: Some(CallSite::new(100, CallType::Constructor)),
+        backtrace: vec![],
     };
     let err_string = err.to_string();
     assert!(err_string.contains("Execution error with code `service:3`"));
@@ -219,6 +220,7 @@ fn execution_result_serde_presentation() {
         description: "Some error".to_owned(),
         runtime_id: None,
         call_site: None,
+        backtrace: vec![],
     }));
     assert_eq!(
         serde_json::to_value(result).unwrap(),
@@ -233,6 +235,7 @@ fn execution_result_serde_presentation() {
         description: String::new(),
         runtime_id: Some(1),
         call_site: Some(CallSite::new(100, CallType::Constructor)),
+        backtrace: vec![],
     }));
     assert_eq!(
         serde_json::to_value(result).unwrap(),
@@ -252,6 +255,7 @@ fn execution_result_serde_presentation() {
         description: String::new(),
         runtime_id: Some(1),
         call_site: Some(CallSite::new(100, CallType::Resume)),
+        backtrace: vec![CallSite::new(0, CallType::AfterTransactions)],
     }));
     assert_eq!(
         serde_json::to_value(result).unwrap(),
@@ -262,7 +266,10 @@ fn execution_result_serde_presentation() {
             "call_site": {
                 "instance_id": 100,
                 "call_type": "resume",
-            }
+            },
+            "backtrace": [
+                { "instance_id": 0, "call_type": "after_transactions" },
+            ],
         })
     );
 
@@ -277,6 +284,7 @@ fn execution_result_serde_presentation() {
                 id: 1,
             },
         )),
+        backtrace: vec![],
     }));
     assert_eq!(
         serde_json::to_value(result).unwrap(),

--- a/exonum/src/runtime/execution_context.rs
+++ b/exonum/src/runtime/execution_context.rs
@@ -194,7 +194,7 @@ impl<'a> ExecutionContext<'a> {
             .map_err(|mut err| {
                 self.should_rollback();
                 err.set_runtime_id(spec.artifact.runtime_id)
-                    .set_call_site(|| CallSite::new(spec.id, CallType::Constructor));
+                    .set_call_site(CallSite::new(spec.id, CallType::Constructor));
                 err
             })?;
 
@@ -329,15 +329,13 @@ impl ExecutionContextUnstable for ExecutionContext<'_> {
             .execute(context, method_id, arguments)
             .map_err(|mut err| {
                 self.should_rollback();
-                err.set_runtime_id(runtime_id).set_call_site(|| {
-                    CallSite::new(
-                        instance_id,
-                        CallType::Method {
-                            interface: interface_name.to_owned(),
-                            id: method_id,
-                        },
-                    )
-                });
+                err.set_runtime_id(runtime_id).set_call_site(CallSite::new(
+                    instance_id,
+                    CallType::Method {
+                        interface: interface_name.to_owned(),
+                        id: method_id,
+                    },
+                ));
                 err
             })
     }
@@ -453,7 +451,7 @@ impl SupervisorExtensions<'_> {
             .map_err(|mut err| {
                 self.0.should_rollback();
                 err.set_runtime_id(spec.artifact.runtime_id)
-                    .set_call_site(|| CallSite::new(instance_id, CallType::Resume));
+                    .set_call_site(CallSite::new(instance_id, CallType::Resume));
                 err
             })
     }


### PR DESCRIPTION
## Overview

This PR adds backtrace to `ExecutionError`. 

---

See: https://jira.bf.local/browse/ECR-4353