### PR TITLE
Fix build errors with the most recent clang and libraries

### DIFF
--- a/components/merkledb/Cargo.toml
+++ b/components/merkledb/Cargo.toml
@@ -25,7 +25,7 @@ im = "15"
 leb128 = "0.2"
 num-traits = "0.2"
 protobuf = { version = "3", optional = true }
-rocksdb = { version = "0.20", default-features = false, features = [ "multi-threaded-cf" ] }
+rocksdb = { version = "0.22", default-features = false, features = [ "multi-threaded-cf" ] }
 rust_decimal = "1.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/services/explorer/src/api/websocket/mod.rs
+++ b/services/explorer/src/api/websocket/mod.rs
@@ -329,7 +329,7 @@ struct Broadcast {
 }
 
 #[derive(Debug, Message)]
-#[rtype("anyhow::Result<TransactionResponse>")]
+#[rtype(result = "anyhow::Result<TransactionResponse>")]
 struct Transaction(TransactionHex);
 
 pub(crate) struct Server {


### PR DESCRIPTION
The currently available version cannot be built at the moment.

`rocksdb` doesn't compile under `clang16` with the current version, and explorer doesn't compile due to a missing `result = ` in the `rtype`.