### PR TITLE
Downgraded `futures-retry` to 0.5 in exonum-node

### DIFF
--- a/exonum-node/Cargo.toml
+++ b/exonum-node/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = { version = "1.3", features = ["i128"] }
 bytes = "0.5"
 chrono = "0.4.6"
 futures = "0.3.4"
-futures-retry = "0.6"
+futures-retry = "0.5"
 log = "0.4.6"
 protobuf = { version = "2.17.0", features = ["with-serde"] }
 rand = "0.7"


### PR DESCRIPTION
## Overview

`futures-retry` v0.6 depends on Tokio 1.6 while other parts of the framework use v0.2. It causes runtime error:

```
thread '...' panicked at 'there is no reactor running, must be called from the context of Tokio 0.2.x runtime'
```

### Definition of Done

- [ ] There are no TODOs left in the merged code
- [ ] Change is covered by automated tests
- [ ] Benchmark results are attached (if applicable)
- [ ] The [coding guidelines] are followed
- [ ] Public API has proper documentation
- [ ] Changelog is updated if needed (in case of notable or breaking changes)
- [ ] The continuous integration build passes

[coding guidelines]: https://github.com/exonum/exonum/blob/master/CONTRIBUTING.md#conventions
