### PR TITLE
Bump RocksDB to 0.17.

### DIFF
--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -26,7 +26,7 @@ enum-primitive-derive = "0.2"
 leb128 = "0.2"
 num-traits = "0.2"
 protobuf = { version = "2.17.0", features = ["with-serde"], optional = true }
-rocksdb = { version = "0.15", default-features = false }
+rocksdb = { version = "0.17", default-features = false }
 rust_decimal = "1.0"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
## Overview

Bring the RocksDb version to 0.17, and fix deprecation warnings with latest Rust 1.54.
