### PR TITLE
Fix performance regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,20 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Inner rocksdb database has been replaced for in-memory data structure in
   TemporaryDB. (#1872)
 
-- `chrono` crate has been replaced with `time` as outdated and unsupported.
+- `rocksdb` has been bumped to 0.19. (#2069)
+
+### Breaking Changes
+
+#### exonum-merkledb
+
+- `chrono` crate has been replaced with `time` as outdated and unsupported. (#2009)
+
+### Performance Improvements
+
+#### exonum-merkledb
+
+- Has been changed some rocksdb settings and made optimizations which prevents
+  performance regression. (#2070)
 
 ## 1.0.0 - 2020-03-31
 

--- a/exonum/src/runtime/dispatcher/schema.rs
+++ b/exonum/src/runtime/dispatcher/schema.rs
@@ -690,8 +690,13 @@ impl Schema<&Fork> {
                 };
                 (artifact, action)
             })
-            .collect();
-        index.clear();
+            .collect::<Vec<_>>();
+
+        if !pending_artifacts.is_empty() {
+            // Clear the index only if there are entities because it's not a cheap operation.
+            index.clear();
+        }
+
         pending_artifacts
     }
 
@@ -709,8 +714,12 @@ impl Schema<&Fork> {
                     .expect("BUG: Instance marked as modified is not saved in `instances`");
                 (state, info)
             })
-            .collect();
-        modified_instances.clear();
+            .collect::<Vec<_>>();
+
+        if !output.is_empty() {
+            // Clear the index only if there are entities because it's not a cheap operation.
+            modified_instances.clear();
+        }
 
         output
     }

--- a/services/supervisor/src/lib.rs
+++ b/services/supervisor/src/lib.rs
@@ -571,8 +571,11 @@ impl Supervisor {
             .map(|(_, request)| request)
             .collect::<Vec<_>>();
 
-        // Clear the index, since we will flush all the migrations now.
-        schema.migrations_to_flush.clear();
+        // Clear the index, since we will flush all the migrations now. Clear the index only if
+        // there are entities because it's not a cheap operation.
+        if !finished_migrations.is_empty() {
+            schema.migrations_to_flush.clear();
+        }
 
         drop(schema);
         for request in finished_migrations {


### PR DESCRIPTION
The PR fix performance regression occurs with time. The reason is that actively range deletion affects the time of getting an iterator of the column family. In hooks `before_transactions` and `commit_block`, we have exactly such behaviour. 

The PR adds two optimizations:

1. Providing `read_options` with setting true of param [ignore_range_deletions](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L1606) to `iterator_cf_opt` and `get_opt` methods.
2. Cleaning indexes in the hooks only if they were not empty to decrease the number of operations with the database.
