### PR TITLE
Add a variant of TemporaryDB like a wrapper over RocksDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,47 @@ jobs:
         with:
           command: test
           # Not enough space on a VM to test with param: --all-targets
-          args: -p exonum -p exonum-merkledb -p exonum-crypto -p exonum-cli -p exonum-keys -p exonum-node --tests
+          args: -p exonum -p exonum-rust-runtime -p exonum-crypto -p exonum-cli -p exonum-keys -p exonum-node --tests
+        env:
+          RUST_BACKTRACE: full
+
+  merkle_db_unit_tests:
+    name: MerkleDB Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [ Linux, MacOS, Windows ]
+        include:
+          - build: Linux
+            os: ubuntu-latest
+          - build: MacOS
+            os: macos-latest
+          - build: Windows
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
+        uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
+        if: runner.os == 'Windows'
+        with:
+          version: "11.0"
+          directory: ${{ runner.temp }}/llvm
+      - if: runner.os == 'Linux'
+        run: sudo apt-get install protobuf-compiler libprotobuf-dev librocksdb-dev
+      - if: runner.os == 'Windows'
+        run: |
+          choco install protoc minisign -y
+          echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+      - if: runner.os == 'MacOS'
+        run: brew install libsodium rocksdb pkg-config protobuf
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust }}
+      - run: |
+          cd components/merkledb
+          cargo test --all-targets
+          cargo test --all-targets -F persisted_tempdb
         env:
           RUST_BACKTRACE: full
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `rocksdb` has been bumped to 0.19. (#2069)
 
-- `TemporaryDB` could be used in two variants: 
+- `TemporaryDB` could be used in two variants:
   - In-memory (default);
   - Wrapper over `RockDB` (feature `persisted_tempdb`). (#2071)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - `rocksdb` has been bumped to 0.19. (#2069)
 
+- `TemporaryDB` could be used in two variants: 
+  - In-memory (default);
+  - Wrapper over `RockDB` (feature `persisted_tempdb`). (#2071)
+
 ### Breaking Changes
 
 #### exonum-merkledb

--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -20,13 +20,12 @@ exonum-proto = { path = "../proto", version = "1.0.0", optional = true }
 
 anyhow = "1.0"
 byteorder = "1.3"
-crossbeam = "0.8"
 enum-primitive-derive = "0.2"
 im = "15"
 leb128 = "0.2"
 num-traits = "0.2"
 protobuf = { version = "2", features = ["with-serde"], optional = true }
-rocksdb = { version = "0.19", default-features = false }
+rocksdb = { version = "0.19", default-features = false, features = [ "multi-threaded-cf" ] }
 rust_decimal = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
@@ -57,11 +56,13 @@ path = "benches/lib.rs"
 harness = false
 
 [features]
-default = ["rocksdb_snappy", "with-protobuf"]
+default = ["rocksdb_snappy", "rocksdb_multithreaded", "with-protobuf"]
 with-protobuf = ["with-serde", "protobuf", "exonum-proto"]
 with-serde = []
+persisted_tempdb = []
 
 # Compression options passed to RocksDB backend.
+rocksdb_multithreaded = ["rocksdb/multi-threaded-cf"]
 rocksdb_snappy = ["rocksdb/snappy"]
 rocksdb_lz4 = ["rocksdb/lz4"]
 rocksdb_zlib = ["rocksdb/zlib"]

--- a/components/merkledb/benches/benchmarks/mod.rs
+++ b/components/merkledb/benches/benchmarks/mod.rs
@@ -12,46 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use exonum_merkledb::{Database, DbOptions, Fork, Patch, Result, RocksDB, Snapshot};
-use tempfile::{tempdir, TempDir};
-
 pub mod encoding;
 pub mod schema_patterns;
 pub mod storage;
 pub mod transactions;
-
-pub(super) struct BenchDB {
-    _dir: TempDir,
-    db: RocksDB,
-}
-
-impl BenchDB {
-    pub(crate) fn new() -> Self {
-        let dir = tempdir().expect("Couldn't create tempdir");
-        let db =
-            RocksDB::open(dir.path(), &DbOptions::default()).expect("Couldn't create database");
-        Self { _dir: dir, db }
-    }
-
-    pub(crate) fn fork(&self) -> Fork {
-        self.db.fork()
-    }
-
-    pub(crate) fn snapshot(&self) -> Box<dyn Snapshot> {
-        self.db.snapshot()
-    }
-
-    pub(crate) fn merge(&self, patch: Patch) -> Result<()> {
-        self.db.merge(patch)
-    }
-
-    pub(crate) fn merge_sync(&self, patch: Patch) -> Result<()> {
-        self.db.merge_sync(patch)
-    }
-}
-
-impl Default for BenchDB {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/components/merkledb/benches/benchmarks/schema_patterns.rs
+++ b/components/merkledb/benches/benchmarks/schema_patterns.rs
@@ -20,10 +20,9 @@ use serde_derive::{Deserialize, Serialize};
 use exonum_crypto::Hash;
 use exonum_merkledb::{
     access::{Access, AccessExt, FromAccess, Prefixed, RawAccessMut},
-    Group, KeySetIndex, Lazy, MapIndex, ObjectHash, ProofListIndex, ProofMapIndex,
+    Database, Group, KeySetIndex, Lazy, MapIndex, ObjectHash, ProofListIndex, ProofMapIndex,
+    TemporaryDB,
 };
-
-use super::BenchDB;
 
 const SEED: [u8; 32] = [100; 32];
 const SAMPLE_SIZE: usize = 10;
@@ -266,7 +265,7 @@ fn bench<T: ExecuteTransaction>(bencher: &mut Bencher<'_>, prefixed: bool) {
     const PREFIX: &str = "moderately_long_prefix";
 
     let transactions = gen_random_transactions(TX_COUNT);
-    bencher.iter_with_setup(BenchDB::default, |db| {
+    bencher.iter_with_setup(TemporaryDB::default, |db| {
         let fork = db.fork();
         if prefixed {
             for transaction in &transactions {

--- a/components/merkledb/benches/benchmarks/storage.rs
+++ b/components/merkledb/benches/benchmarks/storage.rs
@@ -19,9 +19,9 @@ use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 use std::collections::HashSet;
 
 use exonum_crypto::{Hash, HASH_SIZE as KEY_SIZE};
-use exonum_merkledb::{access::CopyAccessExt, Fork, ListIndex, MapIndex, ObjectHash};
-
-use super::BenchDB;
+use exonum_merkledb::{
+    access::CopyAccessExt, Database, Fork, ListIndex, MapIndex, ObjectHash, TemporaryDB,
+};
 
 const NAME: &str = "name";
 const FAMILY: &str = "index_family";
@@ -74,7 +74,7 @@ fn generate_random_values(len: usize) -> Vec<Vec<u8>> {
 fn plain_map_index_insert(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
     b.iter_with_setup(
-        || (BenchDB::default(), data.clone()),
+        || (TemporaryDB::default(), data.clone()),
         |(db, data)| {
             let fork = db.fork();
             {
@@ -91,7 +91,7 @@ fn plain_map_index_insert(b: &mut Bencher<'_>, len: usize) {
 fn plain_map_index_with_family_insert(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
     b.iter_with_setup(
-        || (BenchDB::default(), data.clone()),
+        || (TemporaryDB::default(), data.clone()),
         |(db, data)| {
             let fork = db.fork();
             {
@@ -107,7 +107,7 @@ fn plain_map_index_with_family_insert(b: &mut Bencher<'_>, len: usize) {
 
 fn plain_map_index_iter(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
 
     {
@@ -133,7 +133,7 @@ fn plain_map_index_iter(b: &mut Bencher<'_>, len: usize) {
 
 fn plain_map_index_with_family_iter(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
 
     {
@@ -159,7 +159,7 @@ fn plain_map_index_with_family_iter(b: &mut Bencher<'_>, len: usize) {
 
 fn plain_map_index_read(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
 
     {
@@ -185,7 +185,7 @@ fn plain_map_index_read(b: &mut Bencher<'_>, len: usize) {
 
 fn plain_map_index_with_family_read(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
 
     {
@@ -219,7 +219,7 @@ fn proof_list_append(b: &mut Bencher<'_>, len: usize) {
         })
         .collect::<Vec<_>>();
 
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     b.iter_with_setup(
         || (db.fork(), data.clone()),
         |(fork, data)| {
@@ -242,7 +242,7 @@ fn proof_list_extend(b: &mut Bencher<'_>, len: usize) {
         })
         .collect::<Vec<_>>();
 
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     b.iter_with_setup(
         || (db.fork(), data.clone()),
         |(fork, data)| {
@@ -254,7 +254,7 @@ fn proof_list_extend(b: &mut Bencher<'_>, len: usize) {
 }
 
 fn proof_map_insert_without_merge(b: &mut Bencher<'_>, len: usize) {
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let data = generate_random_kv(len);
     b.iter_with_setup(
         || (db.fork(), data.clone()),
@@ -270,7 +270,7 @@ fn proof_map_insert_without_merge(b: &mut Bencher<'_>, len: usize) {
 fn proof_map_insert_with_merge(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
     b.iter_with_setup(
-        || (BenchDB::default(), data.clone()),
+        || (TemporaryDB::default(), data.clone()),
         |(db, data)| {
             let fork = db.fork();
             {
@@ -286,7 +286,7 @@ fn proof_map_insert_with_merge(b: &mut Bencher<'_>, len: usize) {
 
 fn proof_list_index_build_proofs(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_values(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
     let mut table = fork.get_proof_list(NAME);
 
@@ -310,7 +310,7 @@ fn proof_list_index_build_proofs(b: &mut Bencher<'_>, len: usize) {
 
 fn proof_list_index_verify_proofs(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_values(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
     let mut table = fork.get_proof_list(NAME);
 
@@ -330,7 +330,7 @@ fn proof_list_index_verify_proofs(b: &mut Bencher<'_>, len: usize) {
 
 fn proof_map_index_build_proofs(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
     let mut table = fork.get_proof_map(NAME);
 
@@ -353,7 +353,7 @@ fn proof_map_index_build_proofs(b: &mut Bencher<'_>, len: usize) {
 
 fn proof_map_index_verify_proofs(b: &mut Bencher<'_>, len: usize) {
     let data = generate_random_kv(len);
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     let fork = db.fork();
     let mut table = fork.get_proof_map(NAME);
 
@@ -401,7 +401,7 @@ fn fill_list(list: &mut ListIndex<&Fork, Vec<u8>>, rng: &mut impl Rng) {
 fn bench_index_clearing(bencher: &mut Bencher<'_>) {
     let mut rng = StdRng::from_seed(SEED);
 
-    let db = BenchDB::default();
+    let db = TemporaryDB::default();
     // Surround the cleared index with the indexes in the same column family.
     let fork = db.fork();
     for key in &[0_u8, 2] {

--- a/components/merkledb/src/backends/temporarydb/mod.rs
+++ b/components/merkledb/src/backends/temporarydb/mod.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::Database;
+
+#[cfg(not(feature = "persisted_tempdb"))]
+pub use memory::TemporaryDB;
+#[cfg(feature = "persisted_tempdb")]
+pub use persisted::TemporaryDB;
+
+#[cfg(not(feature = "persisted_tempdb"))]
+mod memory;
+#[cfg(feature = "persisted_tempdb")]
+mod persisted;
+
+impl Default for TemporaryDB {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(clippy::use_self)] // false positive
+impl From<TemporaryDB> for Arc<dyn Database> {
+    fn from(db: TemporaryDB) -> Self {
+        Arc::new(db)
+    }
+}
+
+#[test]
+fn clearing_database() {
+    use crate::access::CopyAccessExt;
+
+    let db = TemporaryDB::new();
+    let fork = db.fork();
+
+    fork.get_list("foo").extend(vec![1_u32, 2, 3]);
+    fork.get_proof_entry(("bar", &0_u8)).set("!".to_owned());
+    fork.get_proof_entry(("bar", &1_u8)).set("?".to_owned());
+    db.merge(fork.into_patch()).unwrap();
+    db.clear().unwrap();
+
+    let fork = db.fork();
+
+    assert!(fork.index_type("foo").is_none());
+    assert!(fork.index_type(("bar", &0_u8)).is_none());
+    assert!(fork.index_type(("bar", &1_u8)).is_none());
+    fork.get_proof_list("foo").extend(vec![4_u32, 5, 6]);
+    db.merge(fork.into_patch()).unwrap();
+
+    let snapshot = db.snapshot();
+    let list = snapshot.get_proof_list::<_, u32>("foo");
+
+    assert_eq!(list.len(), 3);
+    assert_eq!(list.iter().collect::<Vec<_>>(), vec![4, 5, 6]);
+}

--- a/components/merkledb/src/backends/temporarydb/persisted.rs
+++ b/components/merkledb/src/backends/temporarydb/persisted.rs
@@ -1,0 +1,71 @@
+// Copyright 2022 The Exonum Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An implementation of `TemporaryDB` database over `RockDB`.
+
+use tempfile::TempDir;
+
+use crate::{Database, DbOptions, Patch, Result, RocksDB, Snapshot};
+
+/// This database is only used for testing and experimenting; is not designed to
+/// operate under load in production.
+#[derive(Debug)]
+pub struct TemporaryDB {
+    db: RocksDB,
+    dir: TempDir,
+}
+
+impl TemporaryDB {
+    /// Creates a new, temporary, empty database.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("Couldn't create temp directory");
+        let db = RocksDB::open(dir.path(), &DbOptions::default())
+            .expect("Couldn't create temporary database");
+
+        Self { db, dir }
+    }
+
+    /// Clears the contents of the database.
+    pub fn clear(&self) -> Result<()> {
+        let opts = rocksdb::Options::default();
+        let cf_names = rocksdb::DB::list_cf(&opts, self.dir.path())?;
+        let db = self.db.get_inner();
+
+        for cf_name in cf_names {
+            let mut batch = rocksdb::WriteBatch::default();
+
+            if let Some(cf) = db.cf_handle(&cf_name) {
+                self.db.clear_column_family(&mut batch, &cf);
+                db.write(batch)?;
+                db.flush_cf(&cf)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Database for TemporaryDB {
+    fn snapshot(&self) -> Box<dyn Snapshot> {
+        self.db.snapshot()
+    }
+
+    fn merge(&self, patch: Patch) -> Result<()> {
+        self.db.merge(patch)
+    }
+
+    fn merge_sync(&self, patch: Patch) -> Result<()> {
+        self.db.merge_sync(patch)
+    }
+}

--- a/components/merkledb/src/indexes/proof_list/proof_builder.rs
+++ b/components/merkledb/src/indexes/proof_list/proof_builder.rs
@@ -68,7 +68,7 @@ where
         // Exclusive upper boundary of the proof range.
         let to = match indexes.end_bound() {
             Bound::Unbounded => self.len(),
-            // Saturation below doesn't matter: if `to == u64::max_value()`, it is guaranteed
+            // Saturation below doesn't matter: if `to == u64::MAX`, it is guaranteed
             // to be larger than any possible list length.
             Bound::Included(to) => to.saturating_add(1),
             Bound::Excluded(to) => *to,

--- a/components/merkledb/src/indexes/proof_list/tests.rs
+++ b/components/merkledb/src/indexes/proof_list/tests.rs
@@ -75,8 +75,8 @@ fn get_and_iter_from_with_overly_large_index() {
         (1_u64 << 56) + 10,
         1_u64 << 57,
         1_u64 << 60,
-        u64::max_value() - 10,
-        u64::max_value(),
+        u64::MAX - 10,
+        u64::MAX,
     ];
 
     let db = TemporaryDB::new();
@@ -378,8 +378,8 @@ fn proofs_with_overly_large_indexes() {
         (1_u64 << 56) + 10,
         1_u64 << 57,
         1_u64 << 60,
-        u64::max_value() - 10,
-        u64::max_value(),
+        u64::MAX - 10,
+        u64::MAX,
     ];
 
     let db = TemporaryDB::new();
@@ -401,7 +401,7 @@ fn proofs_with_overly_large_index_ranges() {
         (1_u64 << 56) + 10,
         1_u64 << 57,
         1_u64 << 60,
-        u64::max_value() - 10,
+        u64::MAX - 10,
     ];
 
     let db = TemporaryDB::new();
@@ -423,11 +423,11 @@ fn proofs_with_overly_large_index_ranges() {
         assert!(checked_proof.entries().is_empty());
     }
 
-    let proof = index.get_range_proof(..=u64::max_value());
+    let proof = index.get_range_proof(..=u64::MAX);
     let checked_proof = proof.check_against_hash(index.object_hash()).unwrap();
     assert_eq!(checked_proof.entries().len(), 10);
 
-    let proof = index.get_range_proof(7..u64::max_value());
+    let proof = index.get_range_proof(7..u64::MAX);
     let checked_proof = proof.check_against_hash(index.object_hash()).unwrap();
     assert_eq!(checked_proof.entries().len(), 3);
 }

--- a/components/merkledb/src/indexes/proof_list/tests.rs
+++ b/components/merkledb/src/indexes/proof_list/tests.rs
@@ -651,8 +651,8 @@ fn ranges_work_similar_to_vec_slicing() {
 
     let v = vec![1, 2, 3, 4, 5];
     check_bounds(&v, .., ..);
-    for start in 0_usize..10 {
-        for end in 0_usize..10 {
+    for start in 0..5 {
+        for end in 0..5 {
             check_bounds(&v, start..end, (start as u64)..(end as u64));
             check_bounds(&v, start..=end, (start as u64)..=(end as u64));
             if start == 0 {
@@ -1215,11 +1215,11 @@ mod root_hash {
 
     #[test]
     fn object_hash_with_strings() {
-        const STRING: &str = "All human beings are born free and equal in dignity and rights. \
-             They are endowed with reason and conscience and should act towards one another \
-             in a spirit of brotherhood.";
+        let words = "All human beings are born free and equal in dignity and rights."
+            .split_whitespace()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
 
-        let words: Vec<_> = STRING.split_whitespace().map(str::to_owned).collect();
         for i in 1..words.len() {
             assert_object_hash_correct(&words[..i]);
         }

--- a/components/merkledb/src/keys.rs
+++ b/components/merkledb/src/keys.rs
@@ -121,12 +121,12 @@ impl BinaryKey for i8 {
     }
 
     fn write(&self, buffer: &mut [u8]) -> usize {
-        buffer[0] = self.wrapping_add(Self::min_value()) as u8;
+        buffer[0] = self.wrapping_add(Self::MIN) as u8;
         self.size()
     }
 
     fn read(buffer: &[u8]) -> Self::Owned {
-        buffer[0].wrapping_sub(Self::min_value() as u8) as Self
+        buffer[0].wrapping_sub(Self::MIN as u8) as Self
     }
 }
 
@@ -158,12 +158,12 @@ macro_rules! storage_key_for_ints {
             }
 
             fn write(&self, buffer: &mut [u8]) -> usize {
-                BigEndian::$write_method(buffer, self.wrapping_add(Self::min_value()) as $utype);
+                BigEndian::$write_method(buffer, self.wrapping_add(Self::MIN) as $utype);
                 self.size()
             }
 
             fn read(buffer: &[u8]) -> Self {
-                BigEndian::$read_method(buffer).wrapping_sub(Self::min_value() as $utype) as Self
+                BigEndian::$read_method(buffer).wrapping_sub(Self::MIN as $utype) as Self
             }
         }
     };
@@ -388,7 +388,7 @@ mod tests {
 
                 // Fuzzed roundtrip
                 let mut buffer = [0_u8; $size];
-                let handpicked_vals = vec![$type::min_value(), $type::max_value()];
+                let handpicked_vals = vec![$type::MIN, $type::MAX];
                 for x in rng
                     .sample_iter(&Standard)
                     .take(FUZZ_SAMPLES)

--- a/components/merkledb/src/values.rs
+++ b/components/merkledb/src/values.rs
@@ -278,7 +278,7 @@ mod tests {
         ($name:ident, $type:tt) => {
             #[test]
             fn $name() {
-                let values = [$type::min_value(), 1, $type::max_value()];
+                let values = [$type::MIN, 1, $type::MAX];
                 assert_round_trip_eq(&values);
             }
         };
@@ -288,7 +288,7 @@ mod tests {
         ($name:ident, $type:tt) => {
             #[test]
             fn $name() {
-                let values = [$type::min_value(), -1, 0, 1, $type::max_value()];
+                let values = [$type::MIN, -1, 0, 1, $type::MAX];
                 assert_round_trip_eq(&values);
             }
         };

--- a/components/merkledb/src/views/metadata.rs
+++ b/components/merkledb/src/views/metadata.rs
@@ -910,7 +910,7 @@ mod prop_tests {
 
     use std::collections::{BTreeSet, HashMap};
 
-    const ACTIONS_MAX_LEN: usize = 30;
+    const ACTIONS_MAX_LEN: usize = 10;
     const DEFAULT_BUFFER_SIZE: usize = 1_000;
     const SMALL_BUFFER_SIZE: usize = 3;
 

--- a/components/merkledb/src/views/metadata.rs
+++ b/components/merkledb/src/views/metadata.rs
@@ -929,7 +929,7 @@ mod prop_tests {
         ("foo", Some(0)),
         ("foo", Some(1)),
         ("foo", Some(256)),
-        ("foo", Some(u32::max_value())),
+        ("foo", Some(u32::MAX)),
         ("foo_", None),
         ("foo1", Some(0)),
     ];

--- a/components/merkledb/tests/backup.rs
+++ b/components/merkledb/tests/backup.rs
@@ -31,7 +31,7 @@ use exonum_merkledb::{
 mod work;
 use self::work::*;
 
-const ACTIONS_MAX_LEN: usize = 20;
+const ACTIONS_MAX_LEN: usize = 10;
 
 #[derive(Debug, Clone)]
 enum Action {

--- a/components/merkledb/tests/common/mod.rs
+++ b/components/merkledb/tests/common/mod.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 use exonum_merkledb::{Database, Fork, TemporaryDB};
 
 // Max size of the generated sequence of actions.
-pub const ACTIONS_MAX_LEN: usize = 100;
+pub const ACTIONS_MAX_LEN: usize = 10;
 
 pub trait FromFork {
     fn from_fork(fork: Rc<Fork>) -> Self;

--- a/components/merkledb/tests/iter.rs
+++ b/components/merkledb/tests/iter.rs
@@ -304,7 +304,7 @@ where
 
     let large_starts = (10..64)
         .map(|pow| 1_u64 << pow)
-        .chain((0..10).map(|diff| u64::max_value() - diff));
+        .chain((0..10).map(|diff| u64::MAX - diff));
     for start in large_starts {
         prop_assert_eq!(index.index_iter(Some(&start)).count(), 0);
     }

--- a/components/merkledb/tests/migration.rs
+++ b/components/merkledb/tests/migration.rs
@@ -28,7 +28,7 @@ use exonum_merkledb::{
 mod work;
 use self::work::*;
 
-const ACTIONS_MAX_LEN: usize = 25;
+const ACTIONS_MAX_LEN: usize = 15;
 
 const NAMESPACES: Strings = &["test", "other", "tes"];
 

--- a/components/merkledb/tests/persistent_iter.rs
+++ b/components/merkledb/tests/persistent_iter.rs
@@ -28,7 +28,7 @@ use exonum_merkledb::{
     Database, Fork, IndexAddress, IndexType, TemporaryDB,
 };
 
-const ACTIONS_MAX_LEN: usize = 50;
+const ACTIONS_MAX_LEN: usize = 10;
 
 #[derive(Debug, Clone, Copy)]
 struct Collection {

--- a/components/merkledb/tests/state_aggregation.rs
+++ b/components/merkledb/tests/state_aggregation.rs
@@ -25,7 +25,7 @@ use exonum_merkledb::{
     access::CopyAccessExt, Database, IndexAddress, ObjectHash, Patch, SystemSchema, TemporaryDB,
 };
 
-const ACTIONS_MAX_LEN: usize = 50;
+const ACTIONS_MAX_LEN: usize = 10;
 
 #[derive(Debug, Clone)]
 enum Action {

--- a/exonum-dictionary.txt
+++ b/exonum-dictionary.txt
@@ -206,6 +206,7 @@ supermajority
 supervisorctl
 supervisord
 symm
+tempdb
 tempdir
 tempfile
 TemporaryDB

--- a/exonum-node/src/lib.rs
+++ b/exonum-node/src/lib.rs
@@ -1561,7 +1561,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "must be smaller than 65536")]
     fn test_bad_internal_events_capacity_too_large() {
-        let accidental_large_value = usize::max_value();
+        let accidental_large_value = usize::MAX;
         let db = TemporaryDB::new();
 
         let (mut node_cfg, node_keys) = generate_testnet_config(1, 16_500).pop().unwrap();
@@ -1575,7 +1575,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "must be smaller than 65536")]
     fn test_bad_network_requests_capacity_too_large() {
-        let accidental_large_value = usize::max_value();
+        let accidental_large_value = usize::MAX;
         let db = TemporaryDB::new();
 
         let (mut node_cfg, node_keys) = generate_testnet_config(1, 16_500)[0].clone();

--- a/exonum-node/src/pool.rs
+++ b/exonum-node/src/pool.rs
@@ -270,7 +270,7 @@ impl ManagePool for StandardPoolManager {
     }
 
     fn remove_transactions(&mut self, pool: Pool<'_>, snapshot: &dyn Snapshot) -> Vec<Hash> {
-        let tx_limit = self.removal_limit.unwrap_or_else(usize::max_value);
+        let tx_limit = self.removal_limit.unwrap_or(usize::MAX);
         let mut cache = TxCheckCache::new();
 
         pool.transactions()

--- a/exonum-node/src/sandbox/mod.rs
+++ b/exonum-node/src/sandbox/mod.rs
@@ -1036,7 +1036,7 @@ impl Default for SandboxBuilder {
             .max_message_len(1024 * 1024)
             .min_propose_timeout(PROPOSE_TIMEOUT)
             .max_propose_timeout(PROPOSE_TIMEOUT)
-            .propose_timeout_threshold(u32::max_value())
+            .propose_timeout_threshold(u32::MAX)
             .build();
 
         Self {

--- a/exonum/src/blockchain/config.rs
+++ b/exonum/src/blockchain/config.rs
@@ -627,7 +627,7 @@ mod tests {
     fn gen_validator_keys(i: u8) -> ValidatorKeys {
         ValidatorKeys::new(
             gen_keypair_from_seed(&Seed::new([i; SEED_LENGTH])).0,
-            gen_keypair_from_seed(&Seed::new([u8::max_value() - i; SEED_LENGTH])).0,
+            gen_keypair_from_seed(&Seed::new([u8::MAX - i; SEED_LENGTH])).0,
         )
     }
 

--- a/services/explorer/tests/api.rs
+++ b/services/explorer/tests/api.rs
@@ -447,7 +447,7 @@ async fn test_explorer_transaction_statuses() {
     let (mut testkit, api) = init_testkit();
     let tx = KeyPair::random().increment(SERVICE_ID, 5);
     let error_tx = KeyPair::random().increment(SERVICE_ID, 0);
-    let panicking_tx = KeyPair::random().increment(SERVICE_ID, u64::max_value() - 3);
+    let panicking_tx = KeyPair::random().increment(SERVICE_ID, u64::MAX - 3);
 
     let block = testkit.create_block_with_transactions(vec![
         tx.clone(),

--- a/test-suite/rust-runtime-proto/src/tests.rs
+++ b/test-suite/rust-runtime-proto/src/tests.rs
@@ -91,19 +91,19 @@ fn test_scalar_struct_round_trip() {
         hash: Hash::from_slice(&[7; crypto::HASH_SIZE]).unwrap(),
         bit_vec: BitVec::from_bytes(&[0b_1010_0000, 0b_0001_0010]),
         time: datetime!(2018-1-26 18:30:09.453_829 UTC),
-        unsigned_32: u32::max_value(),
-        unsigned_64: u64::max_value(),
-        regular_i32: i32::min_value(),
-        regular_i64: i64::min_value(),
-        fixed_u32: u32::max_value(),
-        fixed_u64: u64::max_value(),
-        fixed_i32: i32::min_value(),
-        fixed_i64: i64::min_value(),
-        float_32: std::f32::MAX,
-        float_64: std::f64::MAX,
+        unsigned_32: u32::MAX,
+        unsigned_64: u64::MAX,
+        regular_i32: i32::MIN,
+        regular_i64: i64::MIN,
+        fixed_u32: u32::MAX,
+        fixed_u64: u64::MAX,
+        fixed_i32: i32::MIN,
+        fixed_i64: i64::MIN,
+        float_32: f32::MAX,
+        float_64: f64::MAX,
         boolean: true,
-        s_i32: i32::min_value(),
-        s_i64: i64::min_value(),
+        s_i32: i32::MIN,
+        s_i64: i64::MIN,
         bytes_field: vec![1, 2, 3, 4],
         string_field: "test".to_string(),
         message_field: Point { x: 1, y: 2 },
@@ -163,7 +163,7 @@ struct StructWithMaps {
 #[test]
 fn test_struct_with_maps_roundtrip() {
     let map_struct = StructWithMaps {
-        num_map: vec![(1, 1), (2, u64::max_value())].into_iter().collect(),
+        num_map: vec![(1, 1), (2, u64::MAX)].into_iter().collect(),
         string_map: vec![(1, String::from("abc")), (2, String::from("def"))]
             .into_iter()
             .collect(),
@@ -173,12 +173,9 @@ fn test_struct_with_maps_roundtrip() {
         point_map: vec![(1, Point { x: 1, y: 2 }), (2, Point { x: 3, y: 4 })]
             .into_iter()
             .collect(),
-        key_string_map: vec![
-            (String::from("abc"), 0),
-            (String::from("def"), u64::max_value()),
-        ]
-        .into_iter()
-        .collect(),
+        key_string_map: vec![(String::from("abc"), 0), (String::from("def"), u64::MAX)]
+            .into_iter()
+            .collect(),
     };
 
     let map_struct_pb = map_struct.to_pb();


### PR DESCRIPTION
The PR adds a variant of TemporaryDB like a wrapper over RocksDB for testing the functionality of RockDB. 