### PR TITLE
Add a possibility to set max allowed json payload size [ECR-4427]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   The module was renamed to `pool` and related names were updated accordingly.
   (#1840)
 
+#### exonum-api
+
+- Added a possibility to set max allowed json payload size in `node.toml` config
+  file in `api` section (e.g. `json_payload_size = 1048576`). (#1918)
+
 ### Internal Improvements
 
 #### exonum

--- a/components/api/Cargo.toml
+++ b/components/api/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "exonum/exonum" }
 [dependencies]
 actix-cors = "0.4.0"
 actix-rt = "1.1"
-actix-web = { version = "3.0.2", default-features = false }
+actix-web = { version = "3.3.0", default-features = false }
 anyhow = "1.0"
 chrono = { version = "0.4.15", features = ["serde"] }
 futures = "0.3.5"

--- a/components/system-api/Cargo.toml
+++ b/components/system-api/Cargo.toml
@@ -20,7 +20,7 @@ exonum = { version = "1.0.0", path = "../../exonum" }
 exonum-api = { version = "1.0.0", path = "../api" }
 exonum-node = { version = "1.0.0", path = "../../exonum-node" }
 
-actix-web = { version = "3.0.2", default-features = false }
+actix-web = { version = "3.3.0", default-features = false }
 futures = "0.3.4"
 semver = "0.10.0"
 serde = "1.0"

--- a/exonum-node/src/lib.rs
+++ b/exonum-node/src/lib.rs
@@ -1384,7 +1384,7 @@ impl Reactor {
 
     /// Listens to the same 3 signals as `actix`: SIGINT, SIGTERM, and SIGQUIT.
     #[cfg(unix)]
-    #[allow(clippy::mut_mut)] // occurs in the `select!` macro
+    #[allow(clippy::mut_mut, clippy::unused_unit)] // occurs in the `select!` macro
     async fn listen_to_signals() {
         use futures::StreamExt;
         use tokio::signal::unix::{signal, SignalKind};
@@ -1415,7 +1415,7 @@ impl Reactor {
             _ = int_listener => (),
             _ = term_listener.next() => (),
             _ = quit_listener.next() => (),
-        }
+        };
     }
 
     #[cfg(not(unix))]

--- a/exonum-node/src/lib.rs
+++ b/exonum-node/src/lib.rs
@@ -229,6 +229,9 @@ pub struct NodeApiConfig {
     ///
     /// [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     pub private_allow_origin: Option<AllowOrigin>,
+    /// Json payload size. If value is `None` (default value) the allowed size of receiving payload
+    /// would be 32 Kb.
+    pub json_payload_size: Option<usize>,
     /// HTTP server restart policy. The server is restarted each time the list of endpoints
     /// is updated (e.g., due to a new service initialization).
     #[serde(default)]
@@ -243,6 +246,7 @@ impl Default for NodeApiConfig {
             private_api_address: None,
             public_allow_origin: None,
             private_allow_origin: None,
+            json_payload_size: None,
             server_restart: ServerRestartPolicy::default(),
         }
     }
@@ -1210,6 +1214,7 @@ impl Node {
         if let Some(listen_address) = api_cfg.public_api_address {
             let mut server_config = WebServerConfig::new(listen_address);
             server_config.allow_origin = api_cfg.public_allow_origin.clone();
+            server_config.json_payload_size = api_cfg.json_payload_size;
             servers.insert(ApiAccess::Public, server_config);
         }
         if let Some(listen_address) = api_cfg.private_api_address {

--- a/runtimes/rust/Cargo.toml
+++ b/runtimes/rust/Cargo.toml
@@ -22,7 +22,7 @@ exonum-derive = { version = "1.0.0", path = "../../components/derive" }
 exonum-merkledb = { version = "1.0.0", path = "../../components/merkledb" }
 exonum-proto = { version = "1.0.0", path = "../../components/proto" }
 
-actix-web = "3.0.2"
+actix-web = "3.3.0"
 futures = "0.3.5"
 log = "0.4.11"
 protobuf = "2.17.0"

--- a/services/explorer/Cargo.toml
+++ b/services/explorer/Cargo.toml
@@ -23,7 +23,7 @@ exonum-explorer = { version = "1.0.0", path = "../../components/explorer" }
 exonum-rust-runtime = { version = "1.0.0", path = "../../runtimes/rust" }
 
 actix = { version = "0.10.0", default-features = false }
-actix-web = { version = "3.0.2", default-features = false }
+actix-web = { version = "3.3.0", default-features = false }
 actix-web-actors = "3.0.0"
 anyhow = "1.0"
 futures = "0.3.4"

--- a/test-suite/testkit/Cargo.toml
+++ b/test-suite/testkit/Cargo.toml
@@ -32,8 +32,8 @@ exonum-proto = { version = "1.0.0", path = "../../components/proto" }
 exonum-rust-runtime = { version = "1.0.0", path = "../../runtimes/rust" }
 
 actix = { version = "0.10.0", default-features = false }
-#actix-rt = "1.1.1"
-actix-web = { version = "3.0.2", default-features = false }
+actix-rt = "1.1"
+actix-web = { version = "3.3.0", default-features = false }
 chrono = "0.4.6"
 futures = "0.3.4"
 log = "0.4.6"

--- a/test-suite/testkit/src/lib.rs
+++ b/test-suite/testkit/src/lib.rs
@@ -722,7 +722,7 @@ impl TestKit {
         &mut self.network
     }
 
-    #[allow(clippy::mut_mut)] // occurs withing `select!` macro
+    #[allow(clippy::mut_mut, clippy::unused_unit)] // occurs withing `select!` macro
     async fn run(mut self, public_api_address: SocketAddr, private_api_address: SocketAddr) {
         let events_task = self.remove_events_stream().fuse();
         futures::pin_mut!(events_task);


### PR DESCRIPTION
## Overview

The PR add a possibility to set max allowed size of json payload receiving in request (e.g. size of a transaction) via `node.toml` config file in `api` section.
E.g. 
```toml
...
[private_config.api]
state_update_timeout = 10000
json_payload_size = 1048576
...
```

---
<!-- This is for Exonum Team members only. -->
<!-- markdownlint-disable MD034 -->
See: https://jira.bf.local/browse/ECR-4427
<!-- markdownlint-enable MD034 -->

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
