### PR TITLE
More verbose REST API error responses [ECR-2696]

### DIFF
--- a/components/api/src/manager.rs
+++ b/components/api/src/manager.rs
@@ -32,7 +32,7 @@ use std::{
     time::Duration,
 };
 
-use crate::{AllowOrigin, ApiAccess, ApiAggregator, ApiBuilder};
+use crate::{backends::actix::error_handlers, AllowOrigin, ApiAccess, ApiAggregator, ApiBuilder};
 
 /// Configuration parameters for a single web server.
 #[derive(Debug, Clone)]
@@ -356,6 +356,7 @@ impl ApiManager {
         let mut server_builder = HttpServer::new(move || {
             App::new()
                 .wrap(server_config.cors_factory())
+                .wrap(error_handlers())
                 .service(aggregator.extend_backend(access, web::scope("api")))
         })
         .listen(listener)?;

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -60,6 +60,7 @@ doctest
 doctests
 emsp
 encodable
+errhandlers
 errored
 Exonum
 exonumhub


### PR DESCRIPTION
Use `JsonBody` in the error responses.
Provide mechanism to override default error handlers.